### PR TITLE
Adopt getMetrics in LowerProtocolHandler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            revision: "cc73bf2dd3cdc3460f1f2a6181a4252a1be3097b",
+            revision: "5f1d45c5356e8052aeb533ef3587c5e2c633e1d3",
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", branch: "main"),

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
@@ -98,6 +98,13 @@ final class QUICChannelOutputHandler: ProtocolInstanceContainer, OutboundDatagra
 }
 
 extension QUICChannelOutputHandler: LowerProtocolHandler {
+    func getMetrics(
+        _ from: SwiftNetwork.ProtocolInstanceReference,
+        requestedNetworkMetric: SwiftNetwork.RequestedNetworkMetrics
+    ) -> SwiftNetwork.NetworkMetrics? {
+        nil
+    }
+
     internal func disconnect(_ from: SwiftNetwork.ProtocolInstanceReference, error: SwiftNetwork.NetworkError?) {
         log("received disconnect")
         upperProtocol.deliverDisconnectedEvent(reference, error: error)


### PR DESCRIPTION
### Motivation

For exposing RTT metrics, `LowerProtocolHandler` now has a protocol requirement of `getMetrics`.

### Modifications

Add `getMetrics` to `LowerProtocolHandler` and bump up to the supporting commit in the package file.

### Result

Adoption of RTT metics without build breakage.
