### PR TITLE
Replace ManagedAtomics with Atomics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", from: "2.92.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.12.1", traits: maxLogLevel),
         .package(url: "https://github.com/apple/swift-metrics", from: "2.4.1"),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", branch: "swift-crypto-5.x"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.4.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", exact: "5.0.0-beta.1"),
@@ -92,7 +91,6 @@ let package = Package(
             name: "ChildChannelMultiplexer",
             dependencies: [
                 .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "HeapModule", package: "swift-collections"),
             ]

--- a/Sources/ChildChannelMultiplexer/ChildChannel.swift
+++ b/Sources/ChildChannelMultiplexer/ChildChannel.swift
@@ -12,11 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import HeapModule
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
+import Synchronization
 
 /// The delegate of a ``ChildChannel``.
 ///
@@ -304,10 +304,10 @@ where
     let allocator: ByteBufferAllocator
     /// Atomic that stores if this channel is currently active.
     @usableFromInline
-    let _isActive: ManagedAtomic<Bool>
+    let _isActive: Synchronization.Atomic<Bool>
     /// Atomic that stores if this channel is currently writable.
     @usableFromInline
-    let _isWritable: ManagedAtomic<Bool>
+    let _isWritable: Synchronization.Atomic<Bool>
     /// The actual channel pipeline.
     ///
     /// We don't have to `nil` this out since the ``ChannelPipeline`` will break the retain cycles
@@ -360,8 +360,8 @@ where
         self._localAddress = localAddress
         self._remoteAddress = remoteAddress
         self._closePromise = parent.eventLoop.makePromise(of: Void.self)
-        self._isActive = ManagedAtomic(false)
-        self._isWritable = ManagedAtomic(true)
+        self._isActive = Atomic(false)
+        self._isWritable = Atomic(true)
         self._activationState = .neverActivated
         self._multiplexedChannelIDs = []
         self._writabilityManager = ChildChannelWritabilityManager(

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -12,11 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import Logging
 import NIOCore
 import NIOQUICHelpers
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+import Synchronization
 
 #if canImport(Darwin)
 import Darwin
@@ -63,10 +63,10 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     let allocator: ByteBufferAllocator
     /// Atomic that stores if this channel is currently active.
     @usableFromInline
-    let _isActive: ManagedAtomic<Bool>
+    let _isActive: Atomic<Bool>
     /// Atomic that stores if this channel is currently writable.
     @usableFromInline
-    let _isWritable: ManagedAtomic<Bool>
+    let _isWritable: Atomic<Bool>
     /// The actual channel pipeline.
     /// This needs to be an implicitly unwrapped optional because the ChannelPipeline holds a ref to this Channel
     /// and that the ChannelPipeline is responsible for breaking the retain cycle.
@@ -138,8 +138,8 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         self.connectionChannel = connectionChannel
         self.eventLoop = connectionChannel.eventLoop
         self.allocator = connectionChannel.allocator
-        self._isActive = ManagedAtomic(false)
-        self._isWritable = ManagedAtomic(true)
+        self._isActive = Atomic(false)
+        self._isWritable = Atomic(true)
         self._closePromise = connectionChannel.eventLoop.makePromise(of: Void.self)
         self._pipeline = ChannelPipeline(channel: self)
     }
@@ -174,8 +174,8 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         self.eventLoop = eventLoop
         self.allocator = connectionChannel?.allocator ?? ByteBufferAllocator()
         self.connectionChannel = connectionChannel
-        self._isActive = ManagedAtomic(false)
-        self._isWritable = ManagedAtomic(true)
+        self._isActive = Atomic(false)
+        self._isWritable = Atomic(true)
         self._closePromise = eventLoop.makePromise(of: Void.self)
 
         do throws(NetworkError) {

--- a/Tests/IntegrationTests/AsyncStreamingTests.swift
+++ b/Tests/IntegrationTests/AsyncStreamingTests.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import Synchronization
 import XCTest
 
 @testable import NIOQUIC
@@ -126,7 +125,7 @@ final class AsyncStreamingTests: XCTestCase {
 
     private static func sendOneRequest(
         connection: QUICConnection<Never>,
-        responses: borrowing Atomic<Int>
+        responses: Counter
     ) async throws {
         let stream = try await connection.createBidirectionalStream { streamInitializer in
             streamInitializer.channel.eventLoop.makeCompletedFuture {
@@ -149,7 +148,7 @@ final class AsyncStreamingTests: XCTestCase {
                 accumulated.writeImmutableBuffer(buf)
             }
             if accumulated == .init(string: "<b>Success</b>") {
-                responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
+                responses.increment()
             }
         }
     }
@@ -171,7 +170,7 @@ final class AsyncStreamingTests: XCTestCase {
                 channel.eventLoop.makeCompletedFuture { fatalError() }
             }
         )
-        let responses = Atomic(0)
+        let responses = Counter()
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -221,7 +220,7 @@ final class AsyncStreamingTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            responses.load(ordering: .sequentiallyConsistent),
+            responses.load(),
             requestCount,
             file: file,
             line: line

--- a/Tests/IntegrationTests/AsyncStreamingTests.swift
+++ b/Tests/IntegrationTests/AsyncStreamingTests.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import NIOCore
+import Synchronization
 import XCTest
 
 @testable import NIOQUIC
@@ -126,7 +126,7 @@ final class AsyncStreamingTests: XCTestCase {
 
     private static func sendOneRequest(
         connection: QUICConnection<Never>,
-        responses: ManagedAtomic<Int>
+        responses: borrowing Atomic<Int>
     ) async throws {
         let stream = try await connection.createBidirectionalStream { streamInitializer in
             streamInitializer.channel.eventLoop.makeCompletedFuture {
@@ -149,7 +149,7 @@ final class AsyncStreamingTests: XCTestCase {
                 accumulated.writeImmutableBuffer(buf)
             }
             if accumulated == .init(string: "<b>Success</b>") {
-                responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
             }
         }
     }
@@ -171,7 +171,7 @@ final class AsyncStreamingTests: XCTestCase {
                 channel.eventLoop.makeCompletedFuture { fatalError() }
             }
         )
-        let responses = ManagedAtomic(0)
+        let responses = Atomic(0)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -536,7 +536,7 @@ final class IntegrationTests: XCTestCase {
                 clientKeepAliveTime: nil  // No keepalives - we want idle timeout to fire
             )
 
-        let connectionClosed = Atomic(false)
+        let connectionClosed = Counter()
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             // Server task - process one request then wait
@@ -552,7 +552,7 @@ final class IntegrationTests: XCTestCase {
                         }
                         // After first stream, wait for idle timeout then exit
                         try await Task.sleep(for: .seconds(3))
-                        connectionClosed.store(true, ordering: .sequentiallyConsistent)
+                        connectionClosed.increment()
                         return
                     }
                 }
@@ -594,7 +594,7 @@ final class IntegrationTests: XCTestCase {
         }
 
         // After idle timeout, the connection should be closed
-        XCTAssertTrue(connectionClosed.load(ordering: .sequentiallyConsistent))
+        XCTAssertEqual(connectionClosed.load(), 1)
     }
 
     // MARK: - Zero-length connection ID tests (RFC 9000 Section 5.1)

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import Crypto
 import Foundation
 import Logging
@@ -21,6 +20,7 @@ import NIOCore
 import NIOEmbedded
 import NIOPosix
 import NIOQUICHelpers
+import Synchronization
 import XCTest
 
 @testable import NIOQUIC
@@ -55,7 +55,7 @@ final class IntegrationTests: XCTestCase {
                 }
             }
 
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             for _ in 0..<requestCount {
                 let stream = try await connection.createBidirectionalStream { streamInitializer in
                     streamInitializer.channel.eventLoop.makeCompletedFuture {
@@ -75,7 +75,7 @@ final class IntegrationTests: XCTestCase {
 
                     for try await buffer in inbound {
                         XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                        responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                        responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                     }
                 }
             }
@@ -307,7 +307,7 @@ final class IntegrationTests: XCTestCase {
             return connection
         }
 
-        let clientGotResponse = ManagedAtomic(false)
+        let clientGotResponse = Atomic(false)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -404,7 +404,7 @@ final class IntegrationTests: XCTestCase {
                 }
             }
 
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             for _ in 0..<requestCount {
                 let stream = try await connection.createBidirectionalStream {
                     let channel = $0.channel
@@ -425,7 +425,7 @@ final class IntegrationTests: XCTestCase {
 
                     for try await buffer in inbound {
                         XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                        responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                        responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                     }
                 }
             }
@@ -536,7 +536,7 @@ final class IntegrationTests: XCTestCase {
                 clientKeepAliveTime: nil  // No keepalives - we want idle timeout to fire
             )
 
-        let connectionClosed = ManagedAtomic(false)
+        let connectionClosed = Atomic(false)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             // Server task - process one request then wait

--- a/Tests/IntegrationTests/TestHelpers.swift
+++ b/Tests/IntegrationTests/TestHelpers.swift
@@ -14,6 +14,7 @@
 
 import NIOCore
 import NIOEmbedded
+import Synchronization
 import XCTest
 
 // taken from swift-nio-http2
@@ -112,5 +113,18 @@ func assertNoThrowWithValue<T>(
         } else {
             throw error
         }
+    }
+}
+
+final class Counter: Sendable {
+    private let value = Atomic<Int>(0)
+
+    @discardableResult
+    func increment() -> Int {
+        self.value.wrappingAdd(1, ordering: .sequentiallyConsistent).newValue
+    }
+
+    func load() -> Int {
+        self.value.load(ordering: .sequentiallyConsistent)
     }
 }

--- a/Tests/NIOQUICTests/CertificateAuthTests.swift
+++ b/Tests/NIOQUICTests/CertificateAuthTests.swift
@@ -12,13 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
 import NIOPosix
 import NIOQUICHelpers
+import Synchronization
 import XCTest
 
 @testable import ChildChannelMultiplexer
@@ -135,7 +135,7 @@ final class CertificateAuthTests: XCTestCase {
                     }
                 }
             }
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             let stream = try await clientConnection.createBidirectionalStream { streamInitializer in
                 streamInitializer.channel.eventLoop.makeCompletedFuture {
                     try NIOAsyncChannel(
@@ -154,7 +154,7 @@ final class CertificateAuthTests: XCTestCase {
 
                 for try await buffer in inbound {
                     XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                    responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                    responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                 }
             }
 
@@ -240,7 +240,7 @@ final class CertificateAuthTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = ManagedAtomic(0)
+                let handledStreams = Atomic(0)
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -253,9 +253,8 @@ final class CertificateAuthTests: XCTestCase {
                                         // count on the connection and then sending it back so it doesnt exactly match the incoming read.
                                         // There may be a better way to do this but for now we are just trying to test that the project
                                         // handles multiple connections with individual reads.
-                                        let streamNumber = handledStreams.wrappingIncrementThenLoad(
-                                            ordering: .sequentiallyConsistent
-                                        )
+                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
+                                        let streamNumber = result.newValue
                                         XCTAssertTrue(String(buffer: buffer).hasPrefix("GET /foo/"))
                                         let responseMessage = "<b>Success \(streamNumber)</b>"
                                         try await outbound.write(.init(string: responseMessage))
@@ -268,7 +267,7 @@ final class CertificateAuthTests: XCTestCase {
                 }
             }
             let connectionCount = 6
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             // Runs a client side connections one at a time (server is handling connections concurrently)
             // NOTE: For this to work the client side needs to increment the local port used so packets do not get mixed up on connections.
             for connectionIndex in 0..<connectionCount {
@@ -307,7 +306,7 @@ final class CertificateAuthTests: XCTestCase {
                     for try await buffer in inbound {
                         // There may be a better way here, but for now just check for the prefix on the client side.
                         XCTAssertTrue(String(buffer: buffer).hasPrefix("<b>Success"))
-                        responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                        responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                     }
                 }
                 try await Task.sleep(for: .milliseconds(5))
@@ -334,7 +333,7 @@ final class CertificateAuthTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = ManagedAtomic(0)
+                let handledStreams = Atomic(0)
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -344,9 +343,8 @@ final class CertificateAuthTests: XCTestCase {
                                 try await stream.executeThenClose { inbound, outbound in
                                     for try await buffer in inbound {
                                         // Just incrementing the stream count on the connection.
-                                        let streamNumber = handledStreams.wrappingIncrementThenLoad(
-                                            ordering: .sequentiallyConsistent
-                                        )
+                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
+                                        let streamNumber = result.newValue
                                         let msg = String(buffer: buffer)
                                         XCTAssertTrue(msg.hasPrefix("GET /connection/"))
                                         let parts = msg.split(separator: "/")
@@ -367,7 +365,7 @@ final class CertificateAuthTests: XCTestCase {
             // Run 6 connections with 6 streams inside each connection
             let connectionCount = 6
             let streamCountPerConnection = 6
-            let streamResponses = ManagedAtomic(0)
+            let streamResponses = Atomic(0)
             // Runs a client side connections one at a time (server is handling connections concurrently)
             // NOTE: For this to work the client side needs to increment the local port used so packets do not get mixed up on connections.
             for connectionIndex in 0..<connectionCount {
@@ -416,7 +414,7 @@ final class CertificateAuthTests: XCTestCase {
                             let clientStreamNumber = try XCTUnwrap(Int(parts[2]), "Unexpected part: \(parts[2])")
                             XCTAssertEqual(connectionIndex + 1, clientConnectionNumber)
                             XCTAssertEqual(streamIndex + 1, clientStreamNumber)
-                            streamResponses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                            streamResponses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                         }
                     }
                 }

--- a/Tests/NIOQUICTests/CertificateAuthTests.swift
+++ b/Tests/NIOQUICTests/CertificateAuthTests.swift
@@ -240,7 +240,7 @@ final class CertificateAuthTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = Atomic(0)
+                let handledStreams = Counter()
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -253,8 +253,7 @@ final class CertificateAuthTests: XCTestCase {
                                         // count on the connection and then sending it back so it doesnt exactly match the incoming read.
                                         // There may be a better way to do this but for now we are just trying to test that the project
                                         // handles multiple connections with individual reads.
-                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
-                                        let streamNumber = result.newValue
+                                        let streamNumber = handledStreams.increment()
                                         XCTAssertTrue(String(buffer: buffer).hasPrefix("GET /foo/"))
                                         let responseMessage = "<b>Success \(streamNumber)</b>"
                                         try await outbound.write(.init(string: responseMessage))
@@ -333,7 +332,7 @@ final class CertificateAuthTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = Atomic(0)
+                let handledStreams = Counter()
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -343,8 +342,7 @@ final class CertificateAuthTests: XCTestCase {
                                 try await stream.executeThenClose { inbound, outbound in
                                     for try await buffer in inbound {
                                         // Just incrementing the stream count on the connection.
-                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
-                                        let streamNumber = result.newValue
+                                        let streamNumber = handledStreams.increment()
                                         let msg = String(buffer: buffer)
                                         XCTAssertTrue(msg.hasPrefix("GET /connection/"))
                                         let parts = msg.split(separator: "/")

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import Foundation
 import Logging
 import NIOConcurrencyHelpers
@@ -20,6 +19,7 @@ import NIOCore
 import NIOEmbedded
 import NIOPosix
 import NIOQUICHelpers
+import Synchronization
 import Testing
 import XCTest
 
@@ -152,7 +152,7 @@ final class QUICProtocolStackTests: XCTestCase {
                     }
                 }
             }
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             let stream = try await clientConnection.createBidirectionalStream { streamInitializer in
                 streamInitializer.channel.eventLoop.makeCompletedFuture {
                     try NIOAsyncChannel(
@@ -171,7 +171,7 @@ final class QUICProtocolStackTests: XCTestCase {
 
                 for try await buffer in inbound {
                     XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                    responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                    responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                 }
             }
 
@@ -234,13 +234,13 @@ final class QUICProtocolStackTests: XCTestCase {
                     }
                 }
             }
-            let clientResponses = ManagedAtomic(0)
+            let clientResponses = Atomic(0)
             group.addTask {
                 for await stream in clientConnection.inboundStreams {
                     try await stream.executeThenClose { inbound, outbound in
                         for try await buffer in inbound {
                             XCTAssertEqual(buffer, .init(string: "Response to client"))
-                            clientResponses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                            clientResponses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                             try clientMultiplexer.eventLoop.close()
                         }
                     }
@@ -392,7 +392,7 @@ final class QUICProtocolStackTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = ManagedAtomic(0)
+                let handledStreams = Atomic(0)
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -405,9 +405,8 @@ final class QUICProtocolStackTests: XCTestCase {
                                         // count on the connection and then sending it back so it doesnt exactly match the incoming read.
                                         // There may be a better way to do this but for now we are just trying to test that the project
                                         // handles multiple connections with individual reads.
-                                        let streamNumber = handledStreams.wrappingIncrementThenLoad(
-                                            ordering: .sequentiallyConsistent
-                                        )
+                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
+                                        let streamNumber = result.newValue
                                         XCTAssertTrue(String(buffer: buffer).hasPrefix("GET /foo/"))
                                         let responseMessage = "<b>Success \(streamNumber)</b>"
                                         try await outbound.write(.init(string: responseMessage))
@@ -420,7 +419,7 @@ final class QUICProtocolStackTests: XCTestCase {
                 }
             }
             let connectionCount = 6
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             // Runs a client side connections one at a time (server is handling connections concurrently)
             // NOTE: For this to work the client side needs to increment the local port used so packets do not get mixed up on connections.
             for connectionIndex in 0..<connectionCount {
@@ -457,7 +456,7 @@ final class QUICProtocolStackTests: XCTestCase {
                     for try await buffer in inbound {
                         // There may be a better way here, but for now just check for the prefix on the client side.
                         XCTAssertTrue(String(buffer: buffer).hasPrefix("<b>Success"))
-                        responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                        responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                     }
                 }
                 try await Task.sleep(for: .milliseconds(5))
@@ -479,7 +478,7 @@ final class QUICProtocolStackTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = ManagedAtomic(0)
+                let handledStreams = Atomic(0)
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -489,9 +488,8 @@ final class QUICProtocolStackTests: XCTestCase {
                                 try await stream.executeThenClose { inbound, outbound in
                                     for try await buffer in inbound {
                                         // Just incrementing the stream count on the connection.
-                                        let streamNumber = handledStreams.wrappingIncrementThenLoad(
-                                            ordering: .sequentiallyConsistent
-                                        )
+                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
+                                        let streamNumber = result.newValue
                                         let msg = String(buffer: buffer)
                                         XCTAssertTrue(msg.hasPrefix("GET /connection/"))
                                         let parts = msg.split(separator: "/")
@@ -512,7 +510,7 @@ final class QUICProtocolStackTests: XCTestCase {
             // Run 6 connections with 6 streams inside each connection
             let connectionCount = 6
             let streamCountPerConnection = 6
-            let streamResponses = ManagedAtomic(0)
+            let streamResponses = Atomic(0)
             // Runs a client side connections one at a time (server is handling connections concurrently)
             // NOTE: For this to work the client side needs to increment the local port used so packets do not get mixed up on connections.
             for connectionIndex in 0..<connectionCount {
@@ -559,7 +557,7 @@ final class QUICProtocolStackTests: XCTestCase {
                             let clientStreamNumber = try XCTUnwrap(Int(parts[2]), "Unexpected part: \(parts[2])")
                             XCTAssertEqual(connectionIndex + 1, clientConnectionNumber)
                             XCTAssertEqual(streamIndex + 1, clientStreamNumber)
-                            streamResponses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                            streamResponses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                         }
                     }
                 }
@@ -603,7 +601,7 @@ final class QUICProtocolStackTests: XCTestCase {
                     }
                 }
             }
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             for _ in 0..<requestCount {
                 let stream = try await connection.createBidirectionalStream { streamInitializer in
                     streamInitializer.channel.eventLoop.makeCompletedFuture {
@@ -623,7 +621,7 @@ final class QUICProtocolStackTests: XCTestCase {
 
                     for try await buffer in inbound {
                         XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                        responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                        responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                     }
                 }
             }
@@ -653,8 +651,8 @@ final class QUICProtocolStackTests: XCTestCase {
             }
         )
 
-        let processedStreams = ManagedAtomic<Int>(0)
-        let allStreamsSent = ManagedAtomic<Bool>(false)
+        let processedStreams = Atomic<Int>(0)
+        let allStreamsSent = Atomic<Bool>(false)
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 for await connection in serverMultiplexer.inboundConnections {
@@ -663,7 +661,7 @@ final class QUICProtocolStackTests: XCTestCase {
                             for try await buffer in inbound {
                                 let str = String(decoding: Array(buffer: buffer), as: Unicode.UTF8.self)
                                 XCTAssert(str.starts(with: "GET /foo/"))
-                                processedStreams.wrappingIncrement(ordering: .sequentiallyConsistent)
+                                processedStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
                             }
                         }
                     }
@@ -738,7 +736,7 @@ final class QUICProtocolStackTests: XCTestCase {
                     }
                 }
             }
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             for _ in 0..<requestCount {
                 let stream = try await connection.createBidirectionalStream { streamInitializer in
                     streamInitializer.channel.eventLoop.makeCompletedFuture {
@@ -758,7 +756,7 @@ final class QUICProtocolStackTests: XCTestCase {
 
                     for try await buffer in inbound {
                         XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                        responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                        responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                     }
                 }
             }
@@ -785,8 +783,8 @@ final class QUICProtocolStackTests: XCTestCase {
                 channel.eventLoop.makeCompletedFuture { fatalError() }
             }
         )
-        let processedStreams = ManagedAtomic<Int>(0)
-        let allStreamsSent = ManagedAtomic<Bool>(false)
+        let processedStreams = Atomic<Int>(0)
+        let allStreamsSent = Atomic<Bool>(false)
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 for await connection in serverMultiplexer.inboundConnections {
@@ -795,7 +793,7 @@ final class QUICProtocolStackTests: XCTestCase {
                             for try await buffer in inbound {
                                 let str = String(decoding: Array(buffer: buffer), as: Unicode.UTF8.self)
                                 XCTAssert(str.starts(with: "GET /foo/"))
-                                processedStreams.wrappingIncrement(ordering: .sequentiallyConsistent)
+                                processedStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
                             }
                         }
                     }
@@ -877,7 +875,7 @@ final class QUICProtocolStackTests: XCTestCase {
                     }
                 }
             }
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             let stream = try await clientConnection.createBidirectionalStream { streamInitializer in
                 streamInitializer.channel.eventLoop.makeCompletedFuture {
                     try NIOAsyncChannel(
@@ -896,7 +894,7 @@ final class QUICProtocolStackTests: XCTestCase {
 
                 for try await buffer in inbound {
                     XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                    responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                    responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                 }
             }
 
@@ -940,7 +938,7 @@ final class QUICProtocolStackTests: XCTestCase {
                     }
                 }
             }
-            let responses = ManagedAtomic(0)
+            let responses = Atomic(0)
             let stream = try await clientConnection.createBidirectionalStream { streamInitializer in
                 streamInitializer.channel.eventLoop.makeCompletedFuture {
                     try NIOAsyncChannel(
@@ -959,7 +957,7 @@ final class QUICProtocolStackTests: XCTestCase {
 
                 for try await buffer in inbound {
                     XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
-                    responses.wrappingIncrement(ordering: .sequentiallyConsistent)
+                    responses.wrappingAdd(1, ordering: .sequentiallyConsistent)
                 }
             }
 

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -392,7 +392,7 @@ final class QUICProtocolStackTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = Atomic(0)
+                let handledStreams = Counter()
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -405,8 +405,7 @@ final class QUICProtocolStackTests: XCTestCase {
                                         // count on the connection and then sending it back so it doesnt exactly match the incoming read.
                                         // There may be a better way to do this but for now we are just trying to test that the project
                                         // handles multiple connections with individual reads.
-                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
-                                        let streamNumber = result.newValue
+                                        let streamNumber = handledStreams.increment()
                                         XCTAssertTrue(String(buffer: buffer).hasPrefix("GET /foo/"))
                                         let responseMessage = "<b>Success \(streamNumber)</b>"
                                         try await outbound.write(.init(string: responseMessage))
@@ -478,7 +477,7 @@ final class QUICProtocolStackTests: XCTestCase {
         XCTAssertNotNil(serverPort, "Server port code not be determined")
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                let handledStreams = Atomic(0)
+                let handledStreams = Counter()
                 // Handle multiple connections
                 await withThrowingTaskGroup(of: Void.self) { connectionGroup in
                     for await connection in serverMultiplexer.inboundConnections {
@@ -488,8 +487,7 @@ final class QUICProtocolStackTests: XCTestCase {
                                 try await stream.executeThenClose { inbound, outbound in
                                     for try await buffer in inbound {
                                         // Just incrementing the stream count on the connection.
-                                        let result = handledStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
-                                        let streamNumber = result.newValue
+                                        let streamNumber = handledStreams.increment()
                                         let msg = String(buffer: buffer)
                                         XCTAssertTrue(msg.hasPrefix("GET /connection/"))
                                         let parts = msg.split(separator: "/")
@@ -651,7 +649,7 @@ final class QUICProtocolStackTests: XCTestCase {
             }
         )
 
-        let processedStreams = Atomic<Int>(0)
+        let processedStreams = Counter()
         let allStreamsSent = Atomic<Bool>(false)
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -661,7 +659,7 @@ final class QUICProtocolStackTests: XCTestCase {
                             for try await buffer in inbound {
                                 let str = String(decoding: Array(buffer: buffer), as: Unicode.UTF8.self)
                                 XCTAssert(str.starts(with: "GET /foo/"))
-                                processedStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
+                                processedStreams.increment()
                             }
                         }
                     }
@@ -689,17 +687,17 @@ final class QUICProtocolStackTests: XCTestCase {
 
             // Give it 4 seconds for all of the streams to be processed
             let startTime = ContinuousClock.now
-            while processedStreams.load(ordering: .sequentiallyConsistent) < requestCount {
+            while processedStreams.load() < requestCount {
                 let elapsed = ContinuousClock.now - startTime
                 if elapsed > .seconds(4) {
                     XCTFail(
-                        "Test timed out, only \(processedStreams.load(ordering: .sequentiallyConsistent))/\(requestCount) streams processed"
+                        "Test timed out, only \(processedStreams.load())/\(requestCount) streams processed"
                     )
                     break
                 }
                 try await Task.sleep(for: .milliseconds(10))
             }
-            XCTAssertEqual(processedStreams.load(ordering: .sequentiallyConsistent), requestCount)
+            XCTAssertEqual(processedStreams.load(), requestCount)
             group.cancelAll()
         }
 
@@ -783,7 +781,7 @@ final class QUICProtocolStackTests: XCTestCase {
                 channel.eventLoop.makeCompletedFuture { fatalError() }
             }
         )
-        let processedStreams = Atomic<Int>(0)
+        let processedStreams = Counter()
         let allStreamsSent = Atomic<Bool>(false)
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -793,7 +791,7 @@ final class QUICProtocolStackTests: XCTestCase {
                             for try await buffer in inbound {
                                 let str = String(decoding: Array(buffer: buffer), as: Unicode.UTF8.self)
                                 XCTAssert(str.starts(with: "GET /foo/"))
-                                processedStreams.wrappingAdd(1, ordering: .sequentiallyConsistent)
+                                processedStreams.increment()
                             }
                         }
                     }
@@ -823,17 +821,17 @@ final class QUICProtocolStackTests: XCTestCase {
 
             // Give it 4 seconds for all of the streams to be processed
             let startTime = ContinuousClock.now
-            while processedStreams.load(ordering: .sequentiallyConsistent) < requestCount {
+            while processedStreams.load() < requestCount {
                 let elapsed = ContinuousClock.now - startTime
                 if elapsed > .seconds(4) {
                     XCTFail(
-                        "Test timed out, only \(processedStreams.load(ordering: .sequentiallyConsistent))/\(requestCount) streams processed"
+                        "Test timed out, only \(processedStreams.load())/\(requestCount) streams processed"
                     )
                     break
                 }
                 try await Task.sleep(for: .milliseconds(10))
             }
-            XCTAssertEqual(processedStreams.load(ordering: .sequentiallyConsistent), requestCount)
+            XCTAssertEqual(processedStreams.load(), requestCount)
             group.cancelAll()
         }
 

--- a/Tests/NIOQUICTests/TestHelpers.swift
+++ b/Tests/NIOQUICTests/TestHelpers.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 import XCTest
 
 extension XCTestCase {
@@ -26,4 +27,17 @@ extension XCTestCase {
 
     static let testPublicKeyPath: String = Bundle.module.url(forResource: "publicKey", withExtension: "der")!
         .path
+}
+
+final class Counter: Sendable {
+    private let value = Atomic<Int>(0)
+
+    @discardableResult
+    func increment() -> Int {
+        self.value.wrappingAdd(1, ordering: .sequentiallyConsistent).newValue
+    }
+
+    func load() -> Int {
+        self.value.load(ordering: .sequentiallyConsistent)
+    }
 }


### PR DESCRIPTION
Motivation:

Atomics from the Syncrhonization module supersede ManagedAtomics from swift-atomics.

Modifications:

- Replace ManagedAtomic with Atomic

Result:

Fewer allocations (2 per stream, 2 per connection)
