### PR TITLE
Use Deque for finalized output

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,6 +84,7 @@ let package = Package(
                 .product(name: "X509", package: "swift-certificates"),
                 .product(name: "SwiftTLS", package: "swift-tls"),
                 .product(name: "SwiftNetwork", package: "swift-network-evolution"),
+                .product(name: "DequeModule", package: "swift-collections"),
                 .target(name: "ChildChannelMultiplexer"),
             ],
             swiftSettings: swiftSettings

--- a/Sources/NIOQUIC/QUICConnectionChildChannelStateMachine.swift
+++ b/Sources/NIOQUIC/QUICConnectionChildChannelStateMachine.swift
@@ -434,28 +434,19 @@ extension QUICConnectionChildChannelStateMachine {
     private mutating func drainFinalizedOutputAndHandleLifecycle(into actions: inout Actions) {
 
         // Drain.
-        do {
-            self.logger.trace("QUICConnectionChildChannelStateMachine drainFinalizedOutputAndHandleLifecycle loop")
-            var shouldFlush = false
-            while let buffer = try self.quicConnection.nextOutboundPacket() {
-                actions.append(
-                    .parentChannelWrite(
-                        message: AddressedEnvelope(remoteAddress: self.remoteAddress, data: buffer),
-                        promise: nil
-                    )
+        self.logger.trace("QUICConnectionChildChannelStateMachine drainFinalizedOutputAndHandleLifecycle loop")
+        var shouldFlush = false
+        while let buffer = self.quicConnection.nextOutboundPacket() {
+            actions.append(
+                .parentChannelWrite(
+                    message: AddressedEnvelope(remoteAddress: self.remoteAddress, data: buffer),
+                    promise: nil
                 )
-                shouldFlush = true
-            }
-            if shouldFlush {
-                actions.append(.childChannelFlush)
-            }
-        } catch {
-            self.logger.trace(
-                "QUICConnectionChildChannelStateMachine drainFinalizedOutputAndHandleLifecycle caught error",
-                metadata: ["error": "\(error)"]
             )
-            let promise = self.close()
-            actions.append(.childChannelEncounterError(error: error, promise: promise))
+            shouldFlush = true
+        }
+        if shouldFlush {
+            actions.append(.childChannelFlush)
         }
 
         // Lifecycle.

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+import DequeModule
 import Logging
 @_spi(CustomByteBufferAllocator) import NIOCore
 import NIOQUICHelpers
@@ -105,7 +106,7 @@ final class SwiftNetworkQUICConnection {
 
     private var connectionStateMachine = QUICConnectionStateMachine()
 
-    private var finalizedOutput: [NIOCore.ByteBuffer] = []
+    private var finalizedOutput: Deque<ByteBuffer> = []
     private var inputPacketQueue: FrameArray = FrameArray(capacity: 10)
     private var newlyConnectedStreams: Set<QUICStreamID> = []
     private var networkContext: NetworkContext
@@ -1126,11 +1127,8 @@ final class SwiftNetworkQUICConnection {
     ///
     @discardableResult
     @inlinable
-    func nextOutboundPacket() throws -> NIOCore.ByteBuffer? {
-        guard !self.finalizedOutput.isEmpty else {
-            return nil
-        }
-        return self.finalizedOutput.removeFirst()
+    func nextOutboundPacket() -> ByteBuffer? {
+        self.finalizedOutput.popFirst()
     }
 
     /// Returns stream IDs for newly connected streams.


### PR DESCRIPTION
Motivation:

SwiftNetworkQUICConnection has a finalized output arrray which stores ByteBuffer's. Users must call 'nextOutboundPacket' to drain the array. However it pops from the front which is linear in the size of the array.

Modifications:

- Use a Deque and call 'popFront()' rather than checking the container is non-empty and then calling 'removeFirst()'
- Remove the 'throws' from 'nextOutboundPacket' as it never throws

Result:

- Simpler, cheaper code