### PR TITLE
Store protocol reference

### DIFF
--- a/.github/workflows/http3_integration_tests.yml
+++ b/.github/workflows/http3_integration_tests.yml
@@ -22,7 +22,8 @@ jobs:
           echo "integration-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_LINUX_SETUP_COMMAND: 'git clone --depth 1 https://github.com/apple/swift-nio-http3.git ../swift-nio-http3 && swift package --package-path ../swift-nio-http3 edit swift-nio-quic --path "$workspace"'
-          MATRIX_LINUX_COMMAND: "SWIFT_CERTIFICATES_ALLOW_SWIFT_CRYPTO_BETA=1 swift test --package-path ../swift-nio-http3 --filter H3IntegrationTests"
+          MATRIX_LINUX_COMMAND: "swift test --package-path ../swift-nio-http3 --filter H3IntegrationTests"
+          MATRIX_LINUX_ENV_VARS_JSON: '{"SWIFT_CERTIFICATES_ALLOW_SWIFT_CRYPTO_BETA": "1"}'
 
   integration-tests:
     name: Integration tests

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -75,8 +75,8 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     private let role: Role
     private let keepAliveInterval: Duration?
     private let logger: Logger
+    internal var reference: ProtocolInstanceReference = ProtocolInstanceReference()
 
-    internal var reference: ProtocolInstanceReference { ProtocolInstanceReference(custom: self) }
     internal var eventManager = ProtocolEventManager()
     internal var streamStateMachine: QUICStreamStateMachine
     internal var pipelineStateMachine: QUICStreamPipelineStateMachine
@@ -143,6 +143,9 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         self._isWritable = Atomic(true)
         self._closePromise = connectionChannel.eventLoop.makePromise(of: Void.self)
         self._pipeline = ChannelPipeline(channel: self)
+
+        // This creates a retain cycle, it's broken in close '_close(error:promise:)'
+        self.reference = ProtocolInstanceReference(custom: self)
     }
 
     internal init?(
@@ -180,6 +183,9 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         self._isActive = Atomic(false)
         self._isWritable = Atomic(true)
         self._closePromise = eventLoop.makePromise(of: Void.self)
+
+        // This creates a retain cycle, it's broken in close '_close(error:promise:)'
+        self.reference = ProtocolInstanceReference(custom: self)
 
         let linkage: OutboundStreamLinkage
         do throws(NetworkError) {
@@ -1225,6 +1231,8 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
             if let disconnect = self.disconnectedEventHandler {
                 disconnect(nil)
             }
+            // Break the retain cycle between the ref and self.
+            self.reference = ProtocolInstanceReference()
             self.clearHandlers()
         }
     }


### PR DESCRIPTION
Motivation:

The ProtocolInstanceReference on the QUICChannelStreamHandler is currently a computed property which does work every time its accessed. Just store it instead, ensuring it's nil'd out when tearing down the stream handler to break the retain cycle (as it has a ref to the stream handler).

Modifications:

- Create and store a ProtocolInstanceReference in init
- Break the retain cycle in close

Result:

A small perf improvement, 1-1.5%