### PR TITLE
Fix memory leak in QUICChannelStreamHandler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            revision: "ca1af826afc6408a2a68eb795db978c16e5ced89",
+            revision: "48f8547777d058e87fdadce12889771b582bd430",
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", branch: "main"),

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelEventLoop.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelEventLoop.swift
@@ -37,10 +37,24 @@ final class QUICChannelEventLoop: NetworkContext.Scheduler, CustomStringConverti
         self.eventLoop = eventLoop
     }
 
+    private struct UnsafeTransfer<Wrapped>: @unchecked Sendable {
+        var wrappedValue: Wrapped
+        init(_ wrappedValue: Wrapped) {
+            self.wrappedValue = wrappedValue
+        }
+    }
+
     func runImmediate(_ task: @escaping (() -> Void)) {
-        // Swift Network expects this to run asynchronously, i.e., the task should be scheduled
-        // even when called from the same event loop.
-        self.eventLoop.assumeIsolated().execute(task)
+        if self.eventLoop.inEventLoop {
+            self.eventLoop.assumeIsolated().execute(task)
+        } else {
+            // Remove once this has landed: https://github.com/apple/swift-network-evolution/pull/36
+            let transfer = UnsafeTransfer(task)
+            self.eventLoop.execute {
+                let value = transfer.wrappedValue
+                value()
+            }
+        }
     }
 
     func schedule(

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1160,6 +1160,7 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
 
             self.pipeline.fireChannelInactive()
             self.pipeline.fireChannelUnregistered()
+            self.removeHandlers(pipeline: self.pipeline)
             self._closePromise.succeed(())
             promise?.succeed()
             // Fire disconnect if there is no error present

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -182,6 +182,63 @@ final class QUICProtocolStackTests: XCTestCase {
         }
     }
 
+    func testClosingStreamRemovesPipelineHandlers() async throws {
+        let loggers = self.getChannelLoggers()
+        let (serverChannel, serverMultiplexer) = try await self.buildServerChannel(logger: loggers.serverLogger)
+        let (_, clientMultiplexer) = try await self.buildClientChannel(logger: loggers.clientLogger)
+
+        let clientConnection = try await clientMultiplexer.createNewConnection(
+            serverName: serverChannel.localAddress!.ipAddress!,
+            remoteAddress: serverChannel.localAddress!,
+            inboundStreamInitializer: { channel in
+                channel.eventLoop.makeCompletedFuture { fatalError() }
+            }
+        )
+
+        let recorder = HandlerRemovalRecorder()
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for await connection in serverMultiplexer.inboundConnections {
+                    for await stream in connection.inboundStreams {
+                        try await stream.executeThenClose { inbound, outbound in
+                            for try await buffer in inbound {
+                                try await outbound.write(buffer)
+                            }
+                            outbound.finish()
+                        }
+                    }
+                }
+            }
+
+            let stream = try await clientConnection.createBidirectionalStream { streamInitializer in
+                streamInitializer.channel.eventLoop.makeCompletedFuture {
+                    try streamInitializer.channel.pipeline.syncOperations.addHandler(recorder)
+                    return try NIOAsyncChannel(
+                        wrappingChannelSynchronously: streamInitializer.channel,
+                        configuration: .init(
+                            isOutboundHalfClosureEnabled: true,
+                            inboundType: ByteBuffer.self,
+                            outboundType: ByteBuffer.self
+                        )
+                    )
+                }
+            }
+
+            try await stream.executeThenClose { inbound, outbound in
+                try await outbound.write(.init(string: "ping"))
+                outbound.finish()
+                for try await buffer in inbound {
+                    XCTAssertEqual(buffer, .init(string: "ping"))
+                }
+            }
+
+            group.cancelAll()
+        }
+
+        XCTAssertTrue(recorder.removed)
+    }
+
     func testSingleDataTransferOverTwoUnidirectionalStreams() async throws {
 
         let loggers = getChannelLoggers()
@@ -1391,5 +1448,22 @@ final class QUICProtocolStackTests: XCTestCase {
 
         try await clientChannel.close().get()
         try await serverChannel.close().get()
+    }
+}
+
+/// Records when it is removed from its `ChannelPipeline`.
+@available(anyAppleOS 26, *)
+private final class HandlerRemovalRecorder: ChannelInboundHandler, Sendable {
+    typealias InboundIn = ByteBuffer
+
+    private let _removed = Mutex(false)
+
+    /// Whether the handler has been removed from its pipeline.
+    var removed: Bool {
+        self._removed.withLock { $0 }
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        self._removed.withLock { $0 = true }
     }
 }


### PR DESCRIPTION
Motivation:

QUICChannelStreamHandler didn't remove handlers from its pipeline when closed. This is required to breaking the retain cycle between the channel and its pipeline. As a result every stream is leaked.

Fixing this highlighted a number of issues:
- one test failed because its assert ran in handler removed, that was never run because the handler was never removed. The failure was in swift-network-evolution and is now fixed.
- a sendability issue in swift-network-evolution which is not yet fixed but is worked around in this PR

Modifications:

- Break retain cycle by removing handlers
- Workaround aforementioned issue

Result:

Fewer leaks