### PR TITLE
Skip Qlog test if not enabled

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,16 @@ import PackageDescription
 
 let isRunningInCI = Context.environment["CI"] != nil
 
-// Enable the QlogOutput in CI as some tests depend on it.
+// Enable the QlogOutput in CI as some tests depend on it; also enable a setting our
+// tests can depend on to gate whether the Qlog tests are expected to run or not.
 let swiftNetworkTraits: Set<Package.Dependency.Trait>
+let qlogSetting: [SwiftSetting]
 if isRunningInCI {
     swiftNetworkTraits = [.defaults, "QlogOutput"]
+    qlogSetting = [.define("QLOG_ENABLED")]
 } else {
     swiftNetworkTraits = [.defaults]
+    qlogSetting = []
 }
 
 // controls logs emitted, lower levels are compiled out
@@ -107,7 +111,7 @@ let package = Package(
                 .copy("privateKey.der"),
                 .copy("publicKey.der"),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + qlogSetting
         ),
         .testTarget(
             name: "IntegrationTests",

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -967,6 +967,8 @@ final class QUICProtocolStackTests: XCTestCase {
     }
 
     func testServerUsingQlog() async throws {
+        try XCTSkipUnless(QUIC.isQlogEnabled, "Qlog isn't enabled, skipping")
+
         let path = FileManager.default.temporaryDirectory
         let tag = UUID().uuidString
         let title = "ServerTestQlog_\(tag)"

--- a/Tests/NIOQUICTests/TestHelper/QUIC.swift
+++ b/Tests/NIOQUICTests/TestHelper/QUIC.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+enum QUIC {
+    static var isQlogEnabled: Bool {
+        #if QLOG_ENABLED
+        return true
+        #else
+        return false
+        #endif
+    }
+}


### PR DESCRIPTION
Motivation:

The QLogOutput trait needs to be enabled on swift-network-evolution for Qlog to be supported. One of our tests relies on it. It's enabled by default when the CI env flag is present but when run locally the test fails which adds noise to local development.

In the fullness of time we should reconsider how traits are handled, for now we should skip the test if Qlog isn't enabled.

Modifications:

- Add a compile setting mirroring when the trait is enabled and gate the Qlog test it being set

Result:

Qlog test is skipped if Qlog isn't enabled