### PR TITLE
Pull in fix for watchOS builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            revision: "5f1d45c5356e8052aeb533ef3587c5e2c633e1d3",
+            revision: "1b7579b056416cdc53d7a66dde4c498bf6983afe",
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", branch: "main"),


### PR DESCRIPTION
### Motivation

32-bit watchOS builds in CI are failing due to missing utf8.span support. A fix landed in swift-network-evolution.

### Modifications

Update swift-network-evolution commit to include the fix.

### Results

macOS tests should pass.