### PR TITLE
Fix `channelInactive` propagation hang and `SwiftNetworkStreamHandle`…

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -369,7 +369,12 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         self.fromExternal {
             do throws(NetworkError) {
                 self.log("abortInbound")
-                try self.swiftNetworkStreamHandle.invokeAbortInbound(from: self.reference, error: error)
+                switch self.swiftNetworkStreamHandle.invokeAbortInbound() {
+                case .proceed(let linkage):
+                    try linkage.invokeAbortInbound(self.reference, error: error)
+                case .ignore:
+                    break
+                }
             } catch {
                 self.log("Failed to abort inbound: \(error)")
                 self.closeStream(mode: .disconnectOnly, error: error, promise: nil)
@@ -381,7 +386,12 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     internal func abortOutbound(error: NetworkError?) {
         self.fromExternal {
             do throws(NetworkError) {
-                try self.swiftNetworkStreamHandle.invokeAbortOutbound(from: self.reference, error: error)
+                switch self.swiftNetworkStreamHandle.invokeAbortOutbound() {
+                case .proceed(let linkage):
+                    try linkage.invokeAbortOutbound(self.reference, error: error)
+                case .ignore:
+                    break
+                }
             } catch {
                 self.log("Failed to abort outbound: \(error)")
                 self.closeStream(mode: .disconnectOnly, error: error, promise: nil)
@@ -459,7 +469,12 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     func start(fromNewFlowHandler: Bool = false) {
         log("start")
         self.eventLoop.preconditionInEventLoop()
-        self.swiftNetworkStreamHandle.invokeConnect(from: self.reference)
+        switch self.swiftNetworkStreamHandle.invokeConnect() {
+        case .proceed(let linkage):
+            linkage.invokeConnect(self.reference)
+        case .handleViolation(let reason):
+            preconditionFailure("invokeConnect on SwiftNetworkStreamHandle: \(reason)")
+        }
         // If started from NewFlowHandler then presumably there is application data waiting in the read queue
         // Do an optimistic read here when the flow is started and then all future data that comes in will get the handleInboundDataAvailableEvent event.
         // The handleInboundDataAvailableEvent signals that its time to read data on the stream.
@@ -483,25 +498,44 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         case .ignoreAlreadyClosed:
             break
         }
-        self.swiftNetworkStreamHandle.invokeDisconnect(from: reference)
+
+        switch self.swiftNetworkStreamHandle.invokeDisconnect() {
+        case .proceed(let linkage):
+            linkage.invokeDisconnect(self.reference, error: nil)
+        case .ignore:
+            break
+        }
         if detachFromLowerProtocol {
-            do throws(NetworkError) {
-                try self.swiftNetworkStreamHandle.invokeDetach(from: reference)
-            } catch {
-                self.log("Failed to detach lower protocol: \(error)")
+            switch self.swiftNetworkStreamHandle.invokeDetach() {
+            case .proceed(let linkage):
+                do throws(NetworkError) {
+                    try linkage.invokeDetach(self.reference)
+                } catch {
+                    self.log("Failed to detach lower protocol: \(error)")
+                }
+            case .skipAlreadyDetached:
+                break
             }
         }
     }
 
-    // Called when the stream handler receives a disconnected event
+    /// Called when the stream handler receives a disconnected event.
+    ///
+    /// Runs the close cascade synchronously
     internal func handleDisconnectedEvent(_ from: ProtocolInstanceReference, error: NetworkError?) {
-        log("handleDisconnectedEvent error: \(String(describing: error))")
-        // Defer to the next event-loop tick: SwiftNetwork can deliver this synchronously
-        // from inside our own `invokeDisconnect` call, and `closeStream(.detachAndClose)`
-        // mutates `swiftNetworkStreamHandle` (via `invokeDetach`) — running it inline would
-        // overlap that mutation with the outer borrow.
-        self.eventLoop.execute {
-            self.closeStream(mode: .detachAndClose, error: error, promise: nil)
+        self.log("handleDisconnectedEvent error: \(String(describing: error))")
+        switch self.swiftNetworkStreamHandle.invokeDetach() {
+        case .proceed(let linkage):
+            do throws(NetworkError) {
+                try linkage.invokeDetach(self.reference)
+            } catch {
+                self.log("Failed to detach lower protocol: \(error)")
+            }
+        case .skipAlreadyDetached:
+            break
+        }
+        if self.isActive {
+            self._close(error: error, promise: nil)
         }
     }
 
@@ -517,10 +551,15 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         case .disconnectOnly:  // Calls stop and detach only, could result in disconnect event as well
             stop(detachFromLowerProtocol: true)
         case .detachAndClose:  // Called on disconnect event callback
-            do throws(NetworkError) {
-                try self.swiftNetworkStreamHandle.invokeDetach(from: reference)
-            } catch {
-                self.log("Failed to detach lower protocol: \(error)")
+            switch self.swiftNetworkStreamHandle.invokeDetach() {
+            case .proceed(let linkage):
+                do throws(NetworkError) {
+                    try linkage.invokeDetach(self.reference)
+                } catch {
+                    self.log("Failed to detach lower protocol: \(error)")
+                }
+            case .skipAlreadyDetached:
+                break
             }
             if self.isActive {
                 self._close(error: error, promise: promise)
@@ -697,7 +736,12 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     // Get metadata about the stream from the internal QUIC stack
     private final func getMetadata<P: NetworkProtocol>() -> ProtocolMetadata<P>? {
         self.fromExternal {
-            self.swiftNetworkStreamHandle.invokeGetMetadata(from: self.reference)
+            switch self.swiftNetworkStreamHandle.invokeGetMetadata() {
+            case .proceed(let linkage):
+                return linkage.invokeGetMetadata(self.reference) as ProtocolMetadata<P>?
+            case .ignore:
+                return nil
+            }
         }
     }
 
@@ -756,10 +800,13 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
             }
             log("write \(frameArray.count) frames, \(totalBytes) bytes, fin: \(fin)")
 
-            try self.swiftNetworkStreamHandle.invokeSendStreamData(
-                from: self.reference,
-                streamData: frameArray
-            )
+            switch self.swiftNetworkStreamHandle.invokeSendStreamData() {
+            case .proceed(let linkage):
+                try linkage.invokeSendStreamData(self.reference, streamData: frameArray)
+            case .handleViolation(let reason):
+                frameArray.finalizeAllFramesAsFailed()
+                throw SwiftNetworkStreamHandle.violationError(operation: "invokeSendStreamData", reason: reason)
+            }
             return true
         } catch {
             self.logger.error("\(self.logPrefix) writeBuffersToStream failed: \(error)")
@@ -769,18 +816,24 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
 
     internal func sendFIN() throws {
         self.eventLoop.preconditionInEventLoop()
-        // Check state machine if a FIN should be sent.
+
         switch try self.streamStateMachine.sendFin() {
         case .sendFin:
             self.log("sending connection complete")
             var finFrame = Frame(copyBuffer: [])
             finFrame.connectionComplete = true
-            try self.swiftNetworkStreamHandle.invokeSendStreamData(
-                from: self.reference,
-                streamData: FrameArray(frame: finFrame)
-            )
+            var finFrameArray = FrameArray(frame: finFrame)
+            switch self.swiftNetworkStreamHandle.invokeSendStreamData() {
+            case .proceed(let linkage):
+                try linkage.invokeSendStreamData(self.reference, streamData: finFrameArray)
+            case .handleViolation(let reason):
+                finFrameArray.finalizeAllFramesAsFailed()
+                throw SwiftNetworkStreamHandle.violationError(operation: "invokeSendStreamData", reason: reason)
+            }
+
         case .ignore(.alreadyFinished):
             self.log("sendFIN ignored: send side already finished")
+
         case .ignore(.streamReset):
             self.log("sendFIN ignored: send side already reset")
         }
@@ -800,11 +853,16 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
 
         var frameArray: FrameArray?
         do throws(NetworkError) {
-            frameArray = try self.swiftNetworkStreamHandle.invokeReceiveStreamData(
-                from: self.reference,
-                minimumBytes: 1,
-                maximumBytes: Int.max
-            )
+            switch self.swiftNetworkStreamHandle.invokeReceiveStreamData() {
+            case .proceed(let linkage):
+                frameArray = try linkage.invokeReceiveStreamData(
+                    self.reference,
+                    minimumBytes: 1,
+                    maximumBytes: Int.max
+                )
+            case .handleViolation(let reason):
+                throw SwiftNetworkStreamHandle.violationError(operation: "invokeReceiveStreamData", reason: reason)
+            }
         } catch {
             self.log("Failed to read with error: \(error)")
             frameArray = nil

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -2304,95 +2304,133 @@ struct SwiftNetworkStreamHandle: ~Copyable {
     }
 
     // MARK: - Wrapper methods
+    //
+    // Every wrapper here returns an action that, on the success path, carries
+    // a *value snapshot* of `self.linkage` (`OutboundStreamLinkage` is a
+    // `struct` wrapping a struct `ProtocolInstanceReference`). Callers extract
+    // the linkage from the action, which releases the borrow on
+    // `self.swiftNetworkStreamHandle`, and then perform the SwiftNetwork side
+    // effect on the local value. This is load-bearing: SwiftNetwork's
+    // `handleCallFromUpperProtocol` drains queued peer events in a `defer`
+    // after `body()`, so a peer disconnect can synchronously re-enter
+    // `handleDisconnectedEvent` from inside an outer `invoke*` call. If the
+    // outer call held a `read` access on `self.swiftNetworkStreamHandle` for
+    // the duration of its linkage call, the inner `invokeDetach` (a `modify`)
+    // would overlap and trap on Swift exclusivity. Releasing the borrow before
+    // the side effect makes the re-entry safe at the language level.
 
-    func invokeConnect(from: ProtocolInstanceReference) {
+    enum InvokeConnectAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case handleViolation(StateMachine.ViolationReason)
+    }
+
+    func invokeConnect() -> InvokeConnectAction {
         switch self.stateMachine.invokeConnect() {
         case .performConnect:
-            self.linkage.invokeConnect(from)
+            return .proceed(self.linkage)
         case .handleViolation(let reason):
-            preconditionFailure("invokeConnect on SwiftNetworkStreamHandle: \(reason)")
+            return .handleViolation(reason)
         }
     }
 
-    func invokeDisconnect(from: ProtocolInstanceReference, error: NetworkError? = nil) {
+    enum InvokeDisconnectAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case ignore
+    }
+
+    func invokeDisconnect() -> InvokeDisconnectAction {
         switch self.stateMachine.invokeDisconnect() {
         case .performDisconnect:
-            self.linkage.invokeDisconnect(from, error: error)
+            return .proceed(self.linkage)
         case .ignore:
-            return
+            return .ignore
         }
     }
 
-    func invokeAbortInbound(
-        from: ProtocolInstanceReference,
-        error: NetworkError?
-    ) throws(NetworkError) {
+    enum InvokeAbortInboundAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case ignore
+    }
+
+    func invokeAbortInbound() -> InvokeAbortInboundAction {
         switch self.stateMachine.invokeAbortInbound() {
         case .performAbortInbound:
-            try self.linkage.invokeAbortInbound(from, error: error)
+            return .proceed(self.linkage)
         case .ignore:
-            return
+            return .ignore
         }
     }
 
-    func invokeAbortOutbound(
-        from: ProtocolInstanceReference,
-        error: NetworkError?
-    ) throws(NetworkError) {
+    enum InvokeAbortOutboundAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case ignore
+    }
+
+    func invokeAbortOutbound() -> InvokeAbortOutboundAction {
         switch self.stateMachine.invokeAbortOutbound() {
         case .performAbortOutbound:
-            try self.linkage.invokeAbortOutbound(from, error: error)
+            return .proceed(self.linkage)
         case .ignore:
-            return
+            return .ignore
         }
     }
 
-    func invokeSendStreamData(
-        from: ProtocolInstanceReference,
-        streamData: consuming FrameArray
-    ) throws(NetworkError) {
+    enum InvokeSendStreamDataAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case handleViolation(StateMachine.ViolationReason)
+    }
+
+    func invokeSendStreamData() -> InvokeSendStreamDataAction {
         switch self.stateMachine.invokeSendStreamData() {
         case .performSendStreamData:
-            try self.linkage.invokeSendStreamData(from, streamData: streamData)
+            return .proceed(self.linkage)
         case .handleViolation(let reason):
-            throw Self.violationError(operation: "invokeSendStreamData", reason: reason)
+            return .handleViolation(reason)
         }
     }
 
-    func invokeReceiveStreamData(
-        from: ProtocolInstanceReference,
-        minimumBytes: Int,
-        maximumBytes: Int
-    ) throws(NetworkError) -> FrameArray? {
+    enum InvokeReceiveStreamDataAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case handleViolation(StateMachine.ViolationReason)
+    }
+
+    func invokeReceiveStreamData() -> InvokeReceiveStreamDataAction {
         switch self.stateMachine.invokeReceiveStreamData() {
         case .performReceiveStreamData:
-            return try self.linkage.invokeReceiveStreamData(
-                from,
-                minimumBytes: minimumBytes,
-                maximumBytes: maximumBytes
-            )
+            return .proceed(self.linkage)
         case .handleViolation(let reason):
-            throw Self.violationError(operation: "invokeReceiveStreamData", reason: reason)
+            return .handleViolation(reason)
         }
     }
 
-    func invokeGetMetadata<P: NetworkProtocol>(
-        from: ProtocolInstanceReference
-    ) -> ProtocolMetadata<P>? {
+    enum InvokeGetMetadataAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case ignore
+    }
+
+    func invokeGetMetadata() -> InvokeGetMetadataAction {
         switch self.stateMachine.invokeGetMetadata() {
         case .performGetMetadata:
-            return self.linkage.invokeGetMetadata(from)
+            return .proceed(self.linkage)
         case .ignore:
-            return nil
+            return .ignore
         }
     }
 
-    mutating func invokeDetach(from: ProtocolInstanceReference) throws(NetworkError) {
+    enum InvokeDetachAction: ~Copyable {
+        case proceed(OutboundStreamLinkage)
+        case skipAlreadyDetached
+    }
+
+    /// Mutating: transitions the SM to `.detached` before returning. The
+    /// modify borrow ends with the return; the caller performs `invokeDetach`
+    /// on the returned linkage value without holding any borrow on the handle.
+    mutating func invokeDetach() -> InvokeDetachAction {
         switch self.stateMachine.invokeDetach() {
         case .performDetach:
-            try self.linkage.invokeDetach(from)
+            return .proceed(self.linkage)
         case .skipAlreadyDetached:
-            return
+            return .skipAlreadyDetached
         }
     }
 
@@ -2400,7 +2438,7 @@ struct SwiftNetworkStreamHandle: ~Copyable {
     /// (`invokeSendStreamData`, `invokeReceiveStreamData`). The reason is
     /// included in the description so callers and logs see exactly what
     /// went wrong.
-    private static func violationError(
+    static func violationError(
         operation: String,
         reason: StateMachine.ViolationReason
     ) -> NetworkError {

--- a/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import Logging
+import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
 import NIOQUICHelpers
@@ -320,6 +321,113 @@ struct QUICChannelStreamHandlerTests {
             // and an `inputClosed` event, since we received a FIN.
             #expect(recorder.events == [.read, .channelRead(testData), .inputClosedEvent, .channelReadComplete])
             #expect(readHolder.pendingReadRequests.count == 0)
+        }
+    }
+
+    /// `handleDisconnectedEvent` can fire on an already-detached stream (e.g. connection-level close);
+    /// we shouldn't leak the close promise.
+    @available(anyAppleOS 26, *)
+    @Test("handleDisconnectedEvent still resolves closeFuture when linkage is already detached")
+    func handleDisconnectedEventResolvesCloseFutureWhenLinkageAlreadyDetached() throws {
+        try Self.withServerStream { streamChannel in
+            streamChannel._isActive.store(true, ordering: .sequentiallyConsistent)
+
+            let closeFutureFulfilled = NIOLockedValueBox(false)
+            streamChannel.closeFuture.whenComplete { _ in
+                closeFutureFulfilled.withLockedValue { $0 = true }
+            }
+
+            // Detach the linkage simulating prior teardown
+            switch streamChannel.swiftNetworkStreamHandle.invokeDetach() {
+            case .proceed:
+                break
+            case .skipAlreadyDetached:
+                Issue.record("Pre-condition: handle should have been attached")
+            }
+
+            // Detached linkage + active channel, close future must not have resolved.
+            let isAttachedBefore = streamChannel.swiftNetworkStreamHandle.isAttached
+            #expect(!isAttachedBefore)
+            let isActiveBefore = streamChannel.isActive
+            #expect(isActiveBefore)
+
+            // Fire `handleDisconnectedEvent`, actually perform the full close
+            streamChannel.handleDisconnectedEvent(.init(), error: nil)
+
+            // `_close` defers its body to the next event-loop tick; flush.
+            (streamChannel.eventLoop as! EmbeddedEventLoop).run()
+
+            let isActiveAfter = streamChannel.isActive
+            #expect(!isActiveAfter)
+            let fulfilled = closeFutureFulfilled.withLockedValue { $0 }
+            #expect(
+                fulfilled,
+                "closeFuture must resolve when handleDisconnectedEvent runs on an active channel"
+            )
+        }
+    }
+
+    /// `handleDisconnectedEvent` must flip `_isActive` synchronously; deferring
+    /// races the multiplexer's `removeHandlers` and drops `fireChannelInactive`.
+    @available(anyAppleOS 26, *)
+    @Test("handleDisconnectedEvent flips _isActive synchronously")
+    func handleDisconnectedEventFlipsIsActiveSynchronously() throws {
+        try Self.withServerStream { streamChannel in
+            // Set up the normal case: linkage attached, channel active.
+            streamChannel._isActive.store(true, ordering: .sequentiallyConsistent)
+            let isAttachedBefore = streamChannel.swiftNetworkStreamHandle.isAttached
+            #expect(isAttachedBefore)
+            let isActiveBefore = streamChannel.isActive
+            #expect(isActiveBefore)
+
+            // Fire `handleDisconnectedEvent`. After it returns —
+            // *without* having drained the event loop — `_isActive` must
+            // already be `false`. If the cascade were deferred via
+            // `eventLoop.execute` (the pre-fix shape), `_isActive` would
+            // still be `true` here.
+            streamChannel.handleDisconnectedEvent(.init(), error: nil)
+
+            let isActiveAfterImmediately = streamChannel.isActive
+            #expect(
+                !isActiveAfterImmediately,
+                "handleDisconnectedEvent must flip _isActive synchronously to resolve _closePromise on the same tick as ChildChannelMultiplexer.removeHandlers"
+            )
+
+            // Drain the deferred pipeline body.
+            (streamChannel.eventLoop as! EmbeddedEventLoop).run()
+        }
+    }
+
+    /// `invoke*` wrappers must release their borrow on `swiftNetworkStreamHandle` before the linkage call;
+    /// SwiftNetwork's synchronous drain otherwise re-enters `invokeDetach` on a live read borrow and traps.
+    @available(anyAppleOS 26, *)
+    @Test("invoke* wrappers release the borrow on swiftNetworkStreamHandle before returning")
+    func invokeWrappersReleaseBorrowBeforeReturning() throws {
+        try Self.withServerStream { streamChannel in
+            // Extract the linkage from the non-mutating send-data wrapper.
+            let linkage: OutboundStreamLinkage
+            switch streamChannel.swiftNetworkStreamHandle.invokeSendStreamData() {
+            case .proceed(let extracted):
+                linkage = extracted
+            case .handleViolation:
+                Issue.record("Pre-condition: handle should have been attached")
+                return
+            }
+
+            // The borrow taken by `invokeSendStreamData()` is released by
+            // the time it returns. Take a *modify* access on the same
+            // property right here — under the pre-fix shape this would
+            // overlap the still-live outer read borrow and trap.
+            switch streamChannel.swiftNetworkStreamHandle.invokeDetach() {
+            case .proceed:
+                break
+            case .skipAlreadyDetached:
+                Issue.record("Pre-condition: handle should have been attached")
+            }
+
+            // `linkage` is still usable independently of the handle — it's
+            // a value-type copy, not a borrow.
+            _ = linkage
         }
     }
 }

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -1411,13 +1411,19 @@ struct SwiftNetworkStreamHandleTests {
     func invokeDetachIsIdempotent() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
 
-        try handle.invokeDetach(from: .init())
+        switch handle.invokeDetach() {
+        case .proceed: break
+        case .skipAlreadyDetached: Issue.record("Expected .proceed on first detach")
+        }
 
         let isAttachedAfter = handle.isAttached
         #expect(!isAttachedAfter)
 
-        // Second call should not throw or crash
-        try handle.invokeDetach(from: .init())
+        // Second call should report already detached, not crash.
+        switch handle.invokeDetach() {
+        case .proceed: Issue.record("Expected .skipAlreadyDetached on second detach")
+        case .skipAlreadyDetached: break
+        }
     }
 
     /// Stop sequencing: disconnect after detach is a normal teardown ordering and must not throw.
@@ -1426,10 +1432,15 @@ struct SwiftNetworkStreamHandleTests {
     func invokeDisconnectNoopsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
 
-        try handle.invokeDetach(from: .init())
+        switch handle.invokeDetach() {
+        case .proceed: break
+        case .skipAlreadyDetached: Issue.record("Expected .proceed on first detach")
+        }
 
-        // Should not throw or crash
-        handle.invokeDisconnect(from: .init())
+        switch handle.invokeDisconnect() {
+        case .proceed: Issue.record("Expected .ignore when detached")
+        case .ignore: break
+        }
     }
 
     /// Error/abort during teardown must not raise (called from the close-stream paths).
@@ -1438,10 +1449,15 @@ struct SwiftNetworkStreamHandleTests {
     func invokeAbortInboundNoopsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
 
-        try handle.invokeDetach(from: .init())
+        switch handle.invokeDetach() {
+        case .proceed: break
+        case .skipAlreadyDetached: Issue.record("Expected .proceed on first detach")
+        }
 
-        // Should not throw or crash
-        try handle.invokeAbortInbound(from: .init(), error: nil)
+        switch handle.invokeAbortInbound() {
+        case .proceed: Issue.record("Expected .ignore when detached")
+        case .ignore: break
+        }
     }
 
     /// Error/abort during teardown must not raise (called from the close-stream paths).
@@ -1450,55 +1466,76 @@ struct SwiftNetworkStreamHandleTests {
     func invokeAbortOutboundNoopsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
 
-        try handle.invokeDetach(from: .init())
+        switch handle.invokeDetach() {
+        case .proceed: break
+        case .skipAlreadyDetached: Issue.record("Expected .proceed on first detach")
+        }
 
-        // Should not throw or crash
-        try handle.invokeAbortOutbound(from: .init(), error: nil)
+        switch handle.invokeAbortOutbound() {
+        case .proceed: Issue.record("Expected .ignore when detached")
+        case .ignore: break
+        }
     }
 
-    /// Soft-violation policy: write-after-detach surfaces as a throw the caller can recover
-    /// from (e.g. return false), not a silent no-op that drops bytes.
+    /// Soft-violation policy: write-after-detach surfaces as a violation the caller can
+    /// surface as a throw (e.g. return false), not a silent no-op that drops bytes.
     @available(anyAppleOS 26, *)
-    @Test("invokeSendStreamData throws NetworkError when detached")
+    @Test("invokeSendStreamData reports violation when detached")
     func invokeSendStreamDataThrowsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
 
-        try handle.invokeDetach(from: .init())
+        switch handle.invokeDetach() {
+        case .proceed: break
+        case .skipAlreadyDetached: Issue.record("Expected .proceed on first detach")
+        }
 
-        do throws(NetworkError) {
-            try handle.invokeSendStreamData(from: .init(), streamData: FrameArray())
-            Issue.record("Expected throw")
-        } catch {
-            // Expected
+        switch handle.invokeSendStreamData() {
+        case .proceed:
+            Issue.record("Expected .handleViolation when detached")
+        case .handleViolation(let reason):
+            switch reason {
+            case .detached: break
+            }
         }
     }
 
-    /// Soft-violation policy: read-after-detach surfaces as a throw, not a silent nil that
+    /// Soft-violation policy: read-after-detach surfaces as a violation, not a silent nil that
     /// the caller might confuse with "no data available".
     @available(anyAppleOS 26, *)
-    @Test("invokeReceiveStreamData throws NetworkError when detached")
+    @Test("invokeReceiveStreamData reports violation when detached")
     func invokeReceiveStreamDataThrowsWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
 
-        try handle.invokeDetach(from: .init())
+        switch handle.invokeDetach() {
+        case .proceed: break
+        case .skipAlreadyDetached: Issue.record("Expected .proceed on first detach")
+        }
 
-        do throws(NetworkError) {
-            _ = try handle.invokeReceiveStreamData(from: .init(), minimumBytes: 1, maximumBytes: 100)
-            Issue.record("Expected throw")
-        } catch {
-            // Expected
+        switch handle.invokeReceiveStreamData() {
+        case .proceed:
+            Issue.record("Expected .handleViolation when detached")
+        case .handleViolation(let reason):
+            switch reason {
+            case .detached: break
+            }
         }
     }
 
-    /// Metadata is genuinely unavailable post-detach; nil is the natural API response.
+    /// Metadata is genuinely unavailable post-detach; the wrapper returns `.ignore`
+    /// so the caller can surface nil to its own consumer.
     @available(anyAppleOS 26, *)
-    @Test("invokeGetMetadata returns nil when detached")
+    @Test("invokeGetMetadata reports ignore when detached")
     func invokeGetMetadataReturnsNilWhenDetached() throws(NetworkError) {
         var handle = SwiftNetworkStreamHandle()
 
-        try handle.invokeDetach(from: .init())
+        switch handle.invokeDetach() {
+        case .proceed: break
+        case .skipAlreadyDetached: Issue.record("Expected .proceed on first detach")
+        }
 
-        let metadata: ProtocolMetadata<QUICProtocol>? = handle.invokeGetMetadata(from: .init())
-        #expect(metadata == nil)
+        switch handle.invokeGetMetadata() {
+        case .proceed: Issue.record("Expected .ignore when detached")
+        case .ignore: break
+        }
     }
 }


### PR DESCRIPTION
  ### Motivation

  * `handleDisconnectedEvent` deferred its close cascade through `eventLoop.execute`, so `_closePromise.succeed()` landed on tick 2 - after `ChildChannelMultiplexer.removeHandlers` nilled the context on tick 1, silently dropping `fireChannelInactive` and hanging swift-nio-http3 async tests.
  * Running the close inline trades that hang for a Swift exclusivity trap: SwiftNetwork's `handleCallFromUpperProtocol` synchronously drains queued peer events in a `defer`. A disconnect arriving mid-`invoke*` re-enters `handleDisconnectedEvent`; an inline `invokeDetach` overlaps the outer read borrow on `self.swiftNetworkStreamHandle`.

  ### Modifications

  * `SwiftNetworkStreamHandle.invoke*` wrappers now return an action carrying the linkage by value. Callers run the SwiftNetwork side effect on the local copy, so no borrow is held during the call - synchronous re-entry into the handle is safe.
  * `handleDisconnectedEvent` runs cleanup synchronously: `invokeDetach`, then `_close` when `isActive`. `.skipAlreadyDetached` falls through to the `isActive` check so `_closePromise` still resolves on an already-detached stream.
  * `writeBuffersToStream`/`sendFIN` finalise their `FrameArray` as failed in the new violation arms — the wrapper no longer hands the array to the linkage there.
  * Regression tests in `QUICChannelStreamHandlerTests` cover the synchronous `_isActive` flip, the borrow-release contract, and `_closePromise` resolution on an already-detached stream.

  ### Result

  * Async H/3 integration tests pass; `testResetStream` (and similar write-then-close-with-peer-disconnect flows) no longer trap.
  * No `eventLoop.execute` on any path that touches `swiftNetworkStreamHandle` — the fix is structural at the wrapper boundary, not a hop-on-tick workaround.
  * The remaining `eventLoop.execute` wrapping the pipeline-state teardown is unchanged; `ChildChannelMultiplexer` re-entrancy is the deeper root cause, tracked separately.