### PR TITLE
Emit channelReadComplete on eof

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -580,9 +580,16 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
 
     func streamRead() {
         self.eventLoop.preconditionInEventLoop()
+
+        // Emit channel read complete when:
+        // - any read was fired, or
+        // - EOF is emitted
+        var emitReadComplete = false
+
         if self.bufferedReadData.readableBytes > 0 {
             // We will now satisfy a pending read request. Reset the flag.
             self.pendingRead = false
+            emitReadComplete = true
 
             let bytesRead = bufferedReadData.readableBytes
             self.log(
@@ -590,21 +597,29 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
             )
             self.pipeline.fireChannelRead(bufferedReadData)
             bufferedReadData.clear()
-            self.fireChannelReadComplete()
         }
+
         switch self.streamStateMachine.completeRead() {
         case .reportFin(let streamFullyClosed):
+            emitReadComplete = true
             self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
             if streamFullyClosed {
                 self.log("stream is now fully closed")
                 self.closeStream(mode: .disconnectOnly, error: nil, promise: nil)
                 self.shutdownStream(direction: .all, applicationErrorCode: nil)
             }
+
         case .reportPeerReset:
+            emitReadComplete = true
             self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
             break
+
         case .nothingToReport:
             break
+        }
+
+        if emitReadComplete {
+            self.fireChannelReadComplete()
         }
     }
 

--- a/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
@@ -268,6 +268,26 @@ struct QUICChannelStreamHandlerTests {
     }
 
     @available(anyAppleOS 26, *)
+    @Test("FIN-only packet fires channelReadComplete with no data")
+    func finOnlyFiresChannelReadComplete() throws {
+        try Self.withServerStream { streamChannel in
+            try streamChannel.syncOptions?.setOption(.autoRead, value: false)
+
+            let recorder = RecordingHandler()
+            try streamChannel.pipeline.syncOperations.addHandler(recorder)
+
+            // FIN arrives with no data.
+            _ = try streamChannel.streamStateMachine.receiveFin(finalSize: 0)
+            streamChannel.handleInboundDataAvailableEvent(.init())
+
+            streamChannel.pipeline.read()
+
+            // No data, but inputClosed and channelReadComplete must both fire.
+            #expect(recorder.events == [.read, .inputClosedEvent, .channelReadComplete])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
     @Test("Packet with FIN delivered to a pending read request")
     func finPacketDeliveredToPendingReadRequest() throws {
         try Self.withServerStream { streamChannel in
@@ -298,7 +318,7 @@ struct QUICChannelStreamHandlerTests {
             #expect(recorder.channelReadCount == 1)
             #expect(recorder.totalReadBytes == testData.readableBytes)
             // and an `inputClosed` event, since we received a FIN.
-            #expect(recorder.events == [.read, .channelRead(testData), .channelReadComplete, .inputClosedEvent])
+            #expect(recorder.events == [.read, .channelRead(testData), .inputClosedEvent, .channelReadComplete])
             #expect(readHolder.pendingReadRequests.count == 0)
         }
     }


### PR DESCRIPTION
Motivation:

A change in 4a0d663 subtely regressed some behavior around emitting channelReadComplete. The expected behavior is that its fired after a channelRead event or EOF.

Modifications:

- fire channelReadComplete for streams on EOF or after a channelRead, importantly this happens _after_ any close inbound event is fired

Result:

Regression fixed