### PR TITLE
Make SwiftTLS/Authenticator argument order consistent

### DIFF
--- a/Sources/NIOQUIC/SwiftTLS/Authenticator.swift
+++ b/Sources/NIOQUIC/SwiftTLS/Authenticator.swift
@@ -40,14 +40,14 @@ public final class Authenticator: Sendable {
         let certificates = try loadCertificates(fromPEMFile: certificateChainFile)
         let privateKey = try loadPrivateKey(fromPEMFile: privateKeyFilePath)
 
-        try self.init(privateKey: privateKey, certificates: certificates)
+        try self.init(certificates: certificates, privateKey: privateKey)
     }
 
     /// Create a new authenticator that sends the certificates to a client to authenticate, providing a
     /// signature with the private key.
     ///
     /// - Throws: If there is not at least one certificate, the leaf certificate does not allow server authentication, or the leaf is not suitable to verify digital signatures.
-    public init(privateKey: Certificate.PrivateKey, certificates: [Certificate]) throws {
+    public init(certificates: [Certificate], privateKey: Certificate.PrivateKey) throws {
         guard let leaf = certificates.first else {
             // Must at least have a leaf certificiate.
             throw QUICError.certificatesMissing

--- a/Tests/NIOQUICTests/AuthenticationCallbackTest.swift
+++ b/Tests/NIOQUICTests/AuthenticationCallbackTest.swift
@@ -34,10 +34,10 @@ struct AuthenticationCallbackTest {
 
         // Key usage bit not set for digitial signatures
         #expect(throws: QUICError.certificateNotSuitableForAuthentication) {
-            _ = try Authenticator(privateKey: rootKey, certificates: [rootCert])
+            _ = try Authenticator(certificates: [rootCert], privateKey: rootKey)
         }
         #expect(throws: QUICError.certificateNotSuitableForAuthentication) {
-            _ = try Authenticator(privateKey: intermediateKey, certificates: [intermediateCert])
+            _ = try Authenticator(certificates: [intermediateCert], privateKey: intermediateKey)
         }
 
         // extended key usage: server auth
@@ -48,7 +48,7 @@ struct AuthenticationCallbackTest {
             extendedKeyUsages: [.serverAuth]
         )
         #expect(throws: Never.self) {
-            _ = try Authenticator(privateKey: leafKey, certificates: [leafCert])
+            _ = try Authenticator(certificates: [leafCert], privateKey: leafKey)
         }
 
         // extended key usage: client auth
@@ -59,7 +59,7 @@ struct AuthenticationCallbackTest {
             extendedKeyUsages: [.clientAuth]
         )
         #expect(throws: QUICError.certificateNotSuitableForAuthentication) {
-            _ = try Authenticator(privateKey: leafKeyClientAuth, certificates: [leafCertClientAuth])
+            _ = try Authenticator(certificates: [leafCertClientAuth], privateKey: leafKeyClientAuth)
         }
 
         // extended key usage: client auth + any
@@ -70,7 +70,7 @@ struct AuthenticationCallbackTest {
             extendedKeyUsages: [.clientAuth, .any]
         )
         #expect(throws: Never.self) {
-            _ = try Authenticator(privateKey: leafKeyClientAuthAny, certificates: [leafCertClientAuthAny])
+            _ = try Authenticator(certificates: [leafCertClientAuthAny], privateKey: leafKeyClientAuthAny)
         }
     }
 
@@ -244,16 +244,15 @@ struct AuthenticationCallbackTest {
 
         // Key usage bit not set for digitial signatures
         #expect(throws: QUICError.certificateNotSuitableForAuthentication) {
-            _ = try Authenticator(privateKey: key, certificates: [cert3])
+            _ = try Authenticator(certificates: [cert3], privateKey: key)
         }
         #expect(throws: QUICError.certificateNotSuitableForAuthentication) {
-            _ = try Authenticator(privateKey: key, certificates: [cert2, cert3])
+            _ = try Authenticator(certificates: [cert2, cert3], privateKey: key)
         }
 
         // Cert intended for server authentication
         #expect(throws: Never.self) {
-            _ = try Authenticator(privateKey: key, certificates: [cert1, cert2, cert3])
+            _ = try Authenticator(certificates: [cert1, cert2, cert3], privateKey: key)
         }
     }
-
 }


### PR DESCRIPTION
### Motivation

SwiftTLS/Authenticator has two initializers. One accepts the certificate chain and private key from filepaths, and the other from in-memory instances.

The file-path initializer takes the certificate chain first, whereas the in-memory initializer takes the private key first. The two orders should be consistent.

### Modifications

Reordered the arguments of the in-memory initializer to be consistent with the other initializer.

### Result

Better consistency in SwiftTLS/Authenticator initializers.