### PR TITLE
Adopt new QUICStreamType

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannelHandler.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannelHandler.swift
@@ -398,7 +398,7 @@ extension QUICConnectionChannelHandler {
     ///   - streamChannelInitializer: Called with the new channel and its confirmed stream ID to configure the channel pipeline.
     func createOutboundStream(
         channelActivationPromise: EventLoopPromise<any Channel>,
-        streamType: QUICStreamID.StreamType,
+        streamType: QUICStreamType,
         streamChannelInitializer: @escaping (any Channel, QUICStreamID) -> EventLoopFuture<Void>
     ) {
         guard let context = self.context else {

--- a/Sources/NIOQUIC/QUICStreamCreator.swift
+++ b/Sources/NIOQUIC/QUICStreamCreator.swift
@@ -24,7 +24,7 @@ public struct QUICStreamCreator: Sendable, NIOQUICHelpers.QUICStreamCreator {
     private let _createOutboundStream:
         NIOLoopBound<
             (
-                EventLoopPromise<any Channel>, QUICStreamID.StreamType,
+                EventLoopPromise<any Channel>, QUICStreamType,
                 @escaping (any Channel, QUICStreamID) -> EventLoopFuture<Void>
             ) -> Void
         >
@@ -34,7 +34,7 @@ public struct QUICStreamCreator: Sendable, NIOQUICHelpers.QUICStreamCreator {
         role: Role,
         createOutboundStream: NIOLoopBound<
             (
-                EventLoopPromise<any Channel>, QUICStreamID.StreamType,
+                EventLoopPromise<any Channel>, QUICStreamType,
                 @escaping (any Channel, QUICStreamID) -> EventLoopFuture<Void>
             ) -> Void
         >
@@ -83,7 +83,7 @@ public struct QUICStreamCreator: Sendable, NIOQUICHelpers.QUICStreamCreator {
         private let role: Role
         private let _createOutboundStream:
             (
-                EventLoopPromise<any Channel>, QUICStreamID.StreamType,
+                EventLoopPromise<any Channel>, QUICStreamType,
                 @escaping (any Channel, QUICStreamID) -> EventLoopFuture<Void>
             ) -> Void
 
@@ -92,7 +92,7 @@ public struct QUICStreamCreator: Sendable, NIOQUICHelpers.QUICStreamCreator {
             role: Role,
             _createOutboundStream:
                 @escaping (
-                    EventLoopPromise<any Channel>, QUICStreamID.StreamType,
+                    EventLoopPromise<any Channel>, QUICStreamType,
                     @escaping (any Channel, QUICStreamID) -> EventLoopFuture<Void>
                 ) -> Void
         ) {
@@ -137,7 +137,7 @@ public struct QUICStreamCreator: Sendable, NIOQUICHelpers.QUICStreamCreator {
             let outputPromise = self.eventLoop.makePromise(of: InitializerOutput.self)
             channelPromise.futureResult.cascadeFailure(to: outputPromise)
 
-            let streamType: QUICStreamID.StreamType
+            let streamType: QUICStreamType
             switch (self.role, isBidirectional) {
             case (.client, true):
                 streamType = .clientInitiatedBidirectional

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -643,7 +643,7 @@ final class SwiftNetworkQUICConnection {
     ///   - channelActivationPromise: Fulfilled with the new ``Channel`` once the stream is fully set up, or failed on error.
     ///   - streamChannelInitializer: Called with the new channel and its confirmed stream ID to configure the channel pipeline.
     internal func addNewOutboundStreamInputHandler(
-        streamType: QUICStreamID.StreamType,
+        streamType: QUICStreamType,
         channelActivationPromise: EventLoopPromise<any Channel>,
         connectionChannel: any Channel,
         streamChannelInitializer: @escaping (any Channel, QUICStreamID) -> EventLoopFuture<Void>


### PR DESCRIPTION
Motivation:

swift-nio-quic-helpers deprecated QUICStreamID.StreamType in favor of a standaolne QUICStreamType.

Modifications:

- Use new type

Result:

Fewer warnings