### PR TITLE
Drop platforms block and add availability annotations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,13 +34,11 @@ let swiftSettings: [SwiftSetting] =
     [
         .enableUpcomingFeature("ExistentialAny"),
         .enableUpcomingFeature("StrictConcurrency"),
+        .enableExperimentalFeature("AnyAppleOSAvailability"),
     ]
 
 let package = Package(
     name: "swift-nio-quic",
-    platforms: [
-        .macOS("26.0"), .iOS("26.0"), .tvOS("26.0"), .watchOS("26.0"), .visionOS("26.0"),
-    ],
     products: [
         .library(name: "NIOQUIC", targets: ["NIOQUIC"])
     ],
@@ -54,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            revision: "1b7579b056416cdc53d7a66dde4c498bf6983afe",
+            revision: "7caf2a52bb68f1f1ec5ba4e287e729d40a02779e",
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", branch: "main"),

--- a/Sources/ChildChannelMultiplexer/ChildChannel.swift
+++ b/Sources/ChildChannelMultiplexer/ChildChannel.swift
@@ -75,6 +75,7 @@ protocol ChildChannelDelegate: AnyObject {
 ///
 /// It reaches out to its state machine for customization.
 @usableFromInline
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 final class ChildChannel<
     ID: Hashable & _ChildChannelMultiplexerSendableMetatype,
     StateMachine: ChildChannelStateMachine & _ChildChannelMultiplexerSendableMetatype,
@@ -443,6 +444,7 @@ extension ChildChannel.TaskWithDeadline: Sendable {}
 
 // MARK: - Channel action processing
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel {
     /// This method processed the generated actions by the state machine. It is protected against reentrancy.
     ///
@@ -1111,6 +1113,7 @@ extension ChildChannel {
 
 // MARK: - Channel initialization
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel {
     @inlinable
     func configure(
@@ -1172,6 +1175,7 @@ extension ChildChannel {
 
 // MARK: Activation state management
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel {
     /// An enum to keep track of whether we've notified the channel of activation or not.
     @usableFromInline
@@ -1226,6 +1230,7 @@ extension ChildChannel {
 
 // MARK: - Calls from the multiplexer
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel {
     @inlinable
     func parentChannelInactive() {
@@ -1282,6 +1287,7 @@ extension ChildChannel {
 
 // MARK: - `Channel` & `ChannelCore` conformance
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel: Channel, ChannelCore {
     @usableFromInline
     struct SynchronousOptions: NIOSynchronousChannelOptions {
@@ -1569,6 +1575,7 @@ extension ChildChannel.SynchronousOptions: Sendable {}
 
 // MARK: - Internal read and write handling
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel {
     @inlinable
     func _tryToRead() {
@@ -1647,6 +1654,7 @@ extension ChildChannel {
     }
 }
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel {
     /// Appends the passed dependent actions to the last action in the passed actions collection.
     /// If the actions collection is empty all dependent actions will be just appended to the collection.
@@ -1680,4 +1688,5 @@ extension ChildChannel {
 
 /// It's okay to mark ``ChildChannel`` as `@unchecked Sendable` because all operations are properly
 /// isolated to `EventLoop`s.
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannel: @unchecked Sendable {}

--- a/Sources/ChildChannelMultiplexer/ChildChannelMultiplexer.swift
+++ b/Sources/ChildChannelMultiplexer/ChildChannelMultiplexer.swift
@@ -79,6 +79,7 @@ extension ChildChannelMultiplexerDelegate where ChildChannelIDProperties == Neve
 
 /// A generic multiplexer that is capable of multiplexing a single channel onto multiple child channels.
 @preconcurrency
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 public final class ChildChannelMultiplexer<
     ChildChannelID: Hashable & _ChildChannelMultiplexerSendableMetatype,
     ChildChannelIDProperties: _ChildChannelMultiplexerSendableMetatype,
@@ -296,6 +297,7 @@ extension ChildChannelMultiplexer: Sendable {}
 
 // MARK: Calls from parent
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannelMultiplexer {
     /// Method to check if there is a child channel for a given ID.
     ///
@@ -808,6 +810,7 @@ extension ChildChannelMultiplexer {
     }
 }
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannelMultiplexer: ChildChannelDelegate {
     @inlinable
     func writeFromChildChannel(
@@ -1009,6 +1012,7 @@ extension ChildChannelMultiplexer: ChildChannelDelegate {
     }
 }
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension ChildChannelMultiplexer {
     @usableFromInline
     struct ChildChannelMap: Collection {

--- a/Sources/NIOQUIC/QUICConnection.swift
+++ b/Sources/NIOQUIC/QUICConnection.swift
@@ -30,7 +30,7 @@ protocol StreamMultiplexerContinuation: Sendable {
 
 /// A struct representing a single QUIC connection.
 /// Can iterate the inbound streams and create new outbound streams.
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 public struct QUICConnection<Output: Sendable>: Sendable, StreamMultiplexerContinuation {
     /// Channel initializer called for each new inbound stream.
     private let inboundStreamInitializer: @Sendable (any Channel) -> EventLoopFuture<Output>

--- a/Sources/NIOQUIC/QUICConnectionChannelHandler.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannelHandler.swift
@@ -25,7 +25,7 @@ private enum StreamInitializer {
 
 /// A channel handler for QUIC connections.
 /// Lives in a connection child channel and multiplexes the streams of a connections into new child channels.
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 final class QUICConnectionChannelHandler {
     /// This machine makes sure that we don't fire inactive whilst in the middle of initializing a stream.
     struct StateMachine {
@@ -185,7 +185,7 @@ final class QUICConnectionChannelHandler {
     }
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICConnectionChannelHandler: ChannelInboundHandler, ChannelOutboundHandler {
     typealias InboundIn = QUICConnectionChannelInboundMessage
     typealias InboundOut = any Channel
@@ -404,7 +404,7 @@ extension NIOLoopBound {
     }
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICConnectionChannelHandler {
 
     /// Initiates creation of a new locally-initiated QUIC stream.

--- a/Sources/NIOQUIC/QUICConnectionChildChannelStateMachine.swift
+++ b/Sources/NIOQUIC/QUICConnectionChildChannelStateMachine.swift
@@ -17,7 +17,7 @@ import Logging
 import NIOCore
 import NIOQUICHelpers
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 struct QUICConnectionChildChannelStateMachine: ChildChannelStateMachine {
     enum Task: Hashable, CustomStringConvertible {
         case writeToParent(ByteBuffer)
@@ -413,7 +413,7 @@ struct QUICConnectionChildChannelStateMachine: ChildChannelStateMachine {
     }
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICConnectionChildChannelStateMachine {
     /// Writes all outbound data from the QUIC connection to the parent channel.
     ///

--- a/Sources/NIOQUIC/QUICConnectionID.swift
+++ b/Sources/NIOQUIC/QUICConnectionID.swift
@@ -19,7 +19,7 @@ import Glibc
 #endif
 
 /// A QUIC connection ID.
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 public struct QUICConnectionID: CustomStringConvertible, Sendable {
     /// The maximum length of a connection ID.
     public static let maxLength = UInt8(20)
@@ -163,7 +163,7 @@ public struct QUICConnectionID: CustomStringConvertible, Sendable {
     }
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICConnectionID: Equatable {
     public static func == (lhs: QUICConnectionID, rhs: QUICConnectionID) -> Bool {
         guard lhs.length == rhs.length else {
@@ -184,7 +184,7 @@ extension QUICConnectionID: Equatable {
     }
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICConnectionID: Hashable {
     public func hash(into hasher: inout Hasher) {
         self.withUnsafeBufferPointer {

--- a/Sources/NIOQUIC/QUICConnectionIDGenerator.swift
+++ b/Sources/NIOQUIC/QUICConnectionIDGenerator.swift
@@ -19,7 +19,7 @@
 ///
 /// All generated CIDs must have a length equal to ``connectionIDLength``
 /// and must be unique across the lifetime of the connection (RFC 9000 Section 5.1).
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 public protocol QUICConnectionIDGenerator: Sendable {
     /// The length of connection IDs produced by this generator (0-20).
     ///
@@ -48,7 +48,7 @@ public protocol QUICConnectionIDGenerator: Sendable {
 }
 
 /// Generates random connection IDs using a `RandomNumberGenerator`.
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 public struct RandomQUICConnectionIDGenerator: QUICConnectionIDGenerator {
     @usableFromInline
     var randomNumberGenerator: any RandomNumberGenerator & Sendable

--- a/Sources/NIOQUIC/QUICEvents.swift
+++ b/Sources/NIOQUIC/QUICEvents.swift
@@ -16,6 +16,7 @@ import NIOConcurrencyHelpers
 
 /// This event informs of new source connection IDs associated with the connection.
 /// It only captures connection IDs created after the initial IDs during connection establishment.
+@available(anyAppleOS 26, *)
 public struct QUICSCIDAssociatedEvent: Sendable {
 
     /// The newly associated source connection ID.
@@ -28,6 +29,7 @@ public struct QUICSCIDAssociatedEvent: Sendable {
 }
 
 /// This event informs of retired source connection IDs in this connection.
+@available(anyAppleOS 26, *)
 public struct QUICSCIDRetiredEvent: Sendable {
 
     /// The retired source connection ID.
@@ -43,6 +45,7 @@ public struct QUICSCIDRetiredEvent: Sendable {
 /// ID that can be used to contact us.
 ///
 /// This event will be handled by the stream state machine.
+@available(anyAppleOS 26, *)
 public struct QUICRequestAssociateSCIDEvent: Sendable {
 
     /// The source connection ID to associate.
@@ -57,6 +60,7 @@ public struct QUICRequestAssociateSCIDEvent: Sendable {
 /// (and our peer) that we will no longer use this `dcid` to contact them.
 ///
 /// This event will be handled by the stream state machine.
+@available(anyAppleOS 26, *)
 public struct QUICRequestRetireDCIDEvent: Sendable {
 
     /// The destination connection ID to retire.
@@ -76,6 +80,7 @@ struct QUICDrainOutputEvent {}
 /// Test-only event: Injects a connection ID into the retired SCID set.
 /// This allows triggering the protocol violation path when the peer reissues this ID.
 /// This event will be handled by the stream state machine.
+@available(anyAppleOS 26, *)
 internal struct _QUICForTestingPoisonRetiredSCIDEvent: Sendable {
     internal var scid: QUICConnectionID
 
@@ -88,6 +93,7 @@ internal struct _QUICForTestingPoisonRetiredSCIDEvent: Sendable {
 /// The result is written into the provided locked box. This allows tests to discover
 /// the initial SCID (which doesn't generate an association event).
 /// This event will be handled by the stream state machine.
+@available(anyAppleOS 26, *)
 public struct _QUICForTestingGetActiveSCIDsEvent: Sendable {
     public var result: NIOLockedValueBox<[QUICConnectionID]>
 
@@ -100,6 +106,7 @@ public struct _QUICForTestingGetActiveSCIDsEvent: Sendable {
 /// by calling `handleRetireConnectionID` directly. This exercises the `scidPendingDeletion`
 /// buffering mechanism without requiring actual QUIC frame exchange.
 /// This event will be handled by the stream state machine.
+@available(anyAppleOS 26, *)
 public struct _QUICForTestingSimulateRetireEvent: Sendable {
     public var scid: QUICConnectionID
 
@@ -114,6 +121,7 @@ public struct _QUICForTestingSimulateRetireEvent: Sendable {
 /// the packet routing path intact. Mirrors the buffering logic: if this is the last
 /// active SCID, it is stored in `scidPendingDeletion` instead of removed.
 /// This event will be handled by the stream state machine.
+@available(anyAppleOS 26, *)
 public struct _QUICForTestingRemoveActiveSCIDEvent: Sendable {
     public var scid: QUICConnectionID
 

--- a/Sources/NIOQUIC/QUICHandler+Multiplexer.swift
+++ b/Sources/NIOQUIC/QUICHandler+Multiplexer.swift
@@ -18,7 +18,7 @@ import NIOCore
 /// Internal type to abstract away the `Output` type of the multiplexer. This means we are going through an existential
 /// in the `QUICHandler` when yielding a new `Channel`. However, this is okay for now otherwise
 /// we would need to make the handler generic as well.
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 protocol ConnectionMultiplexerContinuation: Sendable {
     /// We have to do a bit of an awkward dance here to carry the `Output` between the initializer and the continuation where
     /// we yield to. That's why we are using `Any` here to avoid making the handler generic.
@@ -33,7 +33,7 @@ protocol ConnectionMultiplexerContinuation: Sendable {
     func finish()
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICHandler {
     /// A multiplexer for the QUIC connections of a ``QUICHandler``.
     ///

--- a/Sources/NIOQUIC/QUICHandler.swift
+++ b/Sources/NIOQUIC/QUICHandler.swift
@@ -17,7 +17,7 @@ import Logging
 import NIOCore
 import X509
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 private enum MultiplexerContinuation {
     case connectionMultiplexerContinuation(any ConnectionMultiplexerContinuation)
     case closure(
@@ -31,7 +31,7 @@ private enum MultiplexerContinuation {
 /// A handler for QUIC connections.
 /// Add this to a UDP channel.
 /// It can multiplex multiple QUIC connections.
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 public final class QUICHandler {
     private enum State {
         case accepting
@@ -562,7 +562,7 @@ public final class QUICHandler {
 @available(*, unavailable)
 extension QUICHandler: Sendable {}
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICHandler: ChannelInboundHandler {
     public typealias InboundIn = AddressedEnvelope<ByteBuffer>
     public typealias OutboundOut = AddressedEnvelope<ByteBuffer>
@@ -942,7 +942,7 @@ extension QUICHandler: ChannelInboundHandler {
     }
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICHandler: ChildChannelMultiplexerDelegate {
     public typealias ChildChannelID = QUICConnectionID
     public typealias ChildChannelIDProperties = Never
@@ -1019,7 +1019,7 @@ extension ByteBuffer {
     fileprivate static let maxDatagramSize = 1350
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 public struct QUICHandlerHandle: Sendable {
     private let _wrapped: NIOLoopBound<QUICHandler>
 
@@ -1039,7 +1039,7 @@ public struct QUICHandlerHandle: Sendable {
     }
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension QUICHandler {
     public func makeHandle() -> QUICHandlerHandle {
         QUICHandlerHandle(wrapping: self, eventLoop: self.eventLoop)

--- a/Sources/NIOQUIC/SwiftNetwork/ByteBuffer+Frame.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/ByteBuffer+Frame.swift
@@ -15,6 +15,7 @@
 import NIOCore
 @_spi(ProtocolProvider) import SwiftNetwork
 
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeFrame(_ frame: consuming SwiftNetwork.Frame) -> Int {

--- a/Sources/NIOQUIC/SwiftNetwork/FrameMemory.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/FrameMemory.swift
@@ -15,6 +15,7 @@
 @_spi(CustomByteBufferAllocator) import NIOCore
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
 
+@available(anyAppleOS 26, *)
 enum FrameMemory {
     static let allocator = ByteBufferAllocator(
         allocate: { UnsafeMutableRawPointer.allocate(byteCount: Int($0), alignment: 1) },
@@ -31,6 +32,7 @@ enum FrameMemory {
     )
 }
 
+@available(anyAppleOS 26, *)
 extension Frame {
     // Wrap creation of a new Frame with a .customFinalizer buffer. Allocates `size` bytes
     // and sets a finalizer that deallocates the memory.

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelEventLoop.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelEventLoop.swift
@@ -16,12 +16,14 @@ import NIOCore
 @_spi(ProtocolProvider) @_spi(Essentials) import SwiftNetwork
 
 // TODO: Make ScheduledEntry ~Copyable with UniqueArray / PriorityQueue
+@available(anyAppleOS 26, *)
 struct ScheduledEntry {
     var milliseconds: Int64
     var reference: SwiftNetwork.TimerReference
     var scheduledTask: Scheduled<Void>??
 }
 
+@available(anyAppleOS 26, *)
 final class QUICChannelEventLoop: NetworkContext.Scheduler, CustomStringConvertible {
 
     internal let description = "QUICChannelEventLoop"

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
@@ -29,6 +29,7 @@ import Musl
 /// The `QUICChannelNewFlowHandler` registered with the SwiftNetwork `QUICConnectionImplementation` as a new flow handler.
 /// This object deals with creating and linking the objects describing a new flow, it creates a new `QUICChannelStreamHandler`
 /// for each new flow, registers it and keeps track of it.
+@available(anyAppleOS 26, *)
 final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHandler {
 
     internal typealias LowerProtocol = StreamListenerLinkage
@@ -220,6 +221,7 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICChannelNewFlowHandler: UpperProtocolHandler {
     func handleNetworkProtocolEvent(
         _ from: SwiftNetwork.ProtocolInstanceReference,

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
@@ -27,6 +27,7 @@ import Musl
 /// `QUICChannelOutputHandler` is the bridge between SwiftNetwork and our code on the network-side.
 /// It is registered with the SwiftNetwork `QUICConnectionImplementation` as an output handler.
 /// This object deals with both getting bytes in and out of the `QUICConnectionImplementation` on the network-side.
+@available(anyAppleOS 26, *)
 final class QUICChannelOutputHandler: ProtocolInstanceContainer, OutboundDatagramHandler {
 
     typealias UpperProtocol = InboundDatagramLinkage
@@ -104,6 +105,7 @@ final class QUICChannelOutputHandler: ProtocolInstanceContainer, OutboundDatagra
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICChannelOutputHandler: LowerProtocolHandler {
     func getMetrics(
         _ from: SwiftNetwork.ProtocolInstanceReference,

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -48,6 +48,7 @@ enum StreamClosureState {
 
 /// `QUICChannelStreamHandler` is the bridge between SwiftNetwork and our code on the application-side;
 /// one `QUICChannelStreamHandler` exists for each QUIC stream.
+@available(anyAppleOS 26, *)
 final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHandler, @unchecked Sendable {
 
     // MARK: Channel and ChannelCore conformanace
@@ -840,6 +841,7 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICChannelStreamHandler: UpperProtocolHandler {
     internal func handleNetworkProtocolEvent(
         _ from: SwiftNetwork.ProtocolInstanceReference,
@@ -873,6 +875,7 @@ extension QUICChannelStreamHandler: UpperProtocolHandler {
 
 // MARK: - `Channel` and `ChannelCore` conformance
 
+@available(anyAppleOS 26, *)
 extension QUICChannelStreamHandler: Channel, ChannelCore {
     var parent: (any Channel)? {
         self.connectionChannel

--- a/Sources/NIOQUIC/SwiftNetwork/QUICConfiguration.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICConfiguration.swift
@@ -54,6 +54,7 @@ public enum KeyExchangeGroup: UInt16, Sendable {
     case x25519 = 0x001D
     case x25519MLKEM768 = 0x11EC
 
+    @available(anyAppleOS 26, *)
     internal var swiftTLSKeyExchangeGroup: SwiftTLS.SwiftTLSOptions.KeyExchangeGroup {
         switch self {
         case .secp256:
@@ -68,6 +69,7 @@ public enum KeyExchangeGroup: UInt16, Sendable {
     }
 }
 
+@available(anyAppleOS 26, *)
 public struct QUICConfiguration: Sendable {
     public struct QLogConfiguration: Sendable {
         /// The directory to where the qlog files are written to.

--- a/Sources/NIOQUIC/SwiftNetwork/QUICConnectionID+SwiftNetwork.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICConnectionID+SwiftNetwork.swift
@@ -14,6 +14,7 @@
 
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
 
+@available(anyAppleOS 26, *)
 extension NIOQUIC.QUICConnectionID {
     /// Creates a NIOQUIC connection ID from a SwiftNetwork connection ID.
     init(_ connectionID: SwiftNetwork.QUICConnectionID) {
@@ -24,6 +25,7 @@ extension NIOQUIC.QUICConnectionID {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension SwiftNetwork.QUICConnectionID {
     /// Creates a SwiftNetwork connection ID from a NIOQUIC connection ID.
     init(_ connectionID: NIOQUIC.QUICConnectionID) {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICConnectionStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICConnectionStateMachine.swift
@@ -64,6 +64,7 @@ import Darwin
 //                                           └──────────┘
 
 /// A state machine managing the QUIC connection lifecycle.
+@available(anyAppleOS 26, *)
 struct QUICConnectionStateMachine: ~Copyable {
     /// The possible states of a QUIC connection.
     enum State: ~Copyable {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
@@ -16,7 +16,7 @@ import NIOCore
 @_spi(ProtocolProvider) import SwiftNetwork
 
 /// A QUIC packet's header.
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 public struct QUICPacketHeader: Hashable, Sendable {
 
     static func form(_ firstByte: UInt8) -> PacketForm {
@@ -179,7 +179,7 @@ public struct QUICPacketHeader: Hashable, Sendable {
     fileprivate static let AES128GCMTagLength: Int = 16
 }
 
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 extension NIOCore.ByteBuffer {
 
     /// A method to parse a `QUICPacketHeader` from the `ByteBuffer`, mainly to parse the destinationConnectionID only for routing.

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -85,6 +85,7 @@ enum StreamShutdownDirection {
 ///
 /// For bidirectional streams, both send and receive state machines are active.
 /// For unidirectional streams, only one direction is relevant.
+@available(anyAppleOS 26, *)
 struct QUICStreamStateMachine: ~Copyable {
 
     /// Error thrown when a transition is called in an invalid state.
@@ -743,6 +744,7 @@ struct QUICStreamStateMachine: ~Copyable {
 
 // MARK: - State Transitions
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.State {
     /// Replay the FIN with the original finalSize that was received before the stream connected.
     mutating func replayEarlyFin(finalSize: UInt64) {
@@ -1179,6 +1181,7 @@ extension QUICStreamStateMachine.State {
 
 // MARK: - StreamState with*State Helpers
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.State.StreamState {
     /// Mutates the send sub-state-machine via `body`, if this stream has a send direction.
     ///
@@ -1295,6 +1298,7 @@ extension QUICStreamStateMachine.State.StreamState {
 //                └────────────┘
 
 /// State machine for the sending direction of a QUIC stream per RFC 9000 Section 3.1.
+@available(anyAppleOS 26, *)
 struct QUICStreamSendStateMachine: ~Copyable {
     enum State: ~Copyable {
         /// Stream created but no data sent yet.
@@ -1510,6 +1514,7 @@ struct QUICStreamSendStateMachine: ~Copyable {
 
 // MARK: - State Transitions
 
+@available(anyAppleOS 26, *)
 extension QUICStreamSendStateMachine.State {
     mutating func writeData() -> QUICStreamSendStateMachine.WriteDataAction {
         switch consume self {
@@ -1679,6 +1684,7 @@ extension QUICStreamSendStateMachine.State {
 /// The RFC defines a `Size Known` state between `Recv` and `Data Recvd` for when
 /// the FIN has been received but data gaps remain. Since the transport layer handles
 /// reassembly, we skip `Size Known` and go directly from `Recv` to `Data Recvd`.
+@available(anyAppleOS 26, *)
 struct QUICStreamReceiveStateMachine: ~Copyable {
     enum State: ~Copyable {
         /// Receiving data, FIN not yet received.
@@ -1924,6 +1930,7 @@ struct QUICStreamReceiveStateMachine: ~Copyable {
 
 // MARK: - Receive State Transitions
 
+@available(anyAppleOS 26, *)
 extension QUICStreamReceiveStateMachine.State {
     mutating func receiveData() -> QUICStreamReceiveStateMachine.ReceiveDataAction {
         switch consume self {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -2151,6 +2151,7 @@ extension QUICStreamPipelineStateMachine.State {
 }
 
 /// The handle a QUIC stream uses to talk to the SwiftNetwork transport stack.
+@available(anyAppleOS 26, *)
 struct SwiftNetworkStreamHandle: ~Copyable {
     /// Pure state machine: tracks attachment.
     ///
@@ -2412,6 +2413,7 @@ struct SwiftNetworkStreamHandle: ~Copyable {
 
 // MARK: - SwiftNetwork Stream Handle State Transitions
 
+@available(anyAppleOS 26, *)
 extension SwiftNetworkStreamHandle.StateMachine.State {
     mutating func invokeDetach() -> SwiftNetworkStreamHandle.StateMachine.InvokeDetachAction {
         switch consume self {

--- a/Sources/NIOQUIC/SwiftNetwork/SocketAddress+Endpoint.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SocketAddress+Endpoint.swift
@@ -15,6 +15,7 @@
 import NIOCore
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
 
+@available(anyAppleOS 26, *)
 extension SocketAddress {
     /// Returns an `Endpoint` set to a `HostEndpoint` created from this `SocketAddress`.
     func toEndpoint() -> Endpoint {

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -43,7 +43,7 @@ extension NIOCore.ByteBuffer {
 
 /// A wrapper around the objects and state we need to keep track of and access a QUIC connection in SwiftNetwork.
 /// Holds the references required to access QUIC connections and streams
-@available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *)
+@available(anyAppleOS 26, *)
 final class SwiftNetworkQUICConnection {
     /// Struct that contains the results of a read for a stream.
     struct ReadStreamResult {
@@ -1167,6 +1167,7 @@ final class SwiftNetworkQUICConnection {
 
 }
 
+@available(anyAppleOS 26, *)
 extension SwiftNetworkQUICConnection {
 
     /// Schedule a connection close due to a given error. This can be called from callbacks
@@ -1352,6 +1353,7 @@ extension SwiftNetworkQUICConnection {
 }
 
 // Callbacks coming from QUICChannelStreamHandler and QUICChannelNewFlowHandler
+@available(anyAppleOS 26, *)
 extension SwiftNetworkQUICConnection {
 
     /// Handle disconnected events from SwiftNetwork for individual stream handlers.
@@ -1488,6 +1490,7 @@ extension SwiftNetworkQUICConnection {
 }
 
 // Callbacks coming from QUICChannelNewFlowHandler
+@available(anyAppleOS 26, *)
 extension SwiftNetworkQUICConnection {
 
     /// Marks a new server stream as newly connected and adds the new stream to streamInputHandlers
@@ -1510,6 +1513,7 @@ extension SwiftNetworkQUICConnection {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension SwiftNetworkQUICConnection {
     /// Request retiring a connection ID that we are using to address our peer.
     func requestRetirementOfConnectionID(_ connectionID: QUICConnectionID) throws {
@@ -1533,6 +1537,7 @@ extension SwiftNetworkQUICConnection {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension SwiftNetworkQUICConnection {
     #if DEBUG  // For testing purposes only
     /// Injects a connection ID into the retired set. Useful for testing because it allows
@@ -1568,6 +1573,7 @@ extension SwiftNetworkQUICConnection {
 }
 
 // Callbacks coming from QUICChannelOutputHandler
+@available(anyAppleOS 26, *)
 extension SwiftNetworkQUICConnection {
 
     internal func flushOutputFrames() {
@@ -1664,6 +1670,7 @@ extension SwiftNetworkQUICConnection {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension Frame {
     /// The frames returned by Swift QUIC were created in `QUICChannelOutputHandler.getDatagramsToSend`. They all hold
     /// the same buffer type and a pointer to allocated memory. Any other buffer type is unexpected and a logic error. To take ownership
@@ -1708,6 +1715,7 @@ extension Frame {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension SwiftNetworkQUICConnection {
     /// A view over the connection for the `QUICChannelNewFlowHandler`.
     struct NewFlowView {

--- a/Sources/NIOQUIC/SwiftNetwork/Utilities.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/Utilities.swift
@@ -15,6 +15,7 @@
 import NIOQUICHelpers
 @_spi(Essentials) import SwiftNetwork
 
+@available(anyAppleOS 26, *)
 extension NetworkDuration {
     init(duration: Duration) {
         let components = duration.components

--- a/Sources/NIOQUIC/SwiftTLS/AsyncVerifier.swift
+++ b/Sources/NIOQUIC/SwiftTLS/AsyncVerifier.swift
@@ -30,12 +30,14 @@ enum CertificateVerificationResult {
     case invalid(reason: String)
 }
 
+@available(anyAppleOS 26, *)
 struct CallbackVerificationInput {
     var verificationInfo: VerificationInfo
     var hostname: String
 }
 
 /// Asynchronously perform certificate validation during the TLS handshake
+@available(anyAppleOS 26, *)
 public final class AsyncVerifier: Sendable {
     private let stream: AsyncStream<CallbackVerificationInput>
     private let continuation: AsyncStream<CallbackVerificationInput>.Continuation

--- a/Sources/NIOQUIC/SwiftTLS/AsyncVerifierRunner.swift
+++ b/Sources/NIOQUIC/SwiftTLS/AsyncVerifierRunner.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(anyAppleOS 26, *)
 final class AsyncVerifierRunner: Sendable {
     let asyncVerifier: AsyncVerifier
     let asyncVerifierTask: Task<(), Never>

--- a/Sources/NIOQUIC/SwiftTLS/Authenticator.swift
+++ b/Sources/NIOQUIC/SwiftTLS/Authenticator.swift
@@ -17,6 +17,7 @@ import SwiftASN1
 @_spi(SwiftTLSProtocol) import SwiftTLS
 import X509
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 enum AuthParameters {
     static var legacySignatureAlgorithms: Set<Certificate.SignatureAlgorithm> {
         [
@@ -26,6 +27,7 @@ enum AuthParameters {
 }
 
 /// Authenticates the server during TLS 1.3 handshakes using X509 certificates.
+@available(anyAppleOS 26, *)
 public final class Authenticator: Sendable {
     let privateKey: Certificate.PrivateKey
     let certificates: [Certificate]

--- a/Sources/NIOQUIC/SwiftTLS/Certificates.swift
+++ b/Sources/NIOQUIC/SwiftTLS/Certificates.swift
@@ -16,6 +16,7 @@ import Foundation
 import SwiftASN1
 import X509
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 func loadCertificates(fromPEMFile path: String) throws -> [Certificate] {
     let pemData = try Data(contentsOf: URL(fileURLWithPath: path))
     let pemString = String(decoding: pemData, as: UTF8.self)
@@ -28,6 +29,7 @@ func loadCertificates(fromPEMFile path: String) throws -> [Certificate] {
     }
 }
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 func loadPrivateKey(fromPEMFile path: String) throws -> Certificate.PrivateKey {
     let pemData = try Data(contentsOf: URL(fileURLWithPath: path))
     let pemString = String(decoding: pemData, as: UTF8.self)

--- a/Sources/NIOQUIC/SwiftTLS/SigningKeys.swift
+++ b/Sources/NIOQUIC/SwiftTLS/SigningKeys.swift
@@ -15,6 +15,7 @@
 import Crypto
 import Foundation
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension P256.Signing.PrivateKey {
     static func fromDERFile(_ path: String) throws -> P256.Signing.PrivateKey {
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
@@ -22,6 +23,7 @@ extension P256.Signing.PrivateKey {
     }
 }
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension P256.Signing.PublicKey {
     static func fromDERFile(_ path: String) throws -> P256.Signing.PublicKey {
         let data = try Data(contentsOf: URL(fileURLWithPath: path))

--- a/Sources/NIOQUICExample/CertificateChain.swift
+++ b/Sources/NIOQUICExample/CertificateChain.swift
@@ -17,6 +17,7 @@ import Foundation
 import SwiftASN1
 import X509
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 func makeCertificate(
     commonName cn: String,
     issuer: (Certificate, Certificate.PrivateKey)? = nil,
@@ -125,6 +126,7 @@ func makeCertificate(
     }
 }
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 struct CertificateChain {
     let rootCert: Certificate
     let rootKey: Certificate.PrivateKey
@@ -202,6 +204,7 @@ struct CertificateChain {
 
 }
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private func writeCertificates(
     _ certificates: [Certificate],
     directory: URL,
@@ -218,6 +221,7 @@ private func writeCertificates(
     return url
 }
 
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private func writeKey(
     _ privateKey: Certificate.PrivateKey,
     directory: URL,

--- a/Sources/NIOQUICExample/Example.swift
+++ b/Sources/NIOQUICExample/Example.swift
@@ -19,6 +19,7 @@ import NIOPosix
 import NIOQUIC
 
 @main
+@available(anyAppleOS 26, *)
 struct Example {
     static func main() async throws {
         let logger = Logger(label: "quic.example")

--- a/Tests/IntegrationTests/AsyncStreamingTests.swift
+++ b/Tests/IntegrationTests/AsyncStreamingTests.swift
@@ -17,6 +17,7 @@ import XCTest
 
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class AsyncStreamingTests: XCTestCase {
 
     // MARK: - async-wrapper body transfer

--- a/Tests/IntegrationTests/AsyncTestSetup.swift
+++ b/Tests/IntegrationTests/AsyncTestSetup.swift
@@ -27,6 +27,7 @@ enum TestingMode {
     case testing(eventLoop: NIOAsyncTestingEventLoop)
 }
 
+@available(anyAppleOS 26, *)
 func makeClientAndServerPair(
     testMode: TestingMode = .network(
         eventLoopGroup: MultiThreadedEventLoopGroup.singleton,
@@ -90,6 +91,7 @@ func makeClientAndServerPair(
     }
 }
 
+@available(anyAppleOS 26, *)
 func makeMockClientAndServerPair(
     testingEventLoop: NIOAsyncTestingEventLoop,
     publicKeyPath: String,
@@ -184,6 +186,7 @@ func makeMockClientAndServerPair(
     )
 }
 
+@available(anyAppleOS 26, *)
 func makeNetworkClientAndServerPair(
     eventLoopGroup: any EventLoopGroup,
     host: String,
@@ -235,6 +238,7 @@ func makeNetworkClientAndServerPair(
     )
 }
 
+@available(anyAppleOS 26, *)
 private func setUpClientConnectionMultiplexer(
     eventLoopGroup: any EventLoopGroup,
     host: String,
@@ -291,6 +295,7 @@ private func setUpClientConnectionMultiplexer(
     return (channel, multiplexer)
 }
 
+@available(anyAppleOS 26, *)
 private func setUpServerChannelAndConnectionMultiplexer(
     eventLoopGroup: any EventLoopGroup,
     host: String,

--- a/Tests/IntegrationTests/ChannelHierarchyTests.swift
+++ b/Tests/IntegrationTests/ChannelHierarchyTests.swift
@@ -32,6 +32,7 @@ private final class UDPMarker: ChannelInboundHandler, Sendable {
     typealias InboundIn = NIOAny
 }
 
+@available(anyAppleOS 26, *)
 final class ChannelHierarchyTests: XCTestCase {
     /// End-to-end test that asserts the channel hierarchy from the perspective
     /// of a QUIC stream channel:

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -25,6 +25,7 @@ import XCTest
 
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class IntegrationTests: XCTestCase {
     func testHTTP09Requests() async throws {
         // To open more streams you will need to plumb this through on the QUIC stream options. Max is 8.
@@ -738,6 +739,7 @@ final class IntegrationTests: XCTestCase {
     }
 }
 
+@available(anyAppleOS 26, *)
 final class PacketHeaderRecorderHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = AddressedEnvelope<ByteBuffer>
     typealias InboundOut = AddressedEnvelope<ByteBuffer>
@@ -760,6 +762,7 @@ final class PacketHeaderRecorderHandler: ChannelInboundHandler, Sendable {
     }
 }
 
+@available(anyAppleOS 26, *)
 final class ClientApplicationCloseHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = Never
 

--- a/Tests/IntegrationTests/SyncIntegrationTests.swift
+++ b/Tests/IntegrationTests/SyncIntegrationTests.swift
@@ -25,6 +25,7 @@ import XCTest
 @testable import NIOQUIC
 
 /// Reads in quic stream channels, runs the inboundStreamInitializer on them, then passes them down
+@available(anyAppleOS 26, *)
 final class HTTPConnectionHandler: ChannelInboundHandler {
     typealias InboundIn = any Channel  // stream channels
     typealias InboundOut = any Channel  // Pass through the stream channels
@@ -59,6 +60,7 @@ final class HTTPConnectionHandler: ChannelInboundHandler {
 }
 
 /// This channel gives a connection error as soon as it reads an inbound quic stream
+@available(anyAppleOS 26, *)
 final class RejectEverythingHTTPConnectionHandler: ChannelInboundHandler {
     typealias InboundIn = any Channel  // stream channels
     typealias InboundOut = any Channel  // Pass through the stream channels
@@ -77,6 +79,7 @@ final class RejectEverythingHTTPConnectionHandler: ChannelInboundHandler {
 }
 
 /// This channel immediately sends STOP_SENDING (with code 10) on every inbound stream.
+@available(anyAppleOS 26, *)
 final class StreamClosingHTTPConnectionHandler: ChannelInboundHandler {
     typealias InboundIn = any Channel  // stream channels
     typealias InboundOut = any Channel  // Pass through the stream channels
@@ -93,6 +96,7 @@ final class StreamClosingHTTPConnectionHandler: ChannelInboundHandler {
 }
 
 /// This channel immediately fires a RESET\_STREAM (with code 10) on every inbound stream.
+@available(anyAppleOS 26, *)
 final class StreamResettingHTTPConnectionHandler: ChannelInboundHandler {
     typealias InboundIn = any Channel  // stream channels
     typealias InboundOut = any Channel  // Pass through the stream channels
@@ -109,6 +113,7 @@ final class StreamResettingHTTPConnectionHandler: ChannelInboundHandler {
 }
 
 /// Waits for incoming requests, ensure they match GET /foo, then responds with success. Refuses to do this more than once
+@available(anyAppleOS 26, *)
 final class TestServerHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -144,6 +149,7 @@ final class TestServerHandler: ChannelInboundHandler {
 }
 
 /// Waits for the channel to be active, sends a request, awaits the response and asserts that it is as expected. Then closes the channel.
+@available(anyAppleOS 26, *)
 final class TestClientHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -207,6 +213,7 @@ final class TestClientHandler: ChannelInboundHandler {
     }
 }
 
+@available(anyAppleOS 26, *)
 final class ConnectionIDSideChannel: Sendable {
     let connectionID: Mutex<QUICConnectionID?>
 
@@ -216,6 +223,7 @@ final class ConnectionIDSideChannel: Sendable {
 }
 
 /// Waits for incoming "GET /foo" requests and answer them. Shuts down when receiving "GET /bye".
+@available(anyAppleOS 26, *)
 final class TestConnectionIDCycleServerHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -290,6 +298,7 @@ final class TestConnectionIDCycleServerHandler: ChannelInboundHandler {
 /// 2. Receive an inbound event that the connection ID was associated with the connection.
 /// 3. Put the connection ID in the side channel for the server to request its retirement.
 /// 4. Receive an inbound event that the connection ID was retired from the connection.
+@available(anyAppleOS 26, *)
 final class TestConnectionIDCycleClientHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -398,6 +407,7 @@ final class TestConnectionIDCycleClientHandler: ChannelInboundHandler {
 }
 
 /// Server handler for the protocol violation test. Just responds to requests.
+@available(anyAppleOS 26, *)
 final class TestProtocolViolationServerHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -426,6 +436,7 @@ final class TestProtocolViolationServerHandler: ChannelInboundHandler {
 /// `handleAssociateConnectionID` runs on the client side (it's triggered by the local
 /// SwiftNetwork creating the SCID), so it finds the ID in `retiredSCIDs` and triggers
 /// the protocol violation close.
+@available(anyAppleOS 26, *)
 final class TestProtocolViolationClientHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -500,6 +511,7 @@ final class TestProtocolViolationClientHandler: ChannelInboundHandler {
 
 /// Server handler for the buffered connection ID deletion test. Responds to requests
 /// and shuts down on "GET /bye".
+@available(anyAppleOS 26, *)
 final class TestBufferedDeletionServerHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -548,6 +560,7 @@ final class TestBufferedDeletionServerHandler: ChannelInboundHandler {
 ///
 /// Phase transitions are managed by `BufferedDeletionStateMachine`. This handler
 /// switches over the returned actions to perform NIO channel operations.
+@available(anyAppleOS 26, *)
 final class TestBufferedDeletionClientHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -717,6 +730,7 @@ final class TestBufferedDeletionClientHandler: ChannelInboundHandler {
     }
 }
 
+@available(anyAppleOS 26, *)
 final class ErrorCatchingHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = Never
     typealias OutboundIn = Never
@@ -734,6 +748,7 @@ final class ErrorCatchingHandler: ChannelInboundHandler, Sendable {
 }
 
 /// Captures a `QUICStopSendingEvent` delivered as a user inbound event and succeeds a promise.
+@available(anyAppleOS 26, *)
 final class StopSendingEventHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = ByteBuffer
 
@@ -752,6 +767,7 @@ final class StopSendingEventHandler: ChannelInboundHandler, Sendable {
 }
 
 /// Collects all read data into a shared buffer and succeeds a promise when data arrives.
+@available(anyAppleOS 26, *)
 final class ReadCollectorHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = ByteBuffer
 
@@ -778,6 +794,7 @@ final class ReadCollectorHandler: ChannelInboundHandler, Sendable {
 }
 
 /// Handler to track when connection becomes active
+@available(anyAppleOS 26, *)
 final class ConnectionActiveHandler: ChannelInboundHandler {
     typealias InboundIn = Never
     let activePromise: EventLoopPromise<Void>
@@ -793,6 +810,7 @@ final class ConnectionActiveHandler: ChannelInboundHandler {
 }
 
 /// Waits for incoming requests, ensure they match GET /foo, then responds with success. Refuses to do this more than once
+@available(anyAppleOS 26, *)
 final class StreamingServerHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -850,6 +868,7 @@ final class StreamingServerHandler: ChannelInboundHandler {
 }
 
 /// Waits for the channel to be active, sends a request, awaits the response and asserts that it is as expected. Then closes the channel.
+@available(anyAppleOS 26, *)
 final class StreamingClientHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
@@ -914,6 +933,7 @@ final class StreamingClientHandler: ChannelInboundHandler {
 }
 
 // These integration tests use the nio interfaces rather than async ones
+@available(anyAppleOS 26, *)
 final class SyncIntegrationTests: XCTestCase {
 
     func getChannelLoggers() -> (serverLogger: Logger, clientLogger: Logger) {

--- a/Tests/IntegrationTests/SyncTestSetup.swift
+++ b/Tests/IntegrationTests/SyncTestSetup.swift
@@ -33,6 +33,7 @@ import XCTest
 ///     accepted connections. Defaults to a no-op.
 ///   - noMoreConnections: Called when the handler becomes inactive and no
 ///     further connections will be accepted.
+@available(anyAppleOS 26, *)
 func createServerChannel(
     eventLoopGroup: any EventLoopGroup,
     host: String,
@@ -72,6 +73,7 @@ func createServerChannel(
 /// - Parameter udpChannelInitializer: Called once the UDP channel is bound,
 ///   before the `QUICHandler` is added. Use this to install handlers on
 ///   the UDP channel pipeline.
+@available(anyAppleOS 26, *)
 func createClientChannel(
     eventLoopGroup: any EventLoopGroup,
     host: String,
@@ -99,6 +101,7 @@ func createClientChannel(
     )
 }
 
+@available(anyAppleOS 26, *)
 private func createQUICChannel(
     eventLoopGroup: any EventLoopGroup,
     host: String,

--- a/Tests/IntegrationTests/TestHelpers.swift
+++ b/Tests/IntegrationTests/TestHelpers.swift
@@ -116,6 +116,7 @@ func assertNoThrowWithValue<T>(
     }
 }
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 final class Counter: Sendable {
     private let value = Atomic<Int>(0)
 

--- a/Tests/NIOQUICTests/AsyncVerifierTests.swift
+++ b/Tests/NIOQUICTests/AsyncVerifierTests.swift
@@ -25,6 +25,7 @@ enum TaskTypes {
     case testing
 }
 
+@available(anyAppleOS 26, *)
 final class AsyncVerifierTests: XCTestCase {
 
     // MARK: Related tests

--- a/Tests/NIOQUICTests/AuthenticationCallbackTest.swift
+++ b/Tests/NIOQUICTests/AuthenticationCallbackTest.swift
@@ -22,6 +22,7 @@ import X509
 
 struct AuthenticationCallbackTest {
 
+    @available(anyAppleOS 26, *)
     @Test("Verify extended key usage allows server auth")
     func callbackCreationChecksExtendedKeyUsageIfAvailable() throws {
         let (rootCert, rootKey) = try makeCertificate(commonName: "test-root")
@@ -73,6 +74,7 @@ struct AuthenticationCallbackTest {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Test externally generated certificates")
     func callbackCreationWithExternallyGeneratedCertificates() throws {
         let certStr1 = """

--- a/Tests/NIOQUICTests/ByteBuffer+FrameTests.swift
+++ b/Tests/NIOQUICTests/ByteBuffer+FrameTests.swift
@@ -21,6 +21,7 @@ import Testing
 private let testBuffer: [UInt8] = (0..<2048).flatMap { _ in [7, 6, 5, 4, 3, 2, 1, 9, 8] }
 
 struct ByteBuffer_FrameTests {
+    @available(anyAppleOS 26, *)
     @Test(
         "init(frame:) empty buffer"
     )
@@ -34,6 +35,7 @@ struct ByteBuffer_FrameTests {
         #expect(byteBuffer == ByteBuffer(bytes: bytes))
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "init(frame:) buffer consistency"
     )
@@ -46,6 +48,7 @@ struct ByteBuffer_FrameTests {
         #expect(byteBuffer == ByteBuffer(bytes: testBuffer))
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "init(frame:) independent backing storage"
     )

--- a/Tests/NIOQUICTests/CertificateAuthTests.swift
+++ b/Tests/NIOQUICTests/CertificateAuthTests.swift
@@ -24,6 +24,7 @@ import XCTest
 @testable import ChildChannelMultiplexer
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class CertificateAuthTests: XCTestCase {
 
     private func buildClientChannel(

--- a/Tests/NIOQUICTests/CustomFinalizerFrameOwnershipTests.swift
+++ b/Tests/NIOQUICTests/CustomFinalizerFrameOwnershipTests.swift
@@ -24,6 +24,7 @@ struct CustomFinalizerFrameOwnershipTests {
     private let bufferSize = 10
     private let deallocator: (UnsafeMutableRawBufferPointer) -> Void = { $0.baseAddress?.deallocate() }
 
+    @available(anyAppleOS 26, *)
     @Test("Empty frame: fully claimed from start, unclaimedLength == 0")
     func emptyFrame() {
         let buf = allocateAndFillBuffer(of: bufferSize)
@@ -56,6 +57,7 @@ struct CustomFinalizerFrameOwnershipTests {
         #expect(byteBuffer.capacity == bufferSize)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Partially filled frame: claimed from end")
     func partiallyFilledFrame() {
         let buf = allocateAndFillBuffer(of: bufferSize)
@@ -89,6 +91,7 @@ struct CustomFinalizerFrameOwnershipTests {
         #expect(byteBuffer.readBytes(length: 6) == [0, 1, 2, 3, 4, 5])
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Partially filled + consumed: claimed from start and end")
     func partiallyFilledAndConsumedFrame() {
         let buf = allocateAndFillBuffer(of: bufferSize)
@@ -124,6 +127,7 @@ struct CustomFinalizerFrameOwnershipTests {
         #expect(byteBuffer.readBytes(length: 4) == [2, 3, 4, 5])
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Fully filled frame: no claims")
     func fullyFilledFrame() {
         let buf = allocateAndFillBuffer(of: bufferSize)
@@ -155,6 +159,7 @@ struct CustomFinalizerFrameOwnershipTests {
         #expect(byteBuffer.readBytes(length: bufferSize) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Fully filled + fully consumed: all bytes claimed from start")
     func fullyFilledAndConsumedFrame() {
         let buf = allocateAndFillBuffer(of: bufferSize)

--- a/Tests/NIOQUICTests/QUICConnectionChannelHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelHandlerTests.swift
@@ -19,6 +19,7 @@ import XCTest
 
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class QUICConnectionChannelHandlerTests: XCTestCase {
     private var eventLoop: EmbeddedEventLoop!
     private var channel: EmbeddedChannel!

--- a/Tests/NIOQUICTests/QUICConnectionChildChannelStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChildChannelStateMachineTests.swift
@@ -20,6 +20,7 @@ import XCTest
 @testable import ChildChannelMultiplexer
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class QUICConnectionChildChannelStateMachineTests: XCTestCase {
     private var eventLoop: EmbeddedEventLoop!
     private var channel: EmbeddedChannel!

--- a/Tests/NIOQUICTests/QUICConnectionIDGeneratorTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionIDGeneratorTests.swift
@@ -16,6 +16,7 @@ import XCTest
 
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class QUICConnectionIDGeneratorTests: XCTestCase {
     func testRandomGeneratorDefaultLength() {
         var generator = RandomQUICConnectionIDGenerator()

--- a/Tests/NIOQUICTests/QUICConnectionIDTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionIDTests.swift
@@ -16,6 +16,7 @@ import XCTest
 
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class ConnectionIDTests: XCTestCase {
     func testEquatable() {
         let firstConnectionID = QUICConnectionID(

--- a/Tests/NIOQUICTests/QUICConnectionStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionStateMachineTests.swift
@@ -25,6 +25,7 @@ import Glibc
 import Darwin
 #endif
 
+@available(anyAppleOS 26, *)
 final class QUICConnectionStateMachineTests: XCTestCase {
 
     // MARK: - Initial State Tests
@@ -495,6 +496,7 @@ final class QUICConnectionStateMachineTests: XCTestCase {
 
 // MARK: - RFC 9000 §10.2 / §10.2.2: Immediate Close & Draining (Swift Testing)
 
+@available(anyAppleOS 26, *)
 extension QUICConnectionStateMachine {
     /// Assert the connection state machine's key state flags.
     /// Uses local variables to work around `~Copyable` + `#expect` limitation.
@@ -525,6 +527,7 @@ extension QUICConnectionStateMachine {
 
 struct QUICConnectionImmediateCloseTests {
 
+    @available(anyAppleOS 26, *)
     @Test("Immediate close full lifecycle: connected → closing → closed")
     func immediateCloseFullLifecycle() {
         var sm = QUICConnectionStateMachine()
@@ -550,6 +553,7 @@ struct QUICConnectionImmediateCloseTests {
         sm.expectState(canProcessData: false, isDraining: false, isTerminating: true, isTerminal: true)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Immediate close rejects new streams")
     func immediateCloseRejectsNewStreams() {
         var sm = QUICConnectionStateMachine()
@@ -564,6 +568,7 @@ struct QUICConnectionImmediateCloseTests {
         sm.expectState(canProcessData: false, isDraining: false, isTerminating: true, canAcceptNewStreams: false)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Duplicate initiateClose from closing returns alreadyClosing")
     func duplicateInitiateCloseFromClosing() {
         var sm = QUICConnectionStateMachine()
@@ -588,6 +593,7 @@ struct QUICConnectionImmediateCloseTests {
     /// RFC 9000 §10.2.1: When we initiated close and the peer responds with its
     /// own CONNECTION_CLOSE, we go straight to closed (not draining, since we
     /// initiated).
+    @available(anyAppleOS 26, *)
     @Test("Closing completes to closed on peer response")
     func closingTransitionsToClosed() {
         var sm = QUICConnectionStateMachine()
@@ -610,6 +616,7 @@ struct QUICConnectionImmediateCloseTests {
 
 struct QUICConnectionDrainingStateTests {
 
+    @available(anyAppleOS 26, *)
     @Test("Draining state: canProcessData is false, no outbound actions")
     func drainingStateMustNotSendPackets() {
         var sm = QUICConnectionStateMachine()
@@ -630,6 +637,7 @@ struct QUICConnectionDrainingStateTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Draining completes to closed")
     func drainingCompletesToClosed() {
         var sm = QUICConnectionStateMachine()
@@ -646,6 +654,7 @@ struct QUICConnectionDrainingStateTests {
         sm.expectState(canProcessData: false, isDraining: false, isTerminating: true, isTerminal: true)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Draining with peer error captures connectionError")
     func drainingWithPeerErrorCapturesError() {
         var sm = QUICConnectionStateMachine()

--- a/Tests/NIOQUICTests/QUICHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICHandlerTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class QUICHandlerTests: XCTestCase {
     private var eventLoop: EmbeddedEventLoop!
     private var channel: EmbeddedChannel!

--- a/Tests/NIOQUICTests/QUICHeaderTests.swift
+++ b/Tests/NIOQUICTests/QUICHeaderTests.swift
@@ -18,6 +18,7 @@ import Testing
 @testable import NIOQUIC
 
 final class HeaderIDTests {
+    @available(anyAppleOS 26, *)
     @Test(
         "short header"
     )
@@ -40,6 +41,7 @@ final class HeaderIDTests {
         try #require(header?.destinationConnectionID == connectionID)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "version negotiation"
     )
@@ -63,6 +65,7 @@ final class HeaderIDTests {
         try #require(header?.sourceConnectionID == connectionID)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "initial",
         arguments: [1, 2]
@@ -94,6 +97,7 @@ final class HeaderIDTests {
         try #require(header?.token == token)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "zeroRTT",
         arguments: [1, 2]
@@ -118,6 +122,7 @@ final class HeaderIDTests {
         try #require(header?.sourceConnectionID == connectionID)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "handshake",
         arguments: [1, 2]
@@ -142,6 +147,7 @@ final class HeaderIDTests {
         try #require(header?.sourceConnectionID == connectionID)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "retry",
         arguments: [1, 2]
@@ -173,6 +179,7 @@ final class HeaderIDTests {
         try #require(header?.token == token)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "dcid"
     )
@@ -201,6 +208,7 @@ final class HeaderIDTests {
 
     // MARK: - Zero-length connection ID tests (RFC 9000 Section 5.1)
 
+    @available(anyAppleOS 26, *)
     @Test(
         "initial with zero-length SCID",
         arguments: [1, 2]
@@ -236,6 +244,7 @@ final class HeaderIDTests {
         try #require(header?.token == token)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "initial with zero-length DCID and SCID",
         arguments: [1, 2]
@@ -265,6 +274,7 @@ final class HeaderIDTests {
         try #require(header.token == token)
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "short header with zero-length DCID"
     )

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -26,6 +26,7 @@ import XCTest
 @testable import ChildChannelMultiplexer
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 final class QUICProtocolStackTests: XCTestCase {
 
     private func buildClientChannel(

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -1366,7 +1366,7 @@ struct SwiftNetworkStreamHandleStateMachineTests {
     /// Hard violation: starting a torn-down stream is a programmer bug. The wrapper
     /// `preconditionFailure`s on this — which we can't test directly — so we verify
     /// the SM signals it via the action enum here, with the reason that explains why.
-    @available(macOS 26, *)
+    @available(anyAppleOS 26, *)
     @Test("invokeConnect returns .handleViolation(.detached) when detached")
     func invokeConnectReturnsHandleViolation() {
         var sm = SwiftNetworkStreamHandle.StateMachine()

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -19,6 +19,7 @@ import Testing
 
 // MARK: - Test Helpers for ~Copyable Action Enums
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.StreamConnectedAction {
     consuming func requireActivateStream(sourceLocation: SourceLocation = #_sourceLocation) {
         guard case .activateStream = self else {
@@ -28,6 +29,7 @@ extension QUICStreamStateMachine.StreamConnectedAction {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.WriteDataAction {
     consuming func requireSendData(sourceLocation: SourceLocation = #_sourceLocation) {
         guard case .sendData = self else {
@@ -37,6 +39,7 @@ extension QUICStreamStateMachine.WriteDataAction {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.ReceiveDataAction {
     consuming func requireBufferData(sourceLocation: SourceLocation = #_sourceLocation) {
         guard case .bufferData = self else {
@@ -46,6 +49,7 @@ extension QUICStreamStateMachine.ReceiveDataAction {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.SendFinAction {
     @discardableResult
     consuming func requireSendFin(sourceLocation: SourceLocation = #_sourceLocation) -> Bool {
@@ -57,6 +61,7 @@ extension QUICStreamStateMachine.SendFinAction {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.AcknowledgeDataAction {
     consuming func requireCompleteSend(sourceLocation: SourceLocation = #_sourceLocation) {
         guard case .completeSend = self else {
@@ -73,6 +78,7 @@ extension QUICStreamStateMachine.AcknowledgeDataAction {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.ApplicationReadAction {
     consuming func requireDeliverEndOfStream(sourceLocation: SourceLocation = #_sourceLocation) {
         guard case .deliverEndOfStream = self else {
@@ -82,6 +88,7 @@ extension QUICStreamStateMachine.ApplicationReadAction {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension QUICStreamStateMachine.CloseAction {
     consuming func requireClose(sourceLocation: SourceLocation = #_sourceLocation) {
         guard case .close = self else {
@@ -92,6 +99,7 @@ extension QUICStreamStateMachine.CloseAction {
 }
 
 struct QUICStreamSendStateMachineTests {
+    @available(anyAppleOS 26, *)
     @Test("Initial state is ready")
     func initialStateIsReady() {
         let sm = QUICStreamSendStateMachine()
@@ -108,6 +116,7 @@ struct QUICStreamSendStateMachineTests {
     }
 
     /// RFC 9000 §3.5: STOP_SENDING after FIN sent but before ack should still trigger RESET_STREAM.
+    @available(anyAppleOS 26, *)
     @Test("Receive STOP_SENDING from dataSent triggers RESET_STREAM")
     func receiveStopSendingFromDataSent() throws {
         var sm = QUICStreamSendStateMachine()
@@ -121,6 +130,7 @@ struct QUICStreamSendStateMachineTests {
     }
 
     /// STOP_SENDING after all data acknowledged should be ignored.
+    @available(anyAppleOS 26, *)
     @Test("Receive STOP_SENDING from dataRecvd is ignored")
     func receiveStopSendingFromDataRecvd() {
         var sm = QUICStreamSendStateMachine()
@@ -134,6 +144,7 @@ struct QUICStreamSendStateMachineTests {
     }
 
     /// Duplicate STOP_SENDING should preserve the first error code.
+    @available(anyAppleOS 26, *)
     @Test("Duplicate STOP_SENDING preserves first error code")
     func receiveStopSendingFromResetSentPreservesFirstErrorCode() {
         var sm = QUICStreamSendStateMachine()
@@ -147,6 +158,7 @@ struct QUICStreamSendStateMachineTests {
         #expect(resetErrorCode == QUICApplicationErrorCode(1))
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Normal lifecycle: write, FIN, ack")
     func normalLifecycle() {
         var sm = QUICStreamSendStateMachine()
@@ -173,6 +185,7 @@ struct QUICStreamSendStateMachineTests {
         #expect(!wasReset)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Reset lifecycle via localReset")
     func resetLifecycleViaLocalReset() {
         var sm = QUICStreamSendStateMachine()
@@ -195,6 +208,7 @@ struct QUICStreamSendStateMachineTests {
         #expect(resetErrorCode == QUICApplicationErrorCode(77))
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Reset lifecycle via STOP_SENDING")
     func resetLifecycleViaStopSending() {
         var sm = QUICStreamSendStateMachine()
@@ -222,6 +236,7 @@ struct QUICStreamSendStateMachineTests {
 
     /// RFC 9000 §3.5: "An endpoint SHOULD copy the error code from the STOP_SENDING frame
     /// to the RESET_STREAM frame it sends". Verify this from the ready state.
+    @available(anyAppleOS 26, *)
     @Test("STOP_SENDING from ready copies error code to RESET_STREAM")
     func stopSendingFromReadyCopiesErrorCode() {
         var sm = QUICStreamSendStateMachine()
@@ -236,6 +251,7 @@ struct QUICStreamSendStateMachineTests {
     }
 
     /// RFC 9000 §3.5: Verify error code copy from the send state (data in flight).
+    @available(anyAppleOS 26, *)
     @Test("STOP_SENDING from send copies error code to RESET_STREAM")
     func stopSendingFromSendCopiesErrorCode() {
         var sm = QUICStreamSendStateMachine()
@@ -251,6 +267,7 @@ struct QUICStreamSendStateMachineTests {
     }
 
     /// RFC 9000 §3.5: Verify error code copy from the dataSent state (FIN sent, awaiting ack).
+    @available(anyAppleOS 26, *)
     @Test("STOP_SENDING from dataSent copies error code to RESET_STREAM")
     func stopSendingFromDataSentCopiesErrorCode() {
         var sm = QUICStreamSendStateMachine()
@@ -270,6 +287,7 @@ struct QUICStreamSendStateMachineTests {
 
     /// RFC 9000 §3.1: "An endpoint MAY send a RESET_STREAM as the first frame that
     /// mentions a stream". This opens and immediately resets the stream.
+    @available(anyAppleOS 26, *)
     @Test("localReset from ready opens and immediately resets")
     func localResetFromReadyOpensAndResets() {
         var sm = QUICStreamSendStateMachine()
@@ -295,6 +313,7 @@ struct QUICStreamSendStateMachineTests {
 
     /// RFC 9000 §3.3: "A sender MUST NOT send [STREAM, STREAM_DATA_BLOCKED, RESET_STREAM]
     /// from a terminal state". Verify writes are rejected after completion.
+    @available(anyAppleOS 26, *)
     @Test("Write rejected after stream completed")
     func writeRejectedAfterCompletion() {
         var sm = QUICStreamSendStateMachine()
@@ -309,6 +328,7 @@ struct QUICStreamSendStateMachineTests {
     }
 
     /// RFC 9000 §3.3: Verify writes are rejected after stream reset.
+    @available(anyAppleOS 26, *)
     @Test("Write rejected after stream reset")
     func writeRejectedAfterReset() {
         var sm = QUICStreamSendStateMachine()
@@ -322,6 +342,7 @@ struct QUICStreamSendStateMachineTests {
     }
 
     /// RFC 9000 §3.3: localReset from a terminal state should be ignored.
+    @available(anyAppleOS 26, *)
     @Test("localReset ignored after stream completed")
     func localResetIgnoredAfterCompletion() {
         var sm = QUICStreamSendStateMachine()
@@ -337,6 +358,7 @@ struct QUICStreamSendStateMachineTests {
 }
 
 struct QUICStreamReceiveStateMachineTests {
+    @available(anyAppleOS 26, *)
     @Test("Initial state is recv")
     func initialStateIsRecv() {
         let sm = QUICStreamReceiveStateMachine()
@@ -355,6 +377,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// RESET_STREAM after all data received (FIN already processed) should be ignored.
+    @available(anyAppleOS 26, *)
     @Test("Receive RESET_STREAM from dataRecvd is ignored")
     func receiveResetFromDataRecvd() {
         var sm = QUICStreamReceiveStateMachine()
@@ -369,6 +392,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// Duplicate RESET_STREAM should preserve the first error code.
+    @available(anyAppleOS 26, *)
     @Test("Duplicate RESET_STREAM preserves first error code")
     func receiveResetFromResetRecvdPreservesFirst() {
         var sm = QUICStreamReceiveStateMachine()
@@ -383,6 +407,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// FIN arriving after RESET_STREAM should be ignored.
+    @available(anyAppleOS 26, *)
     @Test("Receive FIN from resetRecvd is ignored")
     func receiveFinFromResetRecvd() {
         var sm = QUICStreamReceiveStateMachine()
@@ -394,6 +419,7 @@ struct QUICStreamReceiveStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Normal lifecycle: receive data, FIN, app read")
     func normalLifecycle() {
         var sm = QUICStreamReceiveStateMachine()
@@ -419,6 +445,7 @@ struct QUICStreamReceiveStateMachineTests {
         #expect(!wasReset)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Reset lifecycle: receive data, RESET_STREAM, app read")
     func resetLifecycle() {
         var sm = QUICStreamReceiveStateMachine()
@@ -447,6 +474,7 @@ struct QUICStreamReceiveStateMachineTests {
 
     /// RFC 9000 §3.2: RESET_STREAM can arrive as the first frame on a stream,
     /// before any STREAM data. The stream transitions directly to resetRecvd.
+    @available(anyAppleOS 26, *)
     @Test("RESET_STREAM as first frame with no prior data")
     func resetStreamAsFirstFrame() {
         var sm = QUICStreamReceiveStateMachine()
@@ -471,6 +499,7 @@ struct QUICStreamReceiveStateMachineTests {
     // MARK: - RFC 9000 §3.2: Data after FIN/RESET
 
     /// Receiving data after FIN (dataRecvd state) is rejected.
+    @available(anyAppleOS 26, *)
     @Test("Data after FIN is rejected")
     func dataAfterFinRejected() {
         var sm = QUICStreamReceiveStateMachine()
@@ -484,6 +513,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// Receiving data after RESET_STREAM is rejected.
+    @available(anyAppleOS 26, *)
     @Test("Data after RESET_STREAM is rejected")
     func dataAfterResetRejected() {
         var sm = QUICStreamReceiveStateMachine()
@@ -499,6 +529,7 @@ struct QUICStreamReceiveStateMachineTests {
     // MARK: - RFC 9000 §3.5: STOP_SENDING from receive states
 
     /// STOP_SENDING can be sent while in recv state.
+    @available(anyAppleOS 26, *)
     @Test("sendStopSending from recv is permitted")
     func sendStopSendingFromRecv() {
         var sm = QUICStreamReceiveStateMachine()
@@ -510,6 +541,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// STOP_SENDING after all data received is pointless and ignored.
+    @available(anyAppleOS 26, *)
     @Test("sendStopSending from dataRecvd is ignored")
     func sendStopSendingFromDataRecvd() {
         var sm = QUICStreamReceiveStateMachine()
@@ -523,6 +555,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// STOP_SENDING after RESET_STREAM is unnecessary and ignored.
+    @available(anyAppleOS 26, *)
     @Test("sendStopSending from resetRecvd is ignored")
     func sendStopSendingFromResetRecvd() {
         var sm = QUICStreamReceiveStateMachine()
@@ -536,6 +569,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// Duplicate FIN is ignored.
+    @available(anyAppleOS 26, *)
     @Test("Duplicate FIN is ignored")
     func duplicateFinIgnored() {
         var sm = QUICStreamReceiveStateMachine()
@@ -549,6 +583,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// applicationRead from dataRead (terminal) returns ignore(.alreadyDelivered).
+    @available(anyAppleOS 26, *)
     @Test("applicationRead from terminal dataRead returns ignore(.alreadyDelivered)")
     func applicationReadFromDataRead() {
         var sm = QUICStreamReceiveStateMachine()
@@ -563,6 +598,7 @@ struct QUICStreamReceiveStateMachineTests {
     }
 
     /// applicationRead from terminal resetRead returns ignore(.alreadyDelivered).
+    @available(anyAppleOS 26, *)
     @Test("applicationRead from terminal resetRead returns ignore(.alreadyDelivered)")
     func applicationReadFromResetRead() {
         var sm = QUICStreamReceiveStateMachine()
@@ -581,6 +617,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Initial State
 
+    @available(anyAppleOS 26, *)
     @Test("Pending ID initial state")
     func pendingIDInitialState() {
         let sm = QUICStreamStateMachine()
@@ -596,6 +633,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Connection Lifecycle
 
+    @available(anyAppleOS 26, *)
     @Test("Bidirectional stream connected from pendingID")
     func streamConnectedBidirectionalFromPendingID() throws {
         var sm = QUICStreamStateMachine()
@@ -610,6 +648,7 @@ struct QUICStreamStateMachineTests {
         try sm.receiveData().requireBufferData()
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Send-only stream connected from pendingID")
     func streamConnectedSendOnlyFromPendingID() throws {
         var sm = QUICStreamStateMachine()
@@ -619,6 +658,7 @@ struct QUICStreamStateMachineTests {
         try sm.writeData().requireSendData()
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Receive-only stream connected from pendingID")
     func streamConnectedReceiveOnlyFromPendingID() throws {
         var sm = QUICStreamStateMachine()
@@ -628,6 +668,7 @@ struct QUICStreamStateMachineTests {
         try sm.receiveData().requireBufferData()
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Stream connected from connected is ignored")
     func streamConnectedFromConnected() {
         var sm = QUICStreamStateMachine()
@@ -640,6 +681,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Stream connected from closed is ignored")
     func streamConnectedFromClosed() {
         var sm = QUICStreamStateMachine()
@@ -652,6 +694,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("receiveData and receiveFin work in pendingID for optimistic reads")
     func optimisticReadsInPendingID() throws {
         // receiveData returns .bufferData in pendingID because SwiftNetwork
@@ -671,6 +714,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Bidirectional Stream Lifecycles
 
+    @available(anyAppleOS 26, *)
     @Test("Typical bidirectional stream lifecycle")
     func typicalBidirectionalStreamLifecycle() throws {
         var sm = QUICStreamStateMachine()
@@ -700,6 +744,7 @@ struct QUICStreamStateMachineTests {
         #expect(isFullyClosed)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Bidirectional fully closed requires both sides terminal")
     func combinedFullyClosedBidirectional() throws {
         var sm = QUICStreamStateMachine()
@@ -721,6 +766,7 @@ struct QUICStreamStateMachineTests {
         #expect(isFullyClosed)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Bidirectional stream reset while sending")
     func bidirectionalStreamResetWhileSending() throws {
         var sm = QUICStreamStateMachine()
@@ -748,6 +794,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Unidirectional Stream Lifecycles
 
+    @available(anyAppleOS 26, *)
     @Test("Full outbound send-only lifecycle")
     func fullOutboundSendOnlyLifecycle() throws {
         var sm = QUICStreamStateMachine()
@@ -767,6 +814,7 @@ struct QUICStreamStateMachineTests {
         #expect(isFullyClosed)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Full inbound receive-only lifecycle")
     func fullInboundReceiveOnlyLifecycle() throws {
         var sm = QUICStreamStateMachine()
@@ -792,6 +840,7 @@ struct QUICStreamStateMachineTests {
         #expect(isFullyClosed)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Send-only stream has no read side")
     func sendOnlyDirectionSemantics() {
         var sm = QUICStreamStateMachine()
@@ -801,6 +850,7 @@ struct QUICStreamStateMachineTests {
         #expect(!hasReceivedFin)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Receive-only stream has no write side")
     func receiveOnlyDirectionSemantics() {
         var sm = QUICStreamStateMachine()
@@ -812,6 +862,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Direction Errors
 
+    @available(anyAppleOS 26, *)
     @Test("Send operations throw wrongDirection on receive-only stream")
     func sendOnReceiveOnlyThrows() {
         var sm = QUICStreamStateMachine()
@@ -834,6 +885,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Receive operations throw wrongDirection on send-only stream")
     func receiveOnSendOnlyThrows() {
         var sm = QUICStreamStateMachine()
@@ -856,6 +908,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Operations throw notConnected on closed stream")
     func operationsOnClosedStreamThrow() {
         var sm = QUICStreamStateMachine()
@@ -871,6 +924,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Reset Scenarios
 
+    @available(anyAppleOS 26, *)
     @Test("Stream reset by peer via RESET_STREAM")
     func streamResetByPeer() throws {
         var sm = QUICStreamStateMachine()
@@ -892,6 +946,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Stream reset by peer via STOP_SENDING")
     func streamResetByStopSending() throws {
         var sm = QUICStreamStateMachine()
@@ -913,6 +968,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Receive RESET_STREAM after data received delivers error on read")
     func receiveResetAfterDataReceived() throws {
         var sm = QUICStreamStateMachine()
@@ -938,6 +994,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - RFC Edge Cases
 
+    @available(anyAppleOS 26, *)
     @Test("STOP_SENDING after FIN before ack triggers RESET_STREAM per RFC 9000 §3.1")
     func stopSendingAfterFinBeforeAck() throws {
         var sm = QUICStreamStateMachine()
@@ -953,6 +1010,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("STOP_SENDING after all data acknowledged is ignored")
     func stopSendingAfterAllDataAcknowledged() throws {
         var sm = QUICStreamStateMachine()
@@ -968,6 +1026,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("RESET_STREAM after all data received is ignored")
     func resetStreamAfterAllDataReceived() throws {
         var sm = QUICStreamStateMachine()
@@ -987,6 +1046,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Duplicate RESET_STREAM preserves first error code")
     func duplicateResetStreamPreservesFirstErrorCode() throws {
         var sm = QUICStreamStateMachine()
@@ -1019,6 +1079,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Duplicate STOP_SENDING preserves first error code")
     func duplicateStopSendingPreservesFirstErrorCode() throws {
         var sm = QUICStreamStateMachine()
@@ -1039,6 +1100,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Post-Terminal Behavior
 
+    @available(anyAppleOS 26, *)
     @Test("Write after FIN is rejected")
     func writeAfterFinRejected() throws {
         var sm = QUICStreamStateMachine()
@@ -1052,6 +1114,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Receive data after FIN is rejected")
     func receiveDataAfterFinRejected() throws {
         var sm = QUICStreamStateMachine()
@@ -1065,6 +1128,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Application read after all data read returns .ignore(.alreadyDelivered)")
     func applicationReadAfterAllDataRead() throws {
         var sm = QUICStreamStateMachine()
@@ -1079,6 +1143,7 @@ struct QUICStreamStateMachineTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Reset error delivered on application read")
     func resetErrorDeliveredOnApplicationRead() throws {
         var sm = QUICStreamStateMachine()
@@ -1098,6 +1163,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Close
 
+    @available(anyAppleOS 26, *)
     @Test("Close from pendingID")
     func closeFromPendingID() {
         var sm = QUICStreamStateMachine()
@@ -1108,6 +1174,7 @@ struct QUICStreamStateMachineTests {
         #expect(isFullyClosed)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Close from connected")
     func closeFromConnected() {
         var sm = QUICStreamStateMachine()
@@ -1121,6 +1188,7 @@ struct QUICStreamStateMachineTests {
         #expect(isFullyClosed)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("Double close returns .ignoreAlreadyClosed")
     func doubleClose() {
         var sm = QUICStreamStateMachine()
@@ -1135,6 +1203,7 @@ struct QUICStreamStateMachineTests {
 
     // MARK: - Error Routing
 
+    @available(anyAppleOS 26, *)
     @Test("RESET_STREAM produces correct error type and code")
     func resetStreamFiresCorrectError() throws {
         var sm = QUICStreamStateMachine()
@@ -1152,6 +1221,7 @@ struct QUICStreamStateMachineTests {
         #expect(resetError.code.rawValue == 42)
     }
 
+    @available(anyAppleOS 26, *)
     @Test("STOP_SENDING then RESET_STREAM both produce errors — no cross-direction dedup")
     func bothDirectionsRouteIndependently() throws {
         var sm = QUICStreamStateMachine()

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -1446,7 +1446,6 @@ struct SwiftNetworkStreamHandleTests {
 
     /// Error/abort during teardown must not raise (called from the close-stream paths).
     @available(anyAppleOS 26, *)
-    @available(anyAppleOS 26, *)
     @Test("invokeAbortOutbound silently no-ops when detached")
     func invokeAbortOutboundNoopsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -1396,7 +1396,6 @@ struct SwiftNetworkStreamHandleTests {
 
     /// Inbound init pathway: the listener-attached linkage is wrapped in an attached handle.
     @available(anyAppleOS 26, *)
-    @available(anyAppleOS 26, *)
     @Test("init(linkage:) is attached")
     func initWithLinkageIsAttached() {
         let handle = SwiftNetworkStreamHandle(linkage: OutboundStreamLinkage(reference: .init()))

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -1366,6 +1366,7 @@ struct SwiftNetworkStreamHandleStateMachineTests {
     /// Hard violation: starting a torn-down stream is a programmer bug. The wrapper
     /// `preconditionFailure`s on this — which we can't test directly — so we verify
     /// the SM signals it via the action enum here, with the reason that explains why.
+    @available(macOS 26, *)
     @Test("invokeConnect returns .handleViolation(.detached) when detached")
     func invokeConnectReturnsHandleViolation() {
         var sm = SwiftNetworkStreamHandle.StateMachine()
@@ -1384,6 +1385,7 @@ struct SwiftNetworkStreamHandleStateMachineTests {
 
 struct SwiftNetworkStreamHandleTests {
     /// Outbound streams start with a stub linkage; the handle is usable from creation.
+    @available(anyAppleOS 26, *)
     @Test("Default init is attached")
     func defaultInitIsAttached() {
         let handle = SwiftNetworkStreamHandle()
@@ -1393,6 +1395,8 @@ struct SwiftNetworkStreamHandleTests {
     }
 
     /// Inbound init pathway: the listener-attached linkage is wrapped in an attached handle.
+    @available(anyAppleOS 26, *)
+    @available(anyAppleOS 26, *)
     @Test("init(linkage:) is attached")
     func initWithLinkageIsAttached() {
         let handle = SwiftNetworkStreamHandle(linkage: OutboundStreamLinkage(reference: .init()))
@@ -1403,6 +1407,7 @@ struct SwiftNetworkStreamHandleTests {
 
     /// End-to-end detach contract: wrapper consumes the linkage on the first call and
     /// tolerates duplicates (multiple call sites unconditionally try to tear down).
+    @available(anyAppleOS 26, *)
     @Test("invokeDetach flips state and is idempotent")
     func invokeDetachIsIdempotent() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
@@ -1417,6 +1422,7 @@ struct SwiftNetworkStreamHandleTests {
     }
 
     /// Stop sequencing: disconnect after detach is a normal teardown ordering and must not throw.
+    @available(anyAppleOS 26, *)
     @Test("invokeDisconnect silently no-ops when detached")
     func invokeDisconnectNoopsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
@@ -1428,6 +1434,7 @@ struct SwiftNetworkStreamHandleTests {
     }
 
     /// Error/abort during teardown must not raise (called from the close-stream paths).
+    @available(anyAppleOS 26, *)
     @Test("invokeAbortInbound silently no-ops when detached")
     func invokeAbortInboundNoopsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
@@ -1439,6 +1446,8 @@ struct SwiftNetworkStreamHandleTests {
     }
 
     /// Error/abort during teardown must not raise (called from the close-stream paths).
+    @available(anyAppleOS 26, *)
+    @available(anyAppleOS 26, *)
     @Test("invokeAbortOutbound silently no-ops when detached")
     func invokeAbortOutboundNoopsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
@@ -1451,6 +1460,7 @@ struct SwiftNetworkStreamHandleTests {
 
     /// Soft-violation policy: write-after-detach surfaces as a throw the caller can recover
     /// from (e.g. return false), not a silent no-op that drops bytes.
+    @available(anyAppleOS 26, *)
     @Test("invokeSendStreamData throws NetworkError when detached")
     func invokeSendStreamDataThrowsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
@@ -1467,6 +1477,7 @@ struct SwiftNetworkStreamHandleTests {
 
     /// Soft-violation policy: read-after-detach surfaces as a throw, not a silent nil that
     /// the caller might confuse with "no data available".
+    @available(anyAppleOS 26, *)
     @Test("invokeReceiveStreamData throws NetworkError when detached")
     func invokeReceiveStreamDataThrowsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
@@ -1482,6 +1493,7 @@ struct SwiftNetworkStreamHandleTests {
     }
 
     /// Metadata is genuinely unavailable post-detach; nil is the natural API response.
+    @available(anyAppleOS 26, *)
     @Test("invokeGetMetadata returns nil when detached")
     func invokeGetMetadataReturnsNilWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()

--- a/Tests/NIOQUICTests/SigningKeys.swift
+++ b/Tests/NIOQUICTests/SigningKeys.swift
@@ -76,6 +76,7 @@ let privateKeyRSA = """
     """
 
 struct SingingKeysTests {
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
     @Test("Reading private key from disk")
     func readPrivateKey() throws {
         let privateKey = try P256.Signing.PrivateKey.fromDERFile(p256PrivateKeyPath)
@@ -84,6 +85,7 @@ struct SingingKeysTests {
         #expect(privateKey.derRepresentation == privateKeyData)
     }
 
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
     @Test("Reading public key from disk")
     func readPublicKey() throws {
         let publicKey = try P256.Signing.PublicKey.fromDERFile(p256PublicKeyPath)
@@ -92,6 +94,7 @@ struct SingingKeysTests {
         #expect(publicKey.derRepresentation == publicKeyData)
     }
 
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
     @Test("Reading EC private key")
     func readPrivateECKey() throws {
         // Write key.
@@ -106,6 +109,7 @@ struct SingingKeysTests {
         }
     }
 
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
     @Test("Reading EC private key with parameters")
     func readPrivateECKeyWithParameters() throws {
         // Write key.
@@ -120,6 +124,7 @@ struct SingingKeysTests {
         }
     }
 
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
     @Test("Reading RSA private key")
     func readPrivateRSAKey() throws {
         // Write key.

--- a/Tests/NIOQUICTests/SocketAddress+Endpoint.swift
+++ b/Tests/NIOQUICTests/SocketAddress+Endpoint.swift
@@ -24,6 +24,7 @@ let testIPv6Address = "::1"
 let testPort = 443
 
 struct SocketAddress_EndpointTests {
+    @available(anyAppleOS 26, *)
     @Test(
         "Convert a IPv4 SocketAddress to an Endpoint"
     )
@@ -45,6 +46,7 @@ struct SocketAddress_EndpointTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "Convert a IPv6 SocketAddress to an Host Endpoint"
     )
@@ -61,6 +63,7 @@ struct SocketAddress_EndpointTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "Convert a IPv6 SocketAddress to an Endpoint",
         .disabled("Requirement: Implement conversion to address type")
@@ -83,6 +86,7 @@ struct SocketAddress_EndpointTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
     @Test(
         "Convert a Unix domain SocketAddress to an Endpoint",
         .disabled("Requirement: Implement conversion to address type")

--- a/Tests/NIOQUICTests/TestHelper/CertificateChain.swift
+++ b/Tests/NIOQUICTests/TestHelper/CertificateChain.swift
@@ -17,6 +17,7 @@ import Foundation
 import SwiftASN1
 import X509
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func makeCertificate(
     commonName cn: String,
     issuer: (Certificate, Certificate.PrivateKey)? = nil,
@@ -116,6 +117,7 @@ func makeCertificate(
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func writeCertificates(
     _ certificates: [Certificate],
     fileTag: String = #function,
@@ -133,6 +135,7 @@ func writeCertificates(
     return url
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func writeKey(
     _ privateKey: Certificate.PrivateKey,
     fileTag: String = #function,
@@ -154,6 +157,7 @@ struct TestCAFilePaths {
     let serverPrivateKeyFilePath: String
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct TestCertificates {
     let rootCert: Certificate
     let rootKey: Certificate.PrivateKey

--- a/Tests/NIOQUICTests/TestHelper/ChildChannelAction+Asserts.swift
+++ b/Tests/NIOQUICTests/TestHelper/ChildChannelAction+Asserts.swift
@@ -16,6 +16,7 @@ import XCTest
 
 @testable import ChildChannelMultiplexer
 
+@available(anyAppleOS 26, *)
 extension ChildChannelAction.Action {
     func assertIsChildChannelCompleteActivation(file: StaticString = #filePath, line: UInt = #line) {
         switch self {

--- a/Tests/NIOQUICTests/TestHelper/QuicPackets.swift
+++ b/Tests/NIOQUICTests/TestHelper/QuicPackets.swift
@@ -14,6 +14,7 @@
 
 @testable import NIOQUIC
 
+@available(anyAppleOS 26, *)
 extension QUICConnectionID {
     var asBytes: [UInt8] {
         self.withUnsafeBufferPointer { buffer in
@@ -22,6 +23,7 @@ extension QUICConnectionID {
     }
 }
 
+@available(anyAppleOS 26, *)
 enum QUICPackets {
     static func shortHeader(destinationID: QUICConnectionID) -> [UInt8] {
         [

--- a/Tests/NIOQUICTests/TestHelpers.swift
+++ b/Tests/NIOQUICTests/TestHelpers.swift
@@ -29,6 +29,7 @@ extension XCTestCase {
         .path
 }
 
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 final class Counter: Sendable {
     private let value = Atomic<Int>(0)
 


### PR DESCRIPTION
### Motivation

* The `platforms:` block in `Package.swift` sets an OS 26 deployment-target floor for the package and transitively for every downstream package. Requiring this is an onerous constraint and we should avoid it if possible.

### Modifications

* Drop the `platforms: [.macOS("26.0"), ...]` block from `Package.swift` and add `.enableExperimentalFeature("AnyAppleOSAvailability")` to `swiftSettings`.
* Gate every declaration that reaches `SwiftNetwork`/`SwiftTLS` symbols or uses `Span` / `InlineArray` / `~Copyable` with `@available(anyAppleOS 26, *)`.
* Annotate `extension P256.Signing.PrivateKey/PublicKey` and other CryptoKit-bound declarations with `@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)` — the binding constraint there is `init(derRepresentation:)`.
* Wrap `Example`'s runtime body in `if #available(anyAppleOS 26, *)`.
* In Swift Testing files, place `@available` on each `@Test func` directly rather than on the surrounding suite type: Swift Testing only supports availability on individual test functions, not on the suite type that contains them.

### Result

* Adopters can depend on `swift-nio-quic` without raising their own `platforms:` floor; runtime entry points still refuse to run below OS 26.
