### PR TITLE
Remove maximumTokenLength argument

### DIFF
--- a/Sources/NIOQUIC/QUICHandler.swift
+++ b/Sources/NIOQUIC/QUICHandler.swift
@@ -44,8 +44,6 @@ public final class QUICHandler {
 
     /// The QUIC configuration used to accept connections.
     private let quicConfiguration: QUICConfiguration
-    /// The maximum length of tokens.
-    private let maximumTokenLength: Int
     /// The multiplexer used for multiplexing the connections.
     private let connectionMultiplexer:
         ChildChannelMultiplexer<
@@ -92,7 +90,6 @@ public final class QUICHandler {
     /// - Parameters:
     ///   - channel: The channel this handler resides in.
     ///   - QUICConfiguration: The quic configuration to use for this handler.
-    ///   - maximumTokenLength: The maximum length of tokens.
     ///   - logger: The logger.
     ///   - metrics: The optional metrics to be recorded.
     ///   - inboundStreamChannelInitializer: A closure called for any new inbound stream.
@@ -100,7 +97,6 @@ public final class QUICHandler {
     public static func makeHandlerAndConnectionMultiplexer<Output: Sendable>(
         channel: any Channel,
         quicConfiguration: QUICConfiguration,
-        maximumTokenLength: Int,
         logger: Logger,
         metrics: QUICMetrics? = nil,
         inboundStreamChannelInitializer: @Sendable @escaping (any Channel) -> EventLoopFuture<Output>
@@ -108,7 +104,6 @@ public final class QUICHandler {
         try self.makeHandlerAndConnectionMultiplexer(
             channel: channel,
             quicConfiguration: quicConfiguration,
-            maximumTokenLength: maximumTokenLength,
             logger: logger,
             metrics: metrics,
             inboundStreamChannelInitializer: inboundStreamChannelInitializer,
@@ -121,7 +116,6 @@ public final class QUICHandler {
     /// - Parameters:
     ///   - channel: The channel this handler resides in.
     ///   - QUICConfiguration: The quic configuration to use for this handler.
-    ///   - maximumTokenLength: The maximum length of tokens.
     ///   - logger: The logger.
     ///   - metrics: The optional metrics to be recorded.
     ///   - inboundStreamChannelInitializer: A closure called for any new inbound stream.
@@ -130,7 +124,6 @@ public final class QUICHandler {
     public static func makeHandlerAndConnectionMultiplexer<Output: Sendable>(
         channel: any Channel,
         quicConfiguration: QUICConfiguration,
-        maximumTokenLength: Int,
         logger: Logger,
         metrics: QUICMetrics? = nil,
         inboundStreamChannelInitializer: @Sendable @escaping (any Channel) -> EventLoopFuture<Output>,
@@ -182,7 +175,6 @@ public final class QUICHandler {
         let handler = QUICHandler(
             channel: channel,
             quicConfiguration: quicConfiguration,
-            maximumTokenLength: maximumTokenLength,
             asyncVerifier: asyncVerifier,
             authenticator: authenticator,
             logger: logger,
@@ -207,14 +199,12 @@ public final class QUICHandler {
     /// - Parameters:
     ///   - channel: The channel this handler resides in.
     ///   - quicConfiguration: The quic configuration to use for this handler.
-    ///   - maximumTokenLength: The maximum length of tokens.
-    ///   - asyncVerifier: Callback provider for SwiftTLS cerificate verification.
+    ///   - asyncVerifier: Callback provider for SwiftTLS certificate verification.
     ///   - logger: The logger.
     ///   - metrics: The optional metrics to be recorded.
     init(
         channel: any Channel,
         quicConfiguration: QUICConfiguration,
-        maximumTokenLength: Int,
         asyncVerifier: AsyncVerifier?,
         authenticator: Authenticator?,
         logger: Logger,
@@ -225,7 +215,6 @@ public final class QUICHandler {
         self.eventLoop = channel.eventLoop
         self.connectionMultiplexer = .init(eventLoop: self.eventLoop, logger: logger)
         self.quicConfiguration = quicConfiguration
-        self.maximumTokenLength = maximumTokenLength
         self.outboundBuffer = channel.allocator.buffer(capacity: ByteBuffer.maxDatagramSize)
         self.logger = logger
         self.metrics = metrics
@@ -242,7 +231,6 @@ public final class QUICHandler {
     /// - Parameters:
     ///   - channel: The channel this handler resides in.
     ///   - quicConfiguration: The quic configuration to use for this handler.
-    ///   - maximumTokenLength: The maximum length of tokens.
     ///   - asyncVerifier: Callback provider for SwiftTLS certificate verification.
     ///   - authenticator: Authenticator for SwiftTLS certificate verification.
     ///   - logger: The logger.
@@ -253,7 +241,6 @@ public final class QUICHandler {
     public init(
         channel: any Channel,
         quicConfiguration: QUICConfiguration,
-        maximumTokenLength: Int,
         asyncVerifier: AsyncVerifier?,
         authenticator: Authenticator?,
         logger: Logger,
@@ -267,7 +254,6 @@ public final class QUICHandler {
         self.eventLoop = channel.eventLoop
         self.connectionMultiplexer = .init(eventLoop: self.eventLoop, logger: logger)
         self.quicConfiguration = quicConfiguration
-        self.maximumTokenLength = maximumTokenLength
         self.outboundBuffer = channel.allocator.buffer(capacity: ByteBuffer.maxDatagramSize)
         self.logger = logger
         self.metrics = metrics
@@ -640,8 +626,7 @@ extension QUICHandler: ChannelInboundHandler {
         do {
             guard
                 let quicPacketHeader = try addressedEnvelope.data.parseQUICPacketHeader(
-                    destinationIDLength: self.quicConnectionIDGenerator.connectionIDLength,
-                    maximumTokenLength: self.maximumTokenLength
+                    destinationIDLength: self.quicConnectionIDGenerator.connectionIDLength
                 )
             else {
                 throw QUICError.quicPacketHeaderDecodingFailed

--- a/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
@@ -187,11 +187,9 @@ extension NIOCore.ByteBuffer {
     ///
     /// - Parameters:
     ///   - shortHeaderDCIDLength: The length of the destination connection ID. Required to parse short header packets.
-    ///   - maximumTokenLength: The maximum length of the token. Checked when parsing the packet.
     /// - Returns: The parsed `QUICPacketHeader` or `nil` if the not enough bytes were readable.
     public func parseQUICPacketHeader(
-        destinationIDLength shortHeaderDCIDLength: Int,
-        maximumTokenLength: Int
+        destinationIDLength shortHeaderDCIDLength: Int
     ) throws -> QUICPacketHeader? {
         let routingHeader: QUICPacketHeader? = try self.withUnsafeReadableBytes { buffer in
             let header = QUICConnectionUtilities.parseInboundPacket(
@@ -229,8 +227,7 @@ extension NIOCore.ByteBuffer {
             return routingHeader
         } else {
             return try self.getQUICPacketHeader(
-                destinationIDLength: shortHeaderDCIDLength,
-                maximumTokenLength: maximumTokenLength
+                destinationIDLength: shortHeaderDCIDLength
             )
         }
     }
@@ -239,11 +236,9 @@ extension NIOCore.ByteBuffer {
     ///
     /// - Parameters:
     ///   - shortHeaderDCIDLength: The length of the destination connection ID. Required to parse short header packets.
-    ///   - maximumTokenLength: The maximum length of the token. Checked when parsing the packet.
     /// - Returns: The parsed `QUICPacketHeader` or `nil` if the not enough bytes were readable.
     public func getQUICPacketHeader(
-        destinationIDLength shortHeaderDCIDLength: Int,
-        maximumTokenLength: Int
+        destinationIDLength shortHeaderDCIDLength: Int
     ) throws -> QUICPacketHeader? {
         let packetType: QUICPacketHeader.PacketType
         var sourceConnectionID: QUICConnectionID? = nil

--- a/Sources/NIOQUICExample/Example.swift
+++ b/Sources/NIOQUICExample/Example.swift
@@ -95,7 +95,6 @@ struct Example {
                     let (quicHandler, connectionMultiplexer) = try QUICHandler.makeHandlerAndConnectionMultiplexer(
                         channel: channel,
                         quicConfiguration: quicConfiguration,
-                        maximumTokenLength: 0,
                         logger: logger,
                         metrics: nil,
                         inboundStreamChannelInitializer: { streamChannel in
@@ -161,7 +160,6 @@ struct Example {
                 let (quicHandler, connectionMultiplexer) = try QUICHandler.makeHandlerAndConnectionMultiplexer(
                     channel: channel,
                     quicConfiguration: quicConfiguration,
-                    maximumTokenLength: 0,
                     logger: logger,
                     metrics: nil,
                     inboundStreamChannelInitializer: { channel -> EventLoopFuture<Never> in

--- a/Tests/IntegrationTests/AsyncTestSetup.swift
+++ b/Tests/IntegrationTests/AsyncTestSetup.swift
@@ -131,7 +131,6 @@ func makeMockClientAndServerPair(
                 ),
                 applicationProtocols: ["http/0.9"]
             ),
-            maximumTokenLength: 0,
             logger: Logger(label: "Testing Server"),
             metrics: nil,
             inboundStreamChannelInitializer: { streamChannel in
@@ -164,7 +163,6 @@ func makeMockClientAndServerPair(
         let (quicHandler, connectionMultiplexer) = try QUICHandler.makeHandlerAndConnectionMultiplexer(
             channel: clientChannel,
             quicConfiguration: clientConfiguration,
-            maximumTokenLength: 0,
             logger: Logger(label: "Testing Client"),
             metrics: nil,
             inboundStreamChannelInitializer: { channel in
@@ -275,7 +273,6 @@ private func setUpClientConnectionMultiplexer(
                 let (quicHandler, connectionMultiplexer) = try QUICHandler.makeHandlerAndConnectionMultiplexer(
                     channel: channel,
                     quicConfiguration: clientConfiguration,
-                    maximumTokenLength: 0,
                     logger: logger,
                     metrics: nil,
                     inboundStreamChannelInitializer: { channel in
@@ -327,7 +324,6 @@ private func setUpServerChannelAndConnectionMultiplexer(
                 let (quicHandler, connectionMultiplexer) = try QUICHandler.makeHandlerAndConnectionMultiplexer(
                     channel: channel,
                     quicConfiguration: quicConfiguration,
-                    maximumTokenLength: 0,
                     logger: logger,
                     metrics: nil,
                     inboundStreamChannelInitializer: { streamChannel in

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -751,8 +751,7 @@ final class PacketHeaderRecorderHandler: ChannelInboundHandler, Sendable {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let message = self.unwrapInboundIn(data)
         let header = try? message.data.getQUICPacketHeader(
-            destinationIDLength: 16,  // this is the random ID length
-            maximumTokenLength: 0
+            destinationIDLength: 16  // this is the random ID length
         )
         if let header {
             self.headers.withLockedValue { $0.append(header) }

--- a/Tests/IntegrationTests/SyncTestSetup.swift
+++ b/Tests/IntegrationTests/SyncTestSetup.swift
@@ -120,7 +120,6 @@ private func createQUICChannel(
             let quicHandler = QUICHandler(
                 channel: channel,
                 quicConfiguration: quicConfiguration,
-                maximumTokenLength: 0,
                 asyncVerifier: nil,
                 authenticator: nil,
                 logger: logger,

--- a/Tests/NIOQUICTests/CertificateAuthTests.swift
+++ b/Tests/NIOQUICTests/CertificateAuthTests.swift
@@ -44,7 +44,6 @@ final class CertificateAuthTests: XCTestCase {
                             applicationProtocols: ["swift_nio_quic"],
                             maxIdleTimeout: maxIdleTimeout
                         ),
-                        maximumTokenLength: 0,
                         logger: Logger(label: "test"),
                         metrics: nil,
                         inboundStreamChannelInitializer: { streamChannel in
@@ -79,7 +78,6 @@ final class CertificateAuthTests: XCTestCase {
                             ),
                             applicationProtocols: ["swift_nio_quic"]
                         ),
-                        maximumTokenLength: 0,
                         logger: Logger(label: "test"),
                         metrics: nil,
                         inboundStreamChannelInitializer: { streamChannel in

--- a/Tests/NIOQUICTests/QUICHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICHandlerTests.swift
@@ -46,7 +46,6 @@ final class QUICHandlerTests: XCTestCase {
                 ),
                 applicationProtocols: []
             ),
-            maximumTokenLength: 1,
             logger: Logger(label: "Test"),
             inboundStreamChannelInitializer: { channel in
                 do {
@@ -99,8 +98,7 @@ final class QUICHandlerTests: XCTestCase {
         let packet = QUICPackets.versionNegotiation(destinationID: connectionID, sourceID: connectionID)
         let buffer = ByteBuffer(bytes: packet)
         let outboundHeader = try buffer.parseQUICPacketHeader(
-            destinationIDLength: 8,
-            maximumTokenLength: 8
+            destinationIDLength: 8
         )
         XCTAssertEqual(outboundHeader?.sourceConnectionID, connectionID)
         XCTAssertEqual(outboundHeader?.destinationConnectionID, connectionID)
@@ -120,8 +118,7 @@ final class QUICHandlerTests: XCTestCase {
         let packet = QUICPackets.versionNegotiation(destinationID: connectionID, sourceID: nil)
         let buffer = ByteBuffer(bytes: packet)
         let outboundHeader = try buffer.getQUICPacketHeader(
-            destinationIDLength: 8,
-            maximumTokenLength: 8
+            destinationIDLength: 8
         )
 
         XCTAssertEqual(outboundHeader?.destinationConnectionID, connectionID)
@@ -142,8 +139,7 @@ final class QUICHandlerTests: XCTestCase {
         let packet = QUICPackets.versionNegotiation(destinationID: nil, sourceID: connectionID)
         let buffer = ByteBuffer(bytes: packet)
         let outboundHeader = try buffer.getQUICPacketHeader(
-            destinationIDLength: 8,
-            maximumTokenLength: 8
+            destinationIDLength: 8
         )
         XCTAssertEqual(outboundHeader?.destinationConnectionID.length, 0)
         XCTAssertEqual(outboundHeader?.sourceConnectionID, connectionID)
@@ -154,8 +150,7 @@ final class QUICHandlerTests: XCTestCase {
         let packet = QUICPackets.versionNegotiation(destinationID: nil, sourceID: nil)
         let buffer = ByteBuffer(bytes: packet)
         let outboundHeader = try buffer.getQUICPacketHeader(
-            destinationIDLength: 1,
-            maximumTokenLength: 1
+            destinationIDLength: 1
         )
         XCTAssertEqual(outboundHeader?.sourceConnectionID?.length, 0)
         XCTAssertEqual(outboundHeader?.destinationConnectionID.length, 0)

--- a/Tests/NIOQUICTests/QUICHeaderTests.swift
+++ b/Tests/NIOQUICTests/QUICHeaderTests.swift
@@ -34,7 +34,7 @@ final class HeaderIDTests {
         let packet = QUICPackets.shortHeader(destinationID: connectionID)
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16, maximumTokenLength: 10)
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
 
         try #require(header?.type == .short)
         try #require(header?.destinationConnectionID == connectionID)
@@ -56,7 +56,7 @@ final class HeaderIDTests {
         let packet = QUICPackets.versionNegotiation(destinationID: connectionID, sourceID: connectionID)
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16, maximumTokenLength: 10)
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
 
         try #require(header?.type == .versionNegotiation)
         try #require(header?.destinationConnectionID == connectionID)
@@ -86,7 +86,7 @@ final class HeaderIDTests {
         )
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16, maximumTokenLength: 10)
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
 
         try #require(header?.type == .initial)
         try #require(header?.destinationConnectionID == connectionID)
@@ -111,7 +111,7 @@ final class HeaderIDTests {
         let packet = QUICPackets.zeroRTT(destinationID: connectionID, sourceID: connectionID, version: version)
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16, maximumTokenLength: 10)
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
 
         try #require(header?.type == .zeroRTT)
         try #require(header?.destinationConnectionID == connectionID)
@@ -135,7 +135,7 @@ final class HeaderIDTests {
         let packet = QUICPackets.handshake(destinationID: connectionID, sourceID: connectionID, version: version)
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16, maximumTokenLength: 10)
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
 
         try #require(header?.type == .handshake)
         try #require(header?.destinationConnectionID == connectionID)
@@ -165,7 +165,7 @@ final class HeaderIDTests {
         )
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16, maximumTokenLength: 10)
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
 
         try #require(header?.type == .retry)
         try #require(header?.destinationConnectionID == connectionID)
@@ -195,7 +195,7 @@ final class HeaderIDTests {
             version: 1
         )
         let buffer = ByteBuffer(bytes: packet)
-        let header = try buffer.parseQUICPacketHeader(destinationIDLength: 8, maximumTokenLength: 20)
+        let header = try buffer.parseQUICPacketHeader(destinationIDLength: 8)
         try #require(header?.destinationConnectionID == connectionID)
     }
 
@@ -226,7 +226,7 @@ final class HeaderIDTests {
         )
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try buffer.getQUICPacketHeader(destinationIDLength: 8, maximumTokenLength: 10)
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 8)
 
         try #require(header?.type == .initial)
         try #require(header?.destinationConnectionID == dcid)
@@ -254,7 +254,7 @@ final class HeaderIDTests {
         )
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try #require(try buffer.getQUICPacketHeader(destinationIDLength: 0, maximumTokenLength: 10))
+        let header = try #require(try buffer.getQUICPacketHeader(destinationIDLength: 0))
 
         try #require(header.type == .initial)
         let parsedDCID = header.destinationConnectionID
@@ -276,7 +276,7 @@ final class HeaderIDTests {
         let packet = QUICPackets.shortHeader(destinationID: zeroLengthCID)
         let buffer = ByteBuffer(bytes: packet)
 
-        let header = try #require(try buffer.getQUICPacketHeader(destinationIDLength: 0, maximumTokenLength: 10))
+        let header = try #require(try buffer.getQUICPacketHeader(destinationIDLength: 0))
 
         #expect(header.type == .short)
         #expect(header.destinationConnectionID.length == 0)

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -51,7 +51,6 @@ final class QUICProtocolStackTests: XCTestCase {
                             maxIdleTimeout: maxIdleTimeout,
                             forceVersionNegotiation: forceVersionNegotiation
                         ),
-                        maximumTokenLength: 0,
                         logger: logger,
                         metrics: nil,
                         inboundStreamChannelInitializer: { streamChannel in
@@ -95,7 +94,6 @@ final class QUICProtocolStackTests: XCTestCase {
                             sendRetry: sendRetry,
                             qLogConfiguration: qlogConfiguration
                         ),
-                        maximumTokenLength: 0,
                         logger: logger,
                         metrics: nil,
                         inboundStreamChannelInitializer: { streamChannel in


### PR DESCRIPTION
### Motivation

The argument is in the public API, but unused.

### Modifications

Remove `maximumTokenLength` argument throughout the stack.

### Result

Easier API.
