### PR TITLE
Dedupe quic options when setting up SwiftNetworkQUICConnection

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamOptions+QUICConfiguration.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamOptions+QUICConfiguration.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+@_spi(SwiftTLSOptions) @_spi(SwiftTLSProtocol) import SwiftTLS
+
+@available(anyAppleOS 26, *)
+extension QUICProtocol {
+    static func options(
+        from config: QUICConfiguration
+    ) throws -> ProtocolOptions<QUICStreamProtocol> {
+        let options = Self.options()
+
+        options.connectionOptions.initialMaxData = UInt64(config.initialMaxData)
+        options.connectionOptions.initialMaxStreamDataBidirectionalLocal = UInt64(config.initialMaxStreamDataBidiLocal)
+        options.connectionOptions.initialMaxStreamDataBidirectionalRemote = UInt64(
+            config.initialMaxStreamDataBidiRemote
+        )
+        options.connectionOptions.initialMaxStreamDataUnidirectional = UInt64(config.initialMaxStreamDataUni)
+        options.connectionOptions.initialMaxStreamsBidirectional = UInt64(config.initialMaxStreamsBidi)
+        options.connectionOptions.maximumConcurrentBidirectionalStreams = config.initialMaxStreamsBidi
+        options.connectionOptions.initialMaxStreamsUnidirectional = UInt64(config.initialMaxStreamsUni)
+        options.connectionOptions.maximumConcurrentUnidirectionalStreams = config.initialMaxStreamsUni
+
+        guard let perProtocolOptions = options.perProtocolOptions else {
+            throw QUICError.invalidConfiguration
+        }
+
+        perProtocolOptions.quicConnectionOptions.idleTimeout = NetworkDuration(duration: config.maxIdleTimeout)
+
+        if let qLogConfiguration = config.qLogConfiguration {
+            perProtocolOptions.quicConnectionOptions.qlogConfiguration = QLogConfiguration(
+                logTitle: qLogConfiguration.topic.isEmpty ? nil : qLogConfiguration.topic,
+                logDescription: qLogConfiguration.description.isEmpty ? nil : qLogConfiguration.description,
+                logPath: qLogConfiguration.path
+            )
+        }
+
+        return options
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension TLSProtocol.Options {
+    static func serverOptions(
+        from config: QUICConfiguration,
+        authConfig: AuthenticationConfiguration,
+        authenticator: Authenticator?,
+        serverName: String
+    ) throws -> Self {
+        var options = SwiftTLSProtocol.Options()
+        options.applicationProtocols = config.applicationProtocols
+        options.serverName = serverName
+        options.tlsOptions.keyExchangeGroup = config.keyExchangeGroup.swiftTLSKeyExchangeGroup
+
+        switch authConfig {
+        case .x509Certificates:
+            guard let authenticator else {
+                throw QUICError.tlsConfigurationIncomplete
+            }
+            options.tlsOptions.asyncAuthenticator = .init(
+                supportedCertificateTypes: [.x509],
+                getCertificateChain: authenticator.produceCertificates(info:),
+                signTranscriptHash: authenticator.provideSignature(info:)
+            )
+
+        case .rawPublicKeys(let publicKeyFilePath, let privateKeyFilePath):
+            let publicKey = try P256.Signing.PublicKey.fromDERFile(publicKeyFilePath)
+            options.trustedRawPublicKeyCertificates = [Array(publicKey.derRepresentation)]
+
+            let privateKey = try P256.Signing.PrivateKey.fromDERFile(privateKeyFilePath)
+            options.rawPrivateKey = Array(privateKey.rawRepresentation)
+        }
+
+        return options
+    }
+
+    static func clientOptions(
+        from config: QUICConfiguration,
+        asyncVerifier: AsyncVerifier?,
+        serverName: String
+    ) throws -> Self {
+        var options = SwiftTLSProtocol.Options()
+        options.applicationProtocols = config.applicationProtocols
+        options.serverName = serverName
+        options.tlsOptions.keyExchangeGroup = config.keyExchangeGroup.swiftTLSKeyExchangeGroup
+
+        if let verificationConfiguration = config.verificationConfiguration {
+            switch verificationConfiguration {
+            case .rawPublicKeys(let publicKeyFilePath):
+                let publicKey = try P256.Signing.PublicKey.fromDERFile(publicKeyFilePath)
+                options.trustedRawPublicKeyCertificates = [Array(publicKey.derRepresentation)]
+
+            case .x509Certificates:
+                if let asyncVerifier {
+                    options.tlsOptions.asyncVerifier = .init(
+                        availableCertificateTypes: [.x509],
+                        verificationCallback: asyncVerifier.makeCallback(hostname: serverName)
+                    )
+                } else {
+                    throw QUICError.tlsConfigurationIncomplete
+                }
+            }
+        }
+
+        return options
+    }
+
+}

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -235,76 +235,36 @@ final class SwiftNetworkQUICConnection {
         swiftNetworkParameters.context = networkContext
         self.networkContext = networkContext
         swiftNetworkParameters.isServer = true
-        let quicOptions = QUICStreamProtocol.options()
-        guard let perProtocolOptions = quicOptions.perProtocolOptions else {
-            throw QUICError.invalidConfiguration
-        }
-        sourceConnectionID.withUnsafeBufferPointer { bufferPointer in
-            perProtocolOptions.quicConnectionOptions.sourceConnectionID = Array(bufferPointer)
-        }
-        perProtocolOptions.quicConnectionOptions.disableAutomaticNewConnectionIDs = true
-        quicOptions.connectionOptions.initialMaxData = UInt64(configuration.initialMaxData)
-        quicOptions.connectionOptions.initialMaxStreamDataBidirectionalLocal = UInt64(
-            configuration.initialMaxStreamDataBidiLocal
-        )
-        quicOptions.connectionOptions.initialMaxStreamDataBidirectionalRemote = UInt64(
-            configuration.initialMaxStreamDataBidiRemote
-        )
-        quicOptions.connectionOptions.initialMaxStreamDataUnidirectional = UInt64(configuration.initialMaxStreamDataUni)
-        quicOptions.connectionOptions.initialMaxStreamsBidirectional = UInt64(configuration.initialMaxStreamsBidi)
-        quicOptions.connectionOptions.maximumConcurrentBidirectionalStreams = configuration.initialMaxStreamsBidi
-        quicOptions.connectionOptions.initialMaxStreamsUnidirectional = UInt64(configuration.initialMaxStreamsUni)
-        quicOptions.connectionOptions.maximumConcurrentUnidirectionalStreams = configuration.initialMaxStreamsUni
-        quicOptions.connectionOptions.retry = configuration.sendRetry
-        perProtocolOptions.quicConnectionOptions.idleTimeout = NetworkDuration(duration: configuration.maxIdleTimeout)
-        if let qLogConfiguration = configuration.qLogConfiguration {
-            logger.info("Enabling QLog: \(qLogConfiguration)")
-            perProtocolOptions.quicConnectionOptions.qlogConfiguration = QLogConfiguration(
-                logTitle: qLogConfiguration.topic.isEmpty ? nil : qLogConfiguration.topic,
-                logDescription: qLogConfiguration.description.isEmpty ? nil : qLogConfiguration.description,
-                logPath: qLogConfiguration.path
-            )
-        }
-        self.streamOptions = perProtocolOptions
-        let swiftNetworkQUICConnection = SwiftNetwork.QUICConnection(
-            context: swiftNetworkParameters.context
-        )
-        quicOptions.setProtocolInstance(swiftNetworkQUICConnection.reference)
 
-        self.swiftNetworkParameters = swiftNetworkParameters
-        self.swiftNetworkQUICConnection = swiftNetworkQUICConnection
-        var tlsOptions = SwiftTLSProtocol.Options()
-
-        tlsOptions.applicationProtocols = configuration.applicationProtocols
-        tlsOptions.serverName = serverName
-
-        guard let authConfiguration = configuration.authenticationConfiguration else {
+        guard let authConfig = configuration.authenticationConfiguration else {
             // Either keys for rawPublicKeyAuthenticaiton or certificates are required.
             throw QUICError.tlsConfigurationIncomplete
         }
 
-        switch authConfiguration {
-        case .x509Certificates:
-            guard let authenticator else {
-                throw QUICError.tlsConfigurationIncomplete
-            }
-            tlsOptions.tlsOptions.asyncAuthenticator = .init(
-                supportedCertificateTypes: [.x509],
-                getCertificateChain: authenticator.produceCertificates(info:),
-                signTranscriptHash: authenticator.provideSignature(info:)
-            )
+        let quicOptions = try QUICStreamProtocol.options(from: configuration)
+        // 'retry' is a server-only option.
+        quicOptions.connectionOptions.retry = configuration.sendRetry
+        quicOptions.tlsOptions = try .serverOptions(
+            from: configuration,
+            authConfig: authConfig,
+            authenticator: authenticator,
+            serverName: serverName
+        )
 
-        case .rawPublicKeys(let publicKeyFilePath, let privateKeyFilePath):
-            let publicKey = try P256.Signing.PublicKey.fromDERFile(publicKeyFilePath)
-            tlsOptions.trustedRawPublicKeyCertificates = [Array(publicKey.derRepresentation)]
+        // '!' is okay: the `options(...)` call above throws if this isn't set.
+        let perProtocolOptions = quicOptions.perProtocolOptions!
+        self.streamOptions = perProtocolOptions
 
-            let privateKey = try P256.Signing.PrivateKey.fromDERFile(privateKeyFilePath)
-            tlsOptions.rawPrivateKey = Array(privateKey.rawRepresentation)
+        perProtocolOptions.quicConnectionOptions.disableAutomaticNewConnectionIDs = true
+        sourceConnectionID.withUnsafeBufferPointer { bufferPointer in
+            perProtocolOptions.quicConnectionOptions.sourceConnectionID = Array(bufferPointer)
         }
 
-        tlsOptions.tlsOptions.keyExchangeGroup = configuration.keyExchangeGroup.swiftTLSKeyExchangeGroup
+        let swiftNetworkQUICConnection = SwiftNetwork.QUICConnection(context: swiftNetworkParameters.context)
+        quicOptions.setProtocolInstance(swiftNetworkQUICConnection.reference)
 
-        quicOptions.tlsOptions = tlsOptions
+        self.swiftNetworkParameters = swiftNetworkParameters
+        self.swiftNetworkQUICConnection = swiftNetworkQUICConnection
 
         self.connectionQLogID = Self.nextServerConnectionQLogID()
         quicOptions.setLogID(prefix: "L", parent: "1", protocolLogIDNumber: self.connectionQLogID)
@@ -414,70 +374,33 @@ final class SwiftNetworkQUICConnection {
         swiftNetworkParameters.isServer = false
 
         let swiftNetworkPath = SwiftNetwork.PathProperties(parameters: swiftNetworkParameters)
-        let quicOptions = QUICStreamProtocol.options()
-        guard let perProtocolOptions = quicOptions.perProtocolOptions else {
-            throw QUICError.invalidConfiguration
-        }
+
+        let quicOptions = try QUICStreamProtocol.options(from: configuration)
+        quicOptions.tlsOptions = try .clientOptions(
+            from: configuration,
+            asyncVerifier: asyncVerifier,
+            serverName: serverName
+        )
+        // 'forceVersionNegotiation' is client-only.
+        quicOptions.connectionOptions.forceVersionNegotiation = configuration.forceVersionNegotiation
+
+        // '!' is okay: the `options(...)` call above throws if this isn't set.
+        let perProtocolOptions = quicOptions.perProtocolOptions!
+        self.streamOptions = perProtocolOptions
+
         sourceConnectionID.withUnsafeBufferPointer { bufferPointer in
             quicOptions.connectionOptions.sourceConnectionID = Array(bufferPointer)
         }
-        quicOptions.connectionOptions.initialMaxData = UInt64(configuration.initialMaxData)
-        quicOptions.connectionOptions.initialMaxStreamDataBidirectionalLocal = UInt64(
-            configuration.initialMaxStreamDataBidiLocal
-        )
-        quicOptions.connectionOptions.initialMaxStreamDataBidirectionalRemote = UInt64(
-            configuration.initialMaxStreamDataBidiRemote
-        )
-        quicOptions.connectionOptions.initialMaxStreamDataUnidirectional = UInt64(configuration.initialMaxStreamDataUni)
-        quicOptions.connectionOptions.initialMaxStreamsBidirectional = UInt64(configuration.initialMaxStreamsBidi)
-        quicOptions.connectionOptions.maximumConcurrentBidirectionalStreams = configuration.initialMaxStreamsBidi
-        quicOptions.connectionOptions.initialMaxStreamsUnidirectional = UInt64(configuration.initialMaxStreamsUni)
-        quicOptions.connectionOptions.maximumConcurrentUnidirectionalStreams = configuration.initialMaxStreamsUni
-        quicOptions.connectionOptions.forceVersionNegotiation = configuration.forceVersionNegotiation
+
         perProtocolOptions.quicConnectionOptions.idleTimeout = NetworkDuration(duration: configuration.maxIdleTimeout)
         perProtocolOptions.quicConnectionOptions.disableAutomaticNewConnectionIDs = true
-        if let qLogConfiguration = configuration.qLogConfiguration {
-            logger.info("Enabling QLog: \(qLogConfiguration)")
-            perProtocolOptions.quicConnectionOptions.qlogConfiguration = QLogConfiguration(
-                logTitle: qLogConfiguration.topic.isEmpty ? nil : qLogConfiguration.topic,
-                logDescription: qLogConfiguration.description.isEmpty ? nil : qLogConfiguration.description,
-                logPath: qLogConfiguration.path
-            )
-        }
-        self.streamOptions = perProtocolOptions
+
         let swiftNetworkQUICConnection = SwiftNetwork.QUICConnection(
             context: swiftNetworkParameters.context
         )
         self.swiftNetworkParameters = swiftNetworkParameters
         self.swiftNetworkQUICConnection = swiftNetworkQUICConnection
         quicOptions.setProtocolInstance(self.swiftNetworkQUICConnection.reference)
-
-        var tlsOptions = SwiftTLSProtocol.Options()
-        tlsOptions.applicationProtocols = configuration.applicationProtocols
-
-        tlsOptions.serverName = serverName
-
-        if let verificationConfiguration = configuration.verificationConfiguration {
-            switch verificationConfiguration {
-            case .rawPublicKeys(let publicKeyFilePath):
-                let publicKey = try P256.Signing.PublicKey.fromDERFile(publicKeyFilePath)
-                tlsOptions.trustedRawPublicKeyCertificates = [Array(publicKey.derRepresentation)]
-
-            case .x509Certificates:
-                if let asyncVerifier {
-                    tlsOptions.tlsOptions.asyncVerifier = .init(
-                        availableCertificateTypes: [.x509],
-                        verificationCallback: asyncVerifier.makeCallback(hostname: serverName)
-                    )
-                } else {
-                    throw QUICError.tlsConfigurationIncomplete
-                }
-            }
-        }
-
-        tlsOptions.tlsOptions.keyExchangeGroup = configuration.keyExchangeGroup.swiftTLSKeyExchangeGroup
-
-        quicOptions.tlsOptions = tlsOptions
 
         // TODO: is this (C,1) significant?
         self.connectionQLogID = Self.nextClientConnectionQLogID()

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -253,9 +253,9 @@ final class SwiftNetworkQUICConnection {
 
         // '!' is okay: the `options(...)` call above throws if this isn't set.
         let perProtocolOptions = quicOptions.perProtocolOptions!
+        perProtocolOptions.quicConnectionOptions.disableAutomaticNewConnectionIDs = true
         self.streamOptions = perProtocolOptions
 
-        perProtocolOptions.quicConnectionOptions.disableAutomaticNewConnectionIDs = true
         sourceConnectionID.withUnsafeBufferPointer { bufferPointer in
             perProtocolOptions.quicConnectionOptions.sourceConnectionID = Array(bufferPointer)
         }
@@ -386,14 +386,13 @@ final class SwiftNetworkQUICConnection {
 
         // '!' is okay: the `options(...)` call above throws if this isn't set.
         let perProtocolOptions = quicOptions.perProtocolOptions!
+        perProtocolOptions.quicConnectionOptions.disableAutomaticNewConnectionIDs = true
         self.streamOptions = perProtocolOptions
 
         sourceConnectionID.withUnsafeBufferPointer { bufferPointer in
             quicOptions.connectionOptions.sourceConnectionID = Array(bufferPointer)
         }
 
-        perProtocolOptions.quicConnectionOptions.idleTimeout = NetworkDuration(duration: configuration.maxIdleTimeout)
-        perProtocolOptions.quicConnectionOptions.disableAutomaticNewConnectionIDs = true
 
         let swiftNetworkQUICConnection = SwiftNetwork.QUICConnection(
             context: swiftNetworkParameters.context

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -393,7 +393,6 @@ final class SwiftNetworkQUICConnection {
             quicOptions.connectionOptions.sourceConnectionID = Array(bufferPointer)
         }
 
-
         let swiftNetworkQUICConnection = SwiftNetwork.QUICConnection(
             context: swiftNetworkParameters.context
         )


### PR DESCRIPTION
Motivation:

A lot of the QUIC options derived from QUICConfiguration were duped between the two large inits.

Modifications:

Dedupe somewhat where possible

Result:

No semantics change. Less duplicated code.