### PR TITLE
Cleanup capturing closures

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
@@ -68,6 +68,11 @@ final class QUICChannelOutputHandler: ProtocolInstanceContainer, OutboundDatagra
         self.finalizeOutputFramesHandler = finalizeOutputFramesHandler
     }
 
+    func clearHandlers() {
+        self.inputFramesHandler = nil
+        self.finalizeOutputFramesHandler = nil
+    }
+
     /// Local logging function to debug the datapath
     ///
     /// This layer adds the context and fetches the message only if the debug flags are enabled.

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -877,6 +877,8 @@ final class SwiftNetworkQUICConnection {
             connectionNewFlowHandler.teardown()
         }
         self.connectionNewFlowHandler = nil
+        // Break cycle with outputHandler, which holds closures that capture self, i.e., the connection.
+        self.outputHandler.clearHandlers()
     }
 
     /// Action returned by `close()` indicating what happened.

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -902,6 +902,12 @@ final class SwiftNetworkQUICConnection {
             return .alreadyClosed
         }
 
+        // Capture before initiateClose() below mutates the state machine. A `.connecting`
+        // connection transitions straight to `.closed`, and `hasEstablishedConnection`
+        // reports `true` for `.closed` unconditionally - so reading it afterwards would
+        // always say "established" even for a connection that never left `.connecting`.
+        let hasEstablishedConnection = self.connectionStateMachine.hasEstablishedConnection
+
         // Transition state machine to closing state FIRST, before SwiftNetwork cleanup
         // This is crucial because newFlowHandler.stop() synchronously fires disconnected event
         let action = self.connectionStateMachine.initiateClose(
@@ -937,7 +943,7 @@ final class SwiftNetworkQUICConnection {
 
         // For connections that never established (still in idle or early handshake states),
         // clean up synchronously.
-        if !self.connectionStateMachine.hasEstablishedConnection {
+        if !hasEstablishedConnection {
             // Never established - clean up synchronously
             self.tearDownConnectionState()
             assert(

--- a/Tests/NIOQUICTests/QUICConnectionChannelHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelHandlerTests.swift
@@ -65,11 +65,27 @@ final class QUICConnectionChannelHandlerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
 
-        XCTAssertNoThrow(try self.channel.close().wait())
+        if self.channel.isActive {
+            XCTAssertNoThrow(try self.channel.close().wait())
+        }
         self.eventLoop = nil
         self.channel = nil
         self.serverHandler = nil
         self.quicConnection = nil
+    }
+
+    func testClosingConnectionAllowsDeinit() throws {
+        weak let weakConnection = self.quicConnection
+
+        _ = self.quicConnection.close(sendApplicationClose: false, errorCode: 0, reason: "test")
+        self.quicConnection = nil
+        self.serverHandler = nil
+        try self.channel.close().wait()
+        // EmbeddedChannel.close0 defers pipeline.removeHandlers() to the event loop's task
+        // queue; run() flushes it so the pipeline actually releases its handlers.
+        self.eventLoop.run()
+
+        XCTAssertNil(weakConnection, "SwiftNetworkQUICConnection should deinit once closed and released")
     }
 
     func testChannelReadComplete_whenNoWrite() throws {


### PR DESCRIPTION
### Motivation

The SwiftNetworkQUICConnection is kept alive after a connection finishes.

### Modifications

Cleanup callbacks in the output handler that capture refs to the connection.

### Result

Less leaking.