### PR TITLE
Remove unused dependencies and imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -119,6 +119,7 @@ let package = Package(
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "NIOQUICHelpers", package: "swift-nio-quic-helpers"),

--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,6 @@ let package = Package(
             name: "NIOQUIC",
             dependencies: [
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOQUICHelpers", package: "swift-nio-quic-helpers"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelEventLoop.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelEventLoop.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import NIOPosix
 @_spi(ProtocolProvider) @_spi(Essentials) import SwiftNetwork
 
 // TODO: Make ScheduledEntry ~Copyable with UniqueArray / PriorityQueue

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
@@ -14,8 +14,15 @@
 
 import Logging
 import NIOCore
-import NIOPosix
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 
 /// `QUICChannelNewFlowHandler` is responsible for dealing with new SwiftNetwork 'flows' initiated by the other end of the connection.
 /// A flow in this case is a new stream of data that is registered with the QUIC stack and is represented here by `QUICChannelStreamHandler`.

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
@@ -14,8 +14,15 @@
 
 import Logging
 import NIOCore
-import NIOPosix
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 
 /// `QUICChannelOutputHandler` is the bridge between SwiftNetwork and our code on the network-side.
 /// It is registered with the SwiftNetwork `QUICConnectionImplementation` as an output handler.

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -15,12 +15,15 @@
 import Atomics
 import Logging
 import NIOCore
-import NIOPosix
 import NIOQUICHelpers
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
 
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 extension StreamShutdownDirection {


### PR DESCRIPTION
Motivation:

`NIOHTTP1` is a target dependency but is never used. `NIOPosix` is imported
but isn't necessary (it seems to be imported for it's transitive import of 
`CNIOLinux` to get various errno values). Integration tests depend on `NIOEmbedded`
but don't declare it as a dependency.

Modifications:

- Remove NIOHTTP1 target dependency
- Remove NIOPosix imports and add various lib C imports
- Add NIOEmbedded target dependency

Result:

More accurate dependency list