### PR TITLE
Add CI job for HTTP/3 integration tests

### DIFF
--- a/.github/workflows/http3_integration_tests.yml
+++ b/.github/workflows/http3_integration_tests.yml
@@ -1,0 +1,33 @@
+name: swift-nio-http3 integration tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+
+jobs:
+  construct-matrix:
+    name: Construct integration test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: |
+          echo "integration-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: 'git clone --depth 1 https://github.com/apple/swift-nio-http3.git ../swift-nio-http3 && swift package --package-path ../swift-nio-http3 edit swift-nio-quic --path "$workspace"'
+          MATRIX_LINUX_COMMAND: "swift test --package-path ../swift-nio-http3 --filter H3IntegrationTests"
+
+  integration-tests:
+    name: Integration tests
+    needs: construct-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "swift-nio-http3 integration tests"
+      matrix_string: '${{ needs.construct-matrix.outputs.integration-test-matrix }}'

--- a/.github/workflows/http3_integration_tests.yml
+++ b/.github/workflows/http3_integration_tests.yml
@@ -3,9 +3,6 @@ name: swift-nio-http3 integration tests
 permissions:
   contents: read
 
-on:
-  workflow_call:
-
 jobs:
   construct-matrix:
     name: Construct integration test matrix

--- a/.github/workflows/http3_integration_tests.yml
+++ b/.github/workflows/http3_integration_tests.yml
@@ -3,6 +3,9 @@ name: swift-nio-http3 integration tests
 permissions:
   contents: read
 
+on:
+  workflow_call:
+
 jobs:
   construct-matrix:
     name: Construct integration test matrix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,7 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+
+  http3-integration-tests:
+    name: swift-nio-http3 integration tests
+    uses: ./.github/workflows/http3_integration_tests.yml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,3 +48,7 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+
+  http3-integration-tests:
+    name: swift-nio-http3 integration tests
+    uses: ./.github/workflows/http3_integration_tests.yml


### PR DESCRIPTION
### Motivation

swift-nio-http3 is tightly coupled with this repository and it is important that we don't regress it during active 0.x development.

### Modifications

Clone and run swift-nio-http3 integration tests on PRs and main.

### Result

Regressions are spotted quicker