### PR TITLE
Stream receive refactors

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -266,29 +266,7 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
                 UInt64(applicationErrorCode)
             )!
             do {
-                switch try self.streamStateMachine.receiveResetStream(
-                    applicationErrorCode: errorCode,
-                    finalSize: 0
-                ) {
-                case .closeStream(_):
-                    self.closeStream(
-                        mode: .closeAndDisconnect,
-                        error: NIOQUICHelpers.QUICStreamResetError(code: errorCode),
-                        promise: nil
-                    )
-                case .doNotCloseStream(_):
-                    self.closeStream(
-                        mode: .closeAndDisconnect,
-                        error: NIOQUICHelpers.QUICStreamResetError(code: errorCode),
-                        promise: nil
-                    )
-
-                case .ignore(.alreadyFullyReceived):
-                    self.log("receiveResetStream: all data already received, ignoring")
-
-                case .ignore(.alreadyReset):
-                    self.log("receiveResetStream: stream already reset, ignoring")
-                }
+                try self.handleReceivedResetStream(applicationErrorCode: errorCode)
             } catch {
                 self.logger.warning("\(self.logPrefix) handleInboundAbortedEvent errored: \(error)")
                 switch error {
@@ -300,6 +278,36 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
             }
         } else {
             self.log("handleInboundAbortedEvent called with error: \(String(describing: error))")
+        }
+    }
+
+    // Extracted to avoid compiler crash in `-O` builds on Swift 6.3
+    @inline(never)
+    private func handleReceivedResetStream(
+        applicationErrorCode errorCode: NIOQUICHelpers.QUICApplicationErrorCode
+    ) throws(QUICStreamStateMachine.InvalidTransition) {
+        switch try self.streamStateMachine.receiveResetStream(
+            applicationErrorCode: errorCode,
+            finalSize: 0
+        ) {
+        case .closeStream(_):
+            self.closeStream(
+                mode: .closeAndDisconnect,
+                error: NIOQUICHelpers.QUICStreamResetError(code: errorCode),
+                promise: nil
+            )
+        case .doNotCloseStream(_):
+            self.closeStream(
+                mode: .closeAndDisconnect,
+                error: NIOQUICHelpers.QUICStreamResetError(code: errorCode),
+                promise: nil
+            )
+
+        case .ignore(.alreadyFullyReceived):
+            self.log("receiveResetStream: all data already received, ignoring")
+
+        case .ignore(.alreadyReset):
+            self.log("receiveResetStream: stream already reset, ignoring")
         }
     }
 

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -617,47 +617,51 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         }
     }
 
-    func streamRead() {
-        self.eventLoop.preconditionInEventLoop()
-
-        // Emit channel read complete when:
-        // - any read was fired, or
-        // - EOF is emitted
-        var emitReadComplete = false
-
-        if self.bufferedReadData.readableBytes > 0 {
-            // We will now satisfy a pending read request. Reset the flag.
-            self.pendingRead = false
-            emitReadComplete = true
-
-            let bytesRead = bufferedReadData.readableBytes
-            self.log(
-                "Read \(bytesRead) bytes from stream"
-            )
-            self.pipeline.fireChannelRead(bufferedReadData)
-            bufferedReadData.clear()
+    /// Returns `true` if data was actually delivered
+    private func flushBufferedReadData() -> Bool {
+        guard self.bufferedReadData.readableBytes > 0 else {
+            return false
         }
+        // We will now satisfy a pending read request. Reset the flag.
+        self.pendingRead = false
+        let bytesRead = self.bufferedReadData.readableBytes
+        self.log("Read \(bytesRead) bytes from stream")
+        self.pipeline.fireChannelRead(self.bufferedReadData)
+        self.bufferedReadData.clear()
+        return true
+    }
 
+    /// Returns `true` if an end-of-stream event was surfaced
+    private func surfaceReadCompletion() -> Bool {
         switch self.streamStateMachine.completeRead() {
         case .reportFin(let streamFullyClosed):
-            emitReadComplete = true
             self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
             if streamFullyClosed {
                 self.log("stream is now fully closed")
                 self.closeStream(mode: .disconnectOnly, error: nil, promise: nil)
                 self.shutdownStream(direction: .all, applicationErrorCode: nil)
             }
+            return true
 
         case .reportPeerReset:
-            emitReadComplete = true
             self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
-            break
+            return true
 
         case .nothingToReport:
-            break
+            return false
         }
+    }
 
-        if emitReadComplete {
+    func streamRead() {
+        self.eventLoop.preconditionInEventLoop()
+
+        // Emit channel read complete when:
+        // - any read was fired, or
+        // - EOF is emitted
+        let flushed = self.flushBufferedReadData()
+        let surfaced = self.surfaceReadCompletion()
+
+        if flushed || surfaced {
             self.fireChannelReadComplete()
         }
     }

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -671,11 +671,11 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
 
         // Emit channel read complete when:
         // - any read was fired, or
-        // - EOF is emitted
+        // - FIN or peer RESET is emitted
         let flushed = self.flushBufferedReadData()
-        let surfaced = self.surfaceReadCompletion()
+        let endOfStream = self.surfaceReadCompletion()
 
-        if flushed || surfaced {
+        if flushed || endOfStream {
             self.fireChannelReadComplete()
         }
     }

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -631,6 +631,21 @@ struct QUICStreamStateMachine: ~Copyable {
 
     // MARK: - Compound transitions
 
+    enum ConsumeReceiveTerminatorAction: ~Copyable {
+        /// The receive side has reached its FIN.
+        case reportFin(streamFullyClosed: Bool)
+        /// The receive side was reset by the peer.
+        case reportPeerReset(applicationErrorCode: QUICApplicationErrorCode)
+        /// No terminator was captured, or one has already been consumed.
+        case nothingToReport
+    }
+
+    /// Advance the receive sub-SM past any captured terminator (FIN or
+    /// peer RESET) and report what was consumed.
+    mutating func consumeReceiveTerminator() -> ConsumeReceiveTerminatorAction {
+        self.state.consumeReceiveTerminator()
+    }
+
     enum CompleteReadAction: ~Copyable {
         /// Read side still open — nothing more to report.
         case nothingToReport
@@ -647,26 +662,14 @@ struct QUICStreamStateMachine: ~Copyable {
             // Stream was closed (e.g. connection teardown) — signal end-of-stream.
             return .reportFin(streamFullyClosed: true)
         }
-        if self.hasReceivedFin {
-            // The receive SM has the FIN (state is .dataRecvd); calling
-            // applicationRead transitions it to .dataRead (terminal) and
-            // returns .deliverEndOfStream.
-            do {
-                switch try self.applicationRead() {
-                case .deliverEndOfStream:
-                    return .reportFin(streamFullyClosed: self.isFullyClosed)
-                case .deliverData:
-                    return .nothingToReport
-                case .ignore:
-                    return .nothingToReport
-                case .deliverResetError:
-                    return .reportPeerReset
-                }
-            } catch {
-                return .nothingToReport
-            }
+        switch self.consumeReceiveTerminator() {
+        case .reportFin(let streamFullyClosed):
+            return .reportFin(streamFullyClosed: streamFullyClosed)
+        case .reportPeerReset:
+            return .reportPeerReset
+        case .nothingToReport:
+            return .nothingToReport
         }
-        return .nothingToReport
     }
 
     enum ShutdownStreamAction: ~Copyable {
@@ -1100,6 +1103,41 @@ extension QUICStreamStateMachine.State {
         case .closed(let closed):
             self = .closed(closed)
             throw .notConnected
+        }
+    }
+
+    /// Consuming a received terminator. Non-terminal or non-connected
+    /// states return `.nothingToReport`.
+    mutating func consumeReceiveTerminator()
+        -> QUICStreamStateMachine.ConsumeReceiveTerminatorAction
+    {
+        switch consume self {
+        case .connected(var connected):
+            let readAction = connected.streamState.withReceiveState { $0.applicationRead() }
+            let isFullyClosed = connected.streamState.isFullyClosed
+            self = .connected(connected)
+            switch readAction {
+            case .deliverEndOfStream:
+                return .reportFin(streamFullyClosed: isFullyClosed)
+            case .deliverResetError(let code):
+                return .reportPeerReset(applicationErrorCode: code)
+            case .deliverData:
+                return .nothingToReport
+            case .ignore:
+                return .nothingToReport
+            case nil:
+                return .nothingToReport
+            }
+
+        case .pendingID(let pending):
+            // FIN captured on the pending record is not consumable until
+            // `streamConnected` replays it into the receive sub-SM.
+            self = .pendingID(pending)
+            return .nothingToReport
+
+        case .closed(let closed):
+            self = .closed(closed)
+            return .nothingToReport
         }
     }
 

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -303,11 +303,11 @@ struct QUICStreamStateMachine: ~Copyable {
         case .connected(let connected):
             switch connected.streamState {
             case .bidirectional(let streamState):
-                return streamState.receiveState.isTerminal || streamState.receiveState.wasReset
+                return streamState.receiveState.isTerminal || streamState.receiveState.hasReceivedReset
             case .sendOnly:
                 return true
             case .receiveOnly(let streamState):
-                return streamState.receiveState.isTerminal || streamState.receiveState.wasReset
+                return streamState.receiveState.isTerminal || streamState.receiveState.hasReceivedReset
             }
 
         case .pendingID:
@@ -1814,8 +1814,8 @@ struct QUICStreamReceiveStateMachine: ~Copyable {
         }
     }
 
-    /// Returns `true` if the stream was reset by peer.
-    var wasReset: Bool {
+    /// Returns `true` if the peer has reset the receive side.
+    var hasReceivedReset: Bool {
         switch self.state {
         case .resetRecvd:
             return true

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -631,19 +631,19 @@ struct QUICStreamStateMachine: ~Copyable {
 
     // MARK: - Compound transitions
 
-    enum ConsumeReceiveTerminatorAction: ~Copyable {
+    enum ConsumeFinOrResetAction: ~Copyable {
         /// The receive side has reached its FIN.
         case reportFin(streamFullyClosed: Bool)
         /// The receive side was reset by the peer.
         case reportPeerReset(applicationErrorCode: QUICApplicationErrorCode)
-        /// No terminator was captured, or one has already been consumed.
+        /// No FIN or RESET was captured, or one has already been consumed.
         case nothingToReport
     }
 
-    /// Advance the receive sub-SM past any captured terminator (FIN or
-    /// peer RESET) and report what was consumed.
-    mutating func consumeReceiveTerminator() -> ConsumeReceiveTerminatorAction {
-        self.state.consumeReceiveTerminator()
+    /// Advance the receive sub-SM past any captured FIN or peer RESET,
+    /// and report what was consumed.
+    mutating func consumeFinOrReset() -> ConsumeFinOrResetAction {
+        self.state.consumeFinOrReset()
     }
 
     enum CompleteReadAction: ~Copyable {
@@ -662,7 +662,7 @@ struct QUICStreamStateMachine: ~Copyable {
             // Stream was closed (e.g. connection teardown) — signal end-of-stream.
             return .reportFin(streamFullyClosed: true)
         }
-        switch self.consumeReceiveTerminator() {
+        switch self.consumeFinOrReset() {
         case .reportFin(let streamFullyClosed):
             return .reportFin(streamFullyClosed: streamFullyClosed)
         case .reportPeerReset:
@@ -1106,10 +1106,10 @@ extension QUICStreamStateMachine.State {
         }
     }
 
-    /// Consuming a received terminator. Non-terminal or non-connected
-    /// states return `.nothingToReport`.
-    mutating func consumeReceiveTerminator()
-        -> QUICStreamStateMachine.ConsumeReceiveTerminatorAction
+    /// Consume any captured FIN or peer RESET on the receive side.
+    /// Non-terminal or non-connected states return `.nothingToReport`.
+    mutating func consumeFinOrReset()
+        -> QUICStreamStateMachine.ConsumeFinOrResetAction
     {
         switch consume self {
         case .connected(var connected):

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -366,7 +366,7 @@ struct QUICStreamReceiveStateMachineTests {
         let canRead = sm.canRead
         let isTerminal = sm.isTerminal
         let hasReceivedFin = sm.hasReceivedFin
-        let wasReset = sm.wasReset
+        let wasReset = sm.hasReceivedReset
         let resetErrorCode = sm.resetErrorCode
         let canProduceData = sm.canProduceData
         #expect(canRead)
@@ -388,7 +388,7 @@ struct QUICStreamReceiveStateMachineTests {
             Issue.record("Expected .ignore(.alreadyFullyReceived)")
             return
         }
-        let wasReset = sm.wasReset
+        let wasReset = sm.hasReceivedReset
         #expect(!wasReset)
     }
 
@@ -441,7 +441,7 @@ struct QUICStreamReceiveStateMachineTests {
             return
         }
         let isTerminal = sm.isTerminal
-        let wasReset = sm.wasReset
+        let wasReset = sm.hasReceivedReset
         #expect(isTerminal)
         #expect(!wasReset)
     }
@@ -464,7 +464,7 @@ struct QUICStreamReceiveStateMachineTests {
         }
         #expect(deliveredCode == QUICApplicationErrorCode(77))
         let isTerminal = sm.isTerminal
-        let wasReset = sm.wasReset
+        let wasReset = sm.hasReceivedReset
         let resetErrorCode = sm.resetErrorCode
         #expect(isTerminal)
         #expect(wasReset)
@@ -490,7 +490,7 @@ struct QUICStreamReceiveStateMachineTests {
         #expect(code == QUICApplicationErrorCode(42))
 
         let canRead = sm.canRead
-        let wasReset = sm.wasReset
+        let wasReset = sm.hasReceivedReset
         let canProduceData = sm.canProduceData
         #expect(!canRead)
         #expect(wasReset)


### PR DESCRIPTION
### Motivation

* Preparing for future half-closure-correctness PRs
* `applicationRead` is used for its side effects in `completeRead` which is semantically unclear.
* `QUICStreamReceiveStateMachine.wasReset` may be easily conflated with `QUICStreamSendStateMachine.wasReset` at usage sites.

### Modifications

* Two pure refactoring commits:
  * Extract code for flushing read data and surfacing completions (this will soon be re-used)
  * Extract code into a method to workaround a compiler crash
* Introduce `consumeReceiveTerminator` in `completeRead` which is explicit about its intent meaning we don't need to handle inappropriate returned actions.
* `QUICStreamReceiveStateMachine.wasReset` renamed to `hasReceivedReset`, parallel to `hasReceivedFin`.

### Result

* Clearer code which will make for clearer half-closure PR reviews.
