### PR TITLE
Adopt fix for static builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            revision: "19a73fc78ad5845a79ec67ebbb6cc3b0cf2e8f9b",
+            revision: "ca1af826afc6408a2a68eb795db978c16e5ced89",
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", branch: "main"),

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            revision: "ba18f3f82016d098f83de061b67f46c48f8639a1",
+            branch: "rh/linux-static-sdk-builds",
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", branch: "main"),

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            branch: "rh/linux-static-sdk-builds",
+            revision: "19a73fc78ad5845a79ec67ebbb6cc3b0cf2e8f9b",
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", branch: "main"),

--- a/Sources/NIOQUIC/NIODeadline+Timespec.swift
+++ b/Sources/NIOQUIC/NIODeadline+Timespec.swift
@@ -14,8 +14,10 @@
 
 import NIOCore
 
-#if os(Linux) || os(Android)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Darwin)
 import Darwin
 #endif

--- a/Sources/NIOQUIC/QUICConnectionID.swift
+++ b/Sources/NIOQUIC/QUICConnectionID.swift
@@ -14,8 +14,10 @@
 
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /// A QUIC connection ID.

--- a/Sources/NIOQUIC/SwiftNetwork/QUICConnectionStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICConnectionStateMachine.swift
@@ -18,6 +18,8 @@ import NIOQUICHelpers
 
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Darwin)
 import Darwin
 #endif

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -17,6 +17,8 @@ import NIOQUICHelpers
 
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Darwin)
 import Darwin
 #endif

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -22,8 +22,10 @@ import NIOQUICHelpers
 import Synchronization
 import X509
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Darwin)
 import Darwin
 #endif

--- a/Tests/NIOQUICTests/QUICConnectionStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionStateMachineTests.swift
@@ -21,6 +21,8 @@ import XCTest
 
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Darwin)
 import Darwin
 #endif


### PR DESCRIPTION
### Motivation

Linux static SDK builds are failing in CI due to a nettling dependency. A new branch in swift-network-evolution removes it to make the builds easier.

### Modifications

Switch swift-network-evolution reference.

### Result

Enable Linux static SDK builds
