### PR TITLE
Do not propagate stream channels on connection

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannelHandler.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannelHandler.swift
@@ -186,8 +186,8 @@ final class QUICConnectionChannelHandler {
 @available(anyAppleOS 26, *)
 extension QUICConnectionChannelHandler: ChannelInboundHandler, ChannelOutboundHandler {
     typealias InboundIn = QUICConnectionChannelInboundMessage
-    typealias InboundOut = any Channel
-    typealias OutboundIn = Any
+    typealias InboundOut = Never
+    typealias OutboundIn = Never
     typealias OutboundOut = QUICConnectionChannelOutboundMessage
 
     func handlerAdded(context: ChannelHandlerContext) {
@@ -246,9 +246,9 @@ extension QUICConnectionChannelHandler: ChannelInboundHandler, ChannelOutboundHa
                 case .multiplexer(let continuation):
                     stream.initialize(multiplexerContinuation: continuation, streamID: readableStreamMessage.streamID)
                 case .closure(let initializer):
-                    stream.initialize(context, initializer)
+                    stream.initialize(initializer)
                 case .none:
-                    stream.initialize(context)
+                    stream.initialize()
                 }
             }
 

--- a/Sources/NIOQUIC/QUICHandler.swift
+++ b/Sources/NIOQUIC/QUICHandler.swift
@@ -280,8 +280,10 @@ public final class QUICHandler {
         remoteAddress: SocketAddress,
         connectionInitializer: @escaping @Sendable (any Channel, QUICStreamCreator) -> EventLoopFuture<Void>,
         inboundStreamInitializer: @escaping @Sendable (any Channel) -> EventLoopFuture<Void>
-    ) -> EventLoopFuture<any Channel> {
+    ) -> EventLoopFuture<(any Channel, QUICStreamCreator)> {
         let channelPromise = self.eventLoop.makePromise(of: (any Channel).self)
+        let creatorPromise = self.eventLoop.makePromise(of: QUICStreamCreator.self)
+        channelPromise.futureResult.cascadeFailure(to: creatorPromise)
 
         do {
             let role = self.quicConfiguration.role
@@ -316,14 +318,15 @@ public final class QUICHandler {
 
                     return (channel, connectionChannelHandler.makeStreamCreator(role: .client))
                 }.flatMap { channel, streamCreator in
-                    connectionInitializer(channel, streamCreator)
+                    creatorPromise.succeed(streamCreator)
+                    return connectionInitializer(channel, streamCreator)
                 }
             }
         } catch {
             channelPromise.fail(error)
         }
 
-        return channelPromise.futureResult
+        return channelPromise.futureResult.and(creatorPromise.futureResult)
     }
 
     /// Shuts the server down gracefully.

--- a/Sources/NIOQUIC/QUICHandler.swift
+++ b/Sources/NIOQUIC/QUICHandler.swift
@@ -272,11 +272,9 @@ public final class QUICHandler {
     ///   - serverName: The server to connect to.
     ///   - remoteAddress: The address to connect to.
     ///   - connectionInitializer: How to initialize the connection. This closure will be called with a channel and a stream creator.
-    ///   - inboundStreamInitializer: How to initialize any inbound streams on the new connection. This closure will be called with the stream channel.
-    ///     The returned channel is a QUIC connection channel. You can create streams on that channel by using the provided stream creator.
-    ///     You will receive inbound stream channels as inbound reads on the connection channel.
-    ///     You will likely want to use this closure to add a handler with an InboundIn = any Channel. Then in channelRead, you can initialize the stream channels.
-    /// - Returns: The initialized connection channel.
+    ///   - inboundStreamInitializer: How to initialize any inbound streams on the new connection. This closure is
+    ///     called with each new inbound stream channel; it is the only place inbound streams are surfaced. Add your per-stream handlers here.
+    /// - Returns: The initialized connection channel. Open outbound streams on it with the provided stream creator.
     public func createOutboundConnection(
         serverName: String,
         remoteAddress: SocketAddress,

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -479,10 +479,8 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
             }
     }
 
-    /// Run the closure-style initializer; on success deliver the ready stream
-    /// up `context` and trigger the first read.
+    /// Run the closure-style initializer; on success trigger the first read.
     internal func initialize(
-        _ context: ChannelHandlerContext,
         _ initializer: @escaping @Sendable (any Channel) -> EventLoopFuture<Void>
     ) {
         initializer(self).assumeIsolated().whenComplete { result in
@@ -490,7 +488,6 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
             case .success:
                 switch self.pipelineStateMachine.markInitializerComplete() {
                 case .surfaceInitializedStream:
-                    context.fireChannelRead(QUICConnectionChannelHandler.wrapInboundOut(self))
                     self.tryToAutoRead()
                 case .ignoreAlreadyComplete:
                     break
@@ -502,12 +499,10 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         }
     }
 
-    /// No initializer to run; synchronously deliver the stream up `context`
-    /// and trigger the first read.
-    internal func initialize(_ context: ChannelHandlerContext) {
+    /// No initializer to run; just trigger the first read.
+    internal func initialize() {
         switch self.pipelineStateMachine.markInitializerComplete() {
         case .surfaceInitializedStream:
-            context.fireChannelRead(QUICConnectionChannelHandler.wrapInboundOut(self))
             self.tryToAutoRead()
         case .ignoreAlreadyComplete:
             break

--- a/Tests/IntegrationTests/ChannelHierarchyTests.swift
+++ b/Tests/IntegrationTests/ChannelHierarchyTests.swift
@@ -83,21 +83,22 @@ final class ChannelHierarchyTests: XCTestCase {
 
         // Open an outbound connection so we can hook the connection initializer
         // and add ConnectionMarker before any stream is created.
-        let (connectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(ConnectionMarker())
+        let (connectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeCompletedFuture {
+                            try connectionChannel.pipeline.syncOperations.addHandler(ConnectionMarker())
+                        }
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
                     }
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+                )
+            }.get()
 
         // Open an outbound stream and verify hierarchy in its initializer.
         let streamChannel = try await streamCreator.createBidirectionalStream { parameters in

--- a/Tests/IntegrationTests/ChannelHierarchyTests.swift
+++ b/Tests/IntegrationTests/ChannelHierarchyTests.swift
@@ -83,7 +83,7 @@ final class ChannelHierarchyTests: XCTestCase {
 
         // Open an outbound connection so we can hook the connection initializer
         // and add ConnectionMarker before any stream is created.
-        let connectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (connectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
@@ -100,11 +100,6 @@ final class ChannelHierarchyTests: XCTestCase {
         }.get()
 
         // Open an outbound stream and verify hierarchy in its initializer.
-        let streamCreator = try await connectionChannel.eventLoop.submit {
-            try connectionChannel.pipeline.syncOperations.handler(type: QUICConnectionChannelHandler.self)
-                .makeStreamCreator(role: .client)
-        }.get()
-
         let streamChannel = try await streamCreator.createBidirectionalStream { parameters in
             parameters.channel.eventLoop.makeCompletedFuture {
                 Self.assertHierarchy(forStream: parameters.channel, promise: clientVerified)

--- a/Tests/IntegrationTests/SyncIntegrationTests.swift
+++ b/Tests/IntegrationTests/SyncIntegrationTests.swift
@@ -1119,7 +1119,7 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+        let (_, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
             .flatMap {
                 quicHandler in
                 quicHandler.createOutboundConnection(
@@ -1214,7 +1214,7 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+        let (_, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
             .flatMap {
                 quicHandler in
                 quicHandler.createOutboundConnection(
@@ -1681,7 +1681,7 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, clientStreamCreator) = try await clientChannel.pipeline.handler(
+        let (clientConnectionChannel, _) = try await clientChannel.pipeline.handler(
             type: QUICHandler.self
         ).flatMap {
             quicHandler in
@@ -1778,7 +1778,7 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+        let (_, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
             .flatMap {
                 quicHandler in
                 quicHandler.createOutboundConnection(
@@ -1858,7 +1858,7 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+        let (_, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
             .flatMap {
                 quicHandler in
                 quicHandler.createOutboundConnection(
@@ -1939,7 +1939,7 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+        let (_, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
             .flatMap {
                 quicHandler in
                 quicHandler.createOutboundConnection(

--- a/Tests/IntegrationTests/SyncIntegrationTests.swift
+++ b/Tests/IntegrationTests/SyncIntegrationTests.swift
@@ -917,19 +917,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let clientCloseFutures: [EventLoopFuture<Void>] = (0..<requestCount).map { requestNumber in
             let streamID: NIOLoopBoundBox<UInt64> = NIOLoopBoundBox.makeBoxSendingValue(
@@ -1015,19 +1016,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         var clientCloseFutures: [EventLoopFuture<Void>] = []
         for requestNumber in (0..<requestCount) {
@@ -1117,19 +1119,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let clientCloseFutures: [EventLoopFuture<Void>] = (0..<requestCount).map { requestNumber in
             let streamChannel = streamCreator.createBidirectionalStream { streamInitializer in
@@ -1211,19 +1214,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         var clientCloseFutures: [EventLoopFuture<Void>] = []
         for requestNumber in (0..<requestCount) {
@@ -1293,21 +1297,22 @@ final class SyncIntegrationTests: XCTestCase {
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientChannel.eventLoop)
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(errorCatcher)
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeCompletedFuture {
+                            try connectionChannel.pipeline.syncOperations.addHandler(errorCatcher)
+                        }
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
                     }
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+                )
+            }.get()
 
         let _ = streamCreator.createBidirectionalStream { streamInitializer in
             XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
@@ -1363,19 +1368,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)
 
@@ -1445,19 +1451,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)
 
@@ -1531,19 +1538,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, streamCreator in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)
 
@@ -1598,7 +1606,9 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, clientStreamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, clientStreamCreator) = try await clientChannel.pipeline.handler(
+            type: QUICHandler.self
+        ).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
@@ -1671,7 +1681,9 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, clientStreamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, clientStreamCreator) = try await clientChannel.pipeline.handler(
+            type: QUICHandler.self
+        ).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
@@ -1766,19 +1778,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, streamCreator in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
             XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
@@ -1845,22 +1858,23 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        // Capture the client connection's close future
-                        connectionChannel.closeFuture.cascade(to: clientConnectionClosedPromise)
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, streamCreator in
+                        connectionChannel.eventLoop.makeCompletedFuture {
+                            // Capture the client connection's close future
+                            connectionChannel.closeFuture.cascade(to: clientConnectionClosedPromise)
+                        }
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
                     }
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+                )
+            }.get()
 
         let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
             streamInitializer.channel.eventLoop.makeCompletedFuture {
@@ -1925,19 +1939,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, streamCreator in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
             XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
@@ -1990,19 +2005,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         // Create a stream and send stopSending, then verify the channel is still open for writes
         let requestStreamChannel = try await streamCreator.createBidirectionalStream { streamInitializer in
@@ -2063,19 +2079,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, _ in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, _ in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let responseBuffer = NIOLockedValueBox(ByteBuffer())
         let gotResponsePromise = clientConnectionChannel.eventLoop.makePromise(of: Void.self)
@@ -2159,19 +2176,20 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
-            quicHandler in
-            quicHandler.createOutboundConnection(
-                serverName: "\(host):\(serverPort)",
-                remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeSucceededVoidFuture()
-                },
-                inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
-                }
-            )
-        }.get()
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self)
+            .flatMap {
+                quicHandler in
+                quicHandler.createOutboundConnection(
+                    serverName: "\(host):\(serverPort)",
+                    remoteAddress: try! .init(ipAddress: host, port: serverPort),
+                    connectionInitializer: { connectionChannel, streamCreator in
+                        connectionChannel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    inboundStreamInitializer: { streamChannel in
+                        streamChannel.eventLoop.makeSucceededVoidFuture()
+                    }
+                )
+            }.get()
 
         let stopSendingEventReceived = clientConnectionChannel.eventLoop.makePromise(of: Void.self)
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)

--- a/Tests/IntegrationTests/SyncIntegrationTests.swift
+++ b/Tests/IntegrationTests/SyncIntegrationTests.swift
@@ -24,31 +24,15 @@ import XCTest
 
 @testable import NIOQUIC
 
-/// Reads in quic stream channels, runs the inboundStreamInitializer on them, then passes them down
+/// Holds the stream creator so tests can open outbound streams on a connection.
 @available(anyAppleOS 26, *)
 final class HTTPConnectionHandler: ChannelInboundHandler {
-    typealias InboundIn = any Channel  // stream channels
-    typealias InboundOut = any Channel  // Pass through the stream channels
+    typealias InboundIn = NIOAny
 
     fileprivate let streamCreator: NIOQUIC.QUICStreamCreator
-    private let inboundStreamInitializer: @Sendable (any Channel) throws -> Void
 
-    init(
-        streamCreator: NIOQUIC.QUICStreamCreator,
-        inboundStreamInitializer: @Sendable @escaping (any Channel) throws -> Void
-    ) {
+    init(streamCreator: NIOQUIC.QUICStreamCreator) {
         self.streamCreator = streamCreator
-        self.inboundStreamInitializer = inboundStreamInitializer
-    }
-
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let streamChannel = self.unwrapInboundIn(data)
-        do {
-            try self.inboundStreamInitializer(streamChannel)
-            context.fireChannelRead(data)
-        } catch {
-            context.fireErrorCaught(error)
-        }
     }
 
     func createRequestStream<InitializerOutput: Sendable>(
@@ -56,59 +40,6 @@ final class HTTPConnectionHandler: ChannelInboundHandler {
             @escaping @Sendable (NIOQUICHelpers.QUICStreamInitializerParameters) -> EventLoopFuture<InitializerOutput>
     ) -> EventLoopFuture<InitializerOutput> {
         self.streamCreator.createBidirectionalStream(streamInitializer: streamInitializer)
-    }
-}
-
-/// This channel gives a connection error as soon as it reads an inbound quic stream
-@available(anyAppleOS 26, *)
-final class RejectEverythingHTTPConnectionHandler: ChannelInboundHandler {
-    typealias InboundIn = any Channel  // stream channels
-    typealias InboundOut = any Channel  // Pass through the stream channels
-
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        // immediately close the connection when we get a new inbound stream
-        context.triggerUserOutboundEvent(
-            NIOQUICHelpers.QUICCloseConnectionEvent(
-                code: NIOQUICHelpers.QUICApplicationErrorCode(10)!,
-                reasonPhrase: "test"
-            ),
-            promise: nil
-        )
-        context.fireChannelRead(data)
-    }
-}
-
-/// This channel immediately sends STOP_SENDING (with code 10) on every inbound stream.
-@available(anyAppleOS 26, *)
-final class StreamClosingHTTPConnectionHandler: ChannelInboundHandler {
-    typealias InboundIn = any Channel  // stream channels
-    typealias InboundOut = any Channel  // Pass through the stream channels
-
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        // immediately close the stream when we get a new inbound stream
-        let inboundStream = self.unwrapInboundIn(data)
-        inboundStream.triggerUserOutboundEvent(
-            NIOQUICHelpers.QUICStopSendingEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
-            promise: nil
-        )
-        context.fireChannelRead(data)
-    }
-}
-
-/// This channel immediately fires a RESET\_STREAM (with code 10) on every inbound stream.
-@available(anyAppleOS 26, *)
-final class StreamResettingHTTPConnectionHandler: ChannelInboundHandler {
-    typealias InboundIn = any Channel  // stream channels
-    typealias InboundOut = any Channel  // Pass through the stream channels
-
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        // immediately close the stream when we get a new inbound stream
-        let inboundStream = self.unwrapInboundIn(data)
-        inboundStream.triggerUserOutboundEvent(
-            NIOQUICHelpers.QUICResetStreamEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
-            promise: nil
-        )
-        context.fireChannelRead(data)
     }
 }
 
@@ -975,25 +906,21 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: {
-                                $0.closeFuture.whenSuccess {
-                                    let closedCount = serverRequestStreamClosedCount.withLockedValue {
-                                        $0 += 1
-                                        return $0
-                                    }
-                                    if closedCount == requestCount {
-                                        allServerRequestStreamsClosedPromise.succeed()
-                                    }
-                                }
-                                try $0.pipeline.syncOperations.addHandler(TestServerHandler())
-                            }
-                        )
-                    )
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.closeFuture.whenSuccess {
+                        let closedCount = serverRequestStreamClosedCount.withLockedValue {
+                            $0 += 1
+                            return $0
+                        }
+                        if closedCount == requestCount {
+                            allServerRequestStreamsClosedPromise.succeed()
+                        }
+                    }
+                    try streamChannel.pipeline.syncOperations.addHandler(TestServerHandler())
                 }
             },
             noMoreConnections: {
@@ -1016,11 +943,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1083,25 +1008,21 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: {
-                                $0.closeFuture.whenSuccess {
-                                    let closedCount = serverRequestStreamClosedCount.withLockedValue {
-                                        $0 += 1
-                                        return $0
-                                    }
-                                    if closedCount == requestCount {
-                                        allServerRequestStreamsClosedPromise.succeed()
-                                    }
-                                }
-                                try $0.pipeline.syncOperations.addHandler(TestServerHandler())
-                            }
-                        )
-                    )
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.closeFuture.whenSuccess {
+                        let closedCount = serverRequestStreamClosedCount.withLockedValue {
+                            $0 += 1
+                            return $0
+                        }
+                        if closedCount == requestCount {
+                            allServerRequestStreamsClosedPromise.succeed()
+                        }
+                    }
+                    try streamChannel.pipeline.syncOperations.addHandler(TestServerHandler())
                 }
             },
             noMoreConnections: {
@@ -1124,11 +1045,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1198,26 +1117,22 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: {
-                                $0.closeFuture.whenSuccess {
-                                    let closedCount = serverRequestStreamClosedCount.withLockedValue {
-                                        $0 += 1
-                                        return $0
-                                    }
-                                    if closedCount == requestCount {
-                                        allServerRequestStreamsClosedPromise.succeed()
-                                    }
-                                }
-                                try $0.pipeline.syncOperations.addHandler(
-                                    StreamingServerHandler(chunkSize: chunkSize, chunkCount: chunks)
-                                )
-                            }
-                        )
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.closeFuture.whenSuccess {
+                        let closedCount = serverRequestStreamClosedCount.withLockedValue {
+                            $0 += 1
+                            return $0
+                        }
+                        if closedCount == requestCount {
+                            allServerRequestStreamsClosedPromise.succeed()
+                        }
+                    }
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        StreamingServerHandler(chunkSize: chunkSize, chunkCount: chunks)
                     )
                 }
             },
@@ -1241,11 +1156,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1304,26 +1217,22 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: {
-                                $0.closeFuture.whenSuccess {
-                                    let closedCount = serverRequestStreamClosedCount.withLockedValue {
-                                        $0 += 1
-                                        return $0
-                                    }
-                                    if closedCount == requestCount {
-                                        allServerRequestStreamsClosedPromise.succeed()
-                                    }
-                                }
-                                try $0.pipeline.syncOperations.addHandler(
-                                    StreamingServerHandler(chunkSize: chunkSize, chunkCount: chunks)
-                                )
-                            }
-                        )
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.closeFuture.whenSuccess {
+                        let closedCount = serverRequestStreamClosedCount.withLockedValue {
+                            $0 += 1
+                            return $0
+                        }
+                        if closedCount == requestCount {
+                            allServerRequestStreamsClosedPromise.succeed()
+                        }
+                    }
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        StreamingServerHandler(chunkSize: chunkSize, chunkCount: chunks)
                     )
                 }
             },
@@ -1347,11 +1256,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1407,8 +1314,17 @@ final class SyncIntegrationTests: XCTestCase {
             port: 0,
             logger: loggers.serverLogger,
             inboundConnectionInitializer: { connectionChannel, _ in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(RejectEverythingHTTPConnectionHandler())
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.parent?.triggerUserOutboundEvent(
+                        NIOQUICHelpers.QUICCloseConnectionEvent(
+                            code: NIOQUICHelpers.QUICApplicationErrorCode(10)!,
+                            reasonPhrase: "test"
+                        ),
+                        promise: nil
+                    )
                 }
             },
             noMoreConnections: {}
@@ -1431,11 +1347,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                         try connectionChannel.pipeline.syncOperations.addHandler(errorCatcher)
                     }
                 },
@@ -1485,8 +1399,14 @@ final class SyncIntegrationTests: XCTestCase {
             port: 0,
             logger: loggers.serverLogger,
             inboundConnectionInitializer: { connectionChannel, _ in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(StreamResettingHTTPConnectionHandler())
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.triggerUserOutboundEvent(
+                        NIOQUICHelpers.QUICResetStreamEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
+                        promise: nil
+                    )
                 }
             },
             noMoreConnections: {}
@@ -1507,11 +1427,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1570,8 +1488,14 @@ final class SyncIntegrationTests: XCTestCase {
             port: 0,
             logger: loggers.serverLogger,
             inboundConnectionInitializer: { connectionChannel, _ in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(StreamResettingHTTPConnectionHandler())
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.triggerUserOutboundEvent(
+                        NIOQUICHelpers.QUICResetStreamEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
+                        promise: nil
+                    )
                 }
             },
             noMoreConnections: {}
@@ -1592,11 +1516,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1659,8 +1581,14 @@ final class SyncIntegrationTests: XCTestCase {
             port: 0,
             logger: loggers.serverLogger,
             inboundConnectionInitializer: { connectionChannel, _ in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(StreamClosingHTTPConnectionHandler())
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.triggerUserOutboundEvent(
+                        NIOQUICHelpers.QUICStopSendingEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
+                        promise: nil
+                    )
                 }
             },
             noMoreConnections: {}
@@ -1681,11 +1609,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1729,8 +1655,14 @@ final class SyncIntegrationTests: XCTestCase {
             port: 0,
             logger: loggers.serverLogger,
             inboundConnectionInitializer: { connectionChannel, _ in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(StreamClosingHTTPConnectionHandler())
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.triggerUserOutboundEvent(
+                        NIOQUICHelpers.QUICStopSendingEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
+                        promise: nil
+                    )
                 }
             },
             noMoreConnections: {}
@@ -1752,10 +1684,7 @@ final class SyncIntegrationTests: XCTestCase {
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
                         try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(
-                                streamCreator: streamCreator,
-                                inboundStreamInitializer: { _ in }
-                            )
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
                     }
                 },
@@ -1810,10 +1739,7 @@ final class SyncIntegrationTests: XCTestCase {
                         ConnectionActiveHandler(activePromise: serverConnectionActivePromise)
                     )
                     try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in }
-                        )
+                        HTTPConnectionHandler(streamCreator: streamCreator)
                     )
                     serverConnectionPromise.succeed(connectionChannel)
                 }
@@ -1838,18 +1764,17 @@ final class SyncIntegrationTests: XCTestCase {
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
                         try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(
-                                streamCreator: streamCreator,
-                                inboundStreamInitializer: { _ in }
-                            )
-                        )
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            StreamClosingHTTPConnectionHandler()
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
-                    streamChannel.eventLoop.makeSucceededVoidFuture()
+                    streamChannel.eventLoop.makeCompletedFuture {
+                        streamChannel.triggerUserOutboundEvent(
+                            NIOQUICHelpers.QUICStopSendingEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
+                            promise: nil
+                        )
+                    }
                 }
             )
         }.get()
@@ -1905,21 +1830,17 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandlers([
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { streamInitializer in
-                                streamInitializer.closeFuture.whenSuccess {
-                                    allServerRequestStreamsClosedPromise.succeed()
-                                }
-                                try streamInitializer.pipeline.syncOperations.addHandler(
-                                    TestConnectionIDCycleServerHandler(connectionIDSideChannel: connectionIDSideChannel)
-                                )
-                            }
-                        )
-                    ])
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.closeFuture.whenSuccess {
+                        allServerRequestStreamsClosedPromise.succeed()
+                    }
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        TestConnectionIDCycleServerHandler(connectionIDSideChannel: connectionIDSideChannel)
+                    )
                 }
             },
             noMoreConnections: {
@@ -1942,11 +1863,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -2000,18 +1919,14 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandlers([
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { streamInitializer in
-                                try streamInitializer.pipeline.syncOperations.addHandler(
-                                    TestProtocolViolationServerHandler()
-                                )
-                            }
-                        )
-                    ])
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        TestProtocolViolationServerHandler()
+                    )
                 }
             },
             noMoreConnections: {
@@ -2036,11 +1951,9 @@ final class SyncIntegrationTests: XCTestCase {
                     connectionChannel.eventLoop.makeCompletedFuture {
                         // Capture the client connection's close future
                         connectionChannel.closeFuture.cascade(to: clientConnectionClosedPromise)
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -2090,21 +2003,17 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandlers([
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { streamInitializer in
-                                streamInitializer.closeFuture.whenSuccess {
-                                    allServerRequestStreamsClosedPromise.succeed()
-                                }
-                                try streamInitializer.pipeline.syncOperations.addHandler(
-                                    TestBufferedDeletionServerHandler()
-                                )
-                            }
-                        )
-                    ])
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    streamChannel.closeFuture.whenSuccess {
+                        allServerRequestStreamsClosedPromise.succeed()
+                    }
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        TestBufferedDeletionServerHandler()
+                    )
                 }
             },
             noMoreConnections: {
@@ -2127,11 +2036,9 @@ final class SyncIntegrationTests: XCTestCase {
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        let httpHandler = HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in fatalError() }
+                        try connectionChannel.pipeline.syncOperations.addHandler(
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
-                        try connectionChannel.pipeline.syncOperations.addHandler(httpHandler)
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -2181,15 +2088,8 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { _ in }
-                        )
-                    )
-                }
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
             },
             noMoreConnections: {}
         ).get()
@@ -2210,10 +2110,7 @@ final class SyncIntegrationTests: XCTestCase {
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
                         try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(
-                                streamCreator: streamCreator,
-                                inboundStreamInitializer: { _ in }
-                            )
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
                     }
                 },
@@ -2266,17 +2163,13 @@ final class SyncIntegrationTests: XCTestCase {
             host: host,
             port: 0,
             logger: loggers.serverLogger,
-            inboundConnectionInitializer: { connectionChannel, streamCreator in
-                connectionChannel.eventLoop.makeCompletedFuture {
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(
-                            streamCreator: streamCreator,
-                            inboundStreamInitializer: { streamChannel in
-                                // Server echoes back and closes output
-                                try streamChannel.pipeline.syncOperations.addHandler(TestServerHandler())
-                            }
-                        )
-                    )
+            inboundConnectionInitializer: { connectionChannel, _ in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    // Server echoes back and closes output
+                    try streamChannel.pipeline.syncOperations.addHandler(TestServerHandler())
                 }
             },
             noMoreConnections: {}
@@ -2298,10 +2191,7 @@ final class SyncIntegrationTests: XCTestCase {
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
                         try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(
-                                streamCreator: streamCreator,
-                                inboundStreamInitializer: { _ in }
-                            )
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
                     }
                 },
@@ -2375,10 +2265,14 @@ final class SyncIntegrationTests: XCTestCase {
             port: 0,
             logger: loggers.serverLogger,
             inboundConnectionInitializer: { connectionChannel, _ in
-                connectionChannel.eventLoop.makeCompletedFuture {
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
                     // Server immediately sends STOP_SENDING on every inbound stream
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        StreamClosingHTTPConnectionHandler()
+                    streamChannel.triggerUserOutboundEvent(
+                        NIOQUICHelpers.QUICStopSendingEvent(code: NIOQUICHelpers.QUICApplicationErrorCode(10)!),
+                        promise: nil
                     )
                 }
             },
@@ -2401,10 +2295,7 @@ final class SyncIntegrationTests: XCTestCase {
                 connectionInitializer: { connectionChannel, streamCreator in
                     connectionChannel.eventLoop.makeCompletedFuture {
                         try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(
-                                streamCreator: streamCreator,
-                                inboundStreamInitializer: { _ in }
-                            )
+                            HTTPConnectionHandler(streamCreator: streamCreator)
                         )
                     }
                 },

--- a/Tests/IntegrationTests/SyncIntegrationTests.swift
+++ b/Tests/IntegrationTests/SyncIntegrationTests.swift
@@ -24,25 +24,6 @@ import XCTest
 
 @testable import NIOQUIC
 
-/// Holds the stream creator so tests can open outbound streams on a connection.
-@available(anyAppleOS 26, *)
-final class HTTPConnectionHandler: ChannelInboundHandler {
-    typealias InboundIn = NIOAny
-
-    fileprivate let streamCreator: NIOQUIC.QUICStreamCreator
-
-    init(streamCreator: NIOQUIC.QUICStreamCreator) {
-        self.streamCreator = streamCreator
-    }
-
-    func createRequestStream<InitializerOutput: Sendable>(
-        streamInitializer:
-            @escaping @Sendable (NIOQUICHelpers.QUICStreamInitializerParameters) -> EventLoopFuture<InitializerOutput>
-    ) -> EventLoopFuture<InitializerOutput> {
-        self.streamCreator.createBidirectionalStream(streamInitializer: streamInitializer)
-    }
-}
-
 /// Waits for incoming requests, ensure they match GET /foo, then responds with success. Refuses to do this more than once
 @available(anyAppleOS 26, *)
 final class TestServerHandler: ChannelInboundHandler {
@@ -936,17 +917,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -955,25 +932,25 @@ final class SyncIntegrationTests: XCTestCase {
         }.get()
 
         let clientCloseFutures: [EventLoopFuture<Void>] = (0..<requestCount).map { requestNumber in
-            clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap { httpHandler in
-                let streamID: NIOLoopBoundBox<UInt64> = NIOLoopBoundBox.makeBoxSendingValue(
-                    0,
-                    eventLoop: clientConnectionChannel.eventLoop
-                )
-                let streamChannel = httpHandler.createRequestStream { streamInitializer in
-                    streamID.value = streamInitializer.streamID.rawValue
-                    XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
-                    XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
-                    return streamInitializer.channel.eventLoop.makeCompletedFuture {
-                        try streamInitializer.channel.pipeline.syncOperations.addHandler(
-                            TestClientHandler(expectResponse: true)
-                        )
-                        return streamInitializer.channel
-                    }
+            let streamID: NIOLoopBoundBox<UInt64> = NIOLoopBoundBox.makeBoxSendingValue(
+                0,
+                eventLoop: clientConnectionChannel.eventLoop
+            )
+
+            let streamChannel = streamCreator.createBidirectionalStream { streamInitializer in
+                streamID.value = streamInitializer.streamID.rawValue
+                XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
+                XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
+                return streamInitializer.channel.eventLoop.makeCompletedFuture {
+                    try streamInitializer.channel.pipeline.syncOperations.addHandler(
+                        TestClientHandler(expectResponse: true)
+                    )
+                    return streamInitializer.channel
                 }
-                return streamChannel.flatMap {
-                    $0.closeFuture
-                }
+            }
+
+            return streamChannel.flatMap {
+                $0.closeFuture
             }
         }
 
@@ -1038,17 +1015,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1058,25 +1031,20 @@ final class SyncIntegrationTests: XCTestCase {
 
         var clientCloseFutures: [EventLoopFuture<Void>] = []
         for requestNumber in (0..<requestCount) {
-            let streamChannelFuture = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap
-            {
-                httpHandler in
-                let streamID: NIOLoopBoundBox<UInt64> = NIOLoopBoundBox.makeBoxSendingValue(
-                    0,
-                    eventLoop: clientConnectionChannel.eventLoop
-                )
-                let streamChannel = httpHandler.createRequestStream { streamInitializer in
-                    streamID.value = streamInitializer.streamID.rawValue
-                    XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
-                    XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
-                    return streamInitializer.channel.eventLoop.makeCompletedFuture {
-                        try streamInitializer.channel.pipeline.syncOperations.addHandler(
-                            TestClientHandler(expectResponse: true)
-                        )
-                        return streamInitializer.channel
-                    }
+            let streamID: NIOLoopBoundBox<UInt64> = NIOLoopBoundBox.makeBoxSendingValue(
+                0,
+                eventLoop: clientConnectionChannel.eventLoop
+            )
+            let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
+                streamID.value = streamInitializer.streamID.rawValue
+                XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
+                XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
+                return streamInitializer.channel.eventLoop.makeCompletedFuture {
+                    try streamInitializer.channel.pipeline.syncOperations.addHandler(
+                        TestClientHandler(expectResponse: true)
+                    )
+                    return streamInitializer.channel
                 }
-                return streamChannel
             }
 
             let streamChannel = try await streamChannelFuture.get()
@@ -1149,17 +1117,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1168,19 +1132,17 @@ final class SyncIntegrationTests: XCTestCase {
         }.get()
 
         let clientCloseFutures: [EventLoopFuture<Void>] = (0..<requestCount).map { requestNumber in
-            clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap { httpHandler in
-                let streamChannel = httpHandler.createRequestStream { streamInitializer in
-                    XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
-                    XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
-                    return streamInitializer.channel.eventLoop.makeCompletedFuture {
-                        try streamInitializer.channel.pipeline.syncOperations.addHandler(
-                            StreamingClientHandler(chunkSize: chunkSize, chunkCount: chunks)
-                        )
-                        return streamInitializer.channel
-                    }
+            let streamChannel = streamCreator.createBidirectionalStream { streamInitializer in
+                XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
+                XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
+                return streamInitializer.channel.eventLoop.makeCompletedFuture {
+                    try streamInitializer.channel.pipeline.syncOperations.addHandler(
+                        StreamingClientHandler(chunkSize: chunkSize, chunkCount: chunks)
+                    )
+                    return streamInitializer.channel
                 }
-                return streamChannel.flatMap { $0.closeFuture }
             }
+            return streamChannel.flatMap { $0.closeFuture }
         }
 
         // Each request channel should self-close after getting a response. Let's wait for them to close.
@@ -1249,17 +1211,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1269,20 +1227,15 @@ final class SyncIntegrationTests: XCTestCase {
 
         var clientCloseFutures: [EventLoopFuture<Void>] = []
         for requestNumber in (0..<requestCount) {
-            let streamChannelFuture = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap
-            {
-                httpHandler in
-                let streamChannel = httpHandler.createRequestStream { streamInitializer in
-                    XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
-                    XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
-                    return streamInitializer.channel.eventLoop.makeCompletedFuture {
-                        try streamInitializer.channel.pipeline.syncOperations.addHandler(
-                            StreamingClientHandler(chunkSize: chunkSize, chunkCount: chunks)
-                        )
-                        return streamInitializer.channel
-                    }
+            let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
+                XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
+                XCTAssertEqual(streamInitializer.streamID.rawValue, streamIDs[requestNumber])
+                return streamInitializer.channel.eventLoop.makeCompletedFuture {
+                    try streamInitializer.channel.pipeline.syncOperations.addHandler(
+                        StreamingClientHandler(chunkSize: chunkSize, chunkCount: chunks)
+                    )
+                    return streamInitializer.channel
                 }
-                return streamChannel
             }
 
             let streamChannel = try await streamChannelFuture.get()
@@ -1340,16 +1293,13 @@ final class SyncIntegrationTests: XCTestCase {
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientChannel.eventLoop)
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
+                connectionInitializer: { connectionChannel, _ in
                     connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
                         try connectionChannel.pipeline.syncOperations.addHandler(errorCatcher)
                     }
                 },
@@ -1359,20 +1309,13 @@ final class SyncIntegrationTests: XCTestCase {
             )
         }.get()
 
-        clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).whenComplete { handlerResult in
-            switch handlerResult {
-            case .success(let handler):
-                let _ = handler.createRequestStream { streamInitializer in
-                    XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
-                    return streamInitializer.channel.eventLoop.makeCompletedFuture {
-                        try streamInitializer.channel.pipeline.syncOperations.addHandler(
-                            TestClientHandler(expectResponse: false)
-                        )
-                        return streamInitializer.channel
-                    }
-                }
-            case .failure(let error):
-                XCTFail("Failed to get handler \(error)")
+        let _ = streamCreator.createBidirectionalStream { streamInitializer in
+            XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
+            return streamInitializer.channel.eventLoop.makeCompletedFuture {
+                try streamInitializer.channel.pipeline.syncOperations.addHandler(
+                    TestClientHandler(expectResponse: false)
+                )
+                return streamInitializer.channel
             }
         }
 
@@ -1420,17 +1363,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1440,12 +1379,9 @@ final class SyncIntegrationTests: XCTestCase {
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)
 
-        let requestStreamChannel = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap {
-            handler in
-            handler.createRequestStream { streamInitializer in
-                XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
-                return streamInitializer.channel.pipeline.addHandler(errorCatcher).map { streamInitializer.channel }
-            }
+        let requestStreamChannel = streamCreator.createBidirectionalStream { streamInitializer in
+            XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
+            return streamInitializer.channel.pipeline.addHandler(errorCatcher).map { streamInitializer.channel }
         }
         try await requestStreamChannel.flatMap { $0.writeAndFlush(ByteBuffer(string: "Hello")) }.get()
 
@@ -1509,17 +1445,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1529,12 +1461,9 @@ final class SyncIntegrationTests: XCTestCase {
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)
 
-        let requestStreamChannel = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap {
-            handler in
-            handler.createRequestStream { streamInitializer in
-                XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
-                return streamInitializer.channel.pipeline.addHandler(errorCatcher).map { streamInitializer.channel }
-            }
+        let requestStreamChannel = streamCreator.createBidirectionalStream { streamInitializer in
+            XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
+            return streamInitializer.channel.pipeline.addHandler(errorCatcher).map { streamInitializer.channel }
         }
 
         // Write data to trigger server's RESET_STREAM
@@ -1602,17 +1531,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1622,12 +1547,9 @@ final class SyncIntegrationTests: XCTestCase {
 
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)
 
-        let requestStreamChannel = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap {
-            handler in
-            handler.createRequestStream { streamInitializer in
-                XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
-                return streamInitializer.channel.pipeline.addHandler(errorCatcher).map { streamInitializer.channel }
-            }
+        let requestStreamChannel = streamCreator.createBidirectionalStream { streamInitializer in
+            XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
+            return streamInitializer.channel.pipeline.addHandler(errorCatcher).map { streamInitializer.channel }
         }
         try await requestStreamChannel.flatMap { $0.writeAndFlush(ByteBuffer(string: "Hello")) }.get()
 
@@ -1676,17 +1598,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, clientStreamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1695,9 +1613,6 @@ final class SyncIntegrationTests: XCTestCase {
         }.get()
 
         // Client creates unidirectional stream, server receives and sends STOP_SENDING
-        let clientStreamCreator = try await clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self)
-            .map { $0.streamCreator }.get()
-
         let (streamChannel, errorCatcher) = try await clientStreamCreator.createUnidirectionalStream { streamParams in
             // Create error catcher on the same event loop as the stream
             let errorCatcher = ErrorCatchingHandler(eventLoop: streamParams.channel.eventLoop)
@@ -1728,6 +1643,8 @@ final class SyncIntegrationTests: XCTestCase {
         let serverConnectionPromise = eventLoopGroup.any().makePromise(of: (any Channel).self)
         let serverConnectionActivePromise = eventLoopGroup.any().makePromise(of: Void.self)
 
+        let streamCreatorPromise = eventLoopGroup.any().makePromise(of: QUICStreamCreator.self)
+
         let serverChannel = try await createServerChannel(
             eventLoopGroup: eventLoopGroup,
             host: host,
@@ -1738,9 +1655,7 @@ final class SyncIntegrationTests: XCTestCase {
                     try connectionChannel.pipeline.syncOperations.addHandler(
                         ConnectionActiveHandler(activePromise: serverConnectionActivePromise)
                     )
-                    try connectionChannel.pipeline.syncOperations.addHandler(
-                        HTTPConnectionHandler(streamCreator: streamCreator)
-                    )
+                    streamCreatorPromise.succeed(streamCreator)
                     serverConnectionPromise.succeed(connectionChannel)
                 }
             },
@@ -1756,17 +1671,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, clientStreamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeCompletedFuture {
@@ -1780,14 +1691,13 @@ final class SyncIntegrationTests: XCTestCase {
         }.get()
 
         // Wait for connection to be established and get server connection channel
-        let serverConnectionChannel = try await serverConnectionPromise.futureResult.get()
+        let _ = try await serverConnectionPromise.futureResult.get()
 
         // Wait for the server connection to become active before creating streams
         try await serverConnectionActivePromise.futureResult.get()
 
         // Get the stream creator from the server connection (on the correct event loop)
-        let serverStreamCreator = try await serverConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self)
-            .map { $0.streamCreator }.get()
+        let serverStreamCreator = try await streamCreatorPromise.futureResult.get()
 
         // Server creates unidirectional stream, client receives and sends STOP_SENDING
         let (streamChannel, errorCatcher) = try await serverStreamCreator.createUnidirectionalStream { streamParams in
@@ -1856,17 +1766,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -1874,23 +1780,19 @@ final class SyncIntegrationTests: XCTestCase {
             )
         }.get()
 
-        let clientCloseFuture = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap {
-            httpHandler in
-            let streamChannel = httpHandler.createRequestStream { streamInitializer in
-                XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
-                XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
-                return streamInitializer.channel.eventLoop.makeCompletedFuture {
-                    try streamInitializer.channel.pipeline.syncOperations.addHandlers([
-                        TestConnectionIDCycleClientHandler(connectionIDSideChannel: connectionIDSideChannel)
-                    ])
-                    return streamInitializer.channel
-                }
+        let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
+            XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
+            XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
+            return streamInitializer.channel.eventLoop.makeCompletedFuture {
+                try streamInitializer.channel.pipeline.syncOperations.addHandlers([
+                    TestConnectionIDCycleClientHandler(connectionIDSideChannel: connectionIDSideChannel)
+                ])
+                return streamInitializer.channel
             }
-            return streamChannel.flatMap { $0.closeFuture }
         }
 
         // Each request channel should self-close after getting a response. Let's wait for them to close.
-        try await clientCloseFuture.get()
+        try await streamChannelFuture.flatMap { $0.closeFuture }.get()
 
         // The server sides request stream should also self-close after writing the response
         try await allServerRequestStreamsClosedPromise.futureResult.get()
@@ -1905,6 +1807,7 @@ final class SyncIntegrationTests: XCTestCase {
         // perform checks that they receive the expected events. The test will not finish if the expected events do not
         // arrive. Hence, there is no additional check here.
     }
+
     #if DEBUG  // Test only runs in Debug builds
     func testProtocolViolationOnReissuedConnectionID() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
@@ -1942,7 +1845,7 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
@@ -1951,9 +1854,6 @@ final class SyncIntegrationTests: XCTestCase {
                     connectionChannel.eventLoop.makeCompletedFuture {
                         // Capture the client connection's close future
                         connectionChannel.closeFuture.cascade(to: clientConnectionClosedPromise)
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
                     }
                 },
                 inboundStreamInitializer: { streamChannel in
@@ -1962,20 +1862,16 @@ final class SyncIntegrationTests: XCTestCase {
             )
         }.get()
 
-        let clientCloseFuture = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap {
-            httpHandler in
-            let streamChannel = httpHandler.createRequestStream { streamInitializer in
-                streamInitializer.channel.eventLoop.makeCompletedFuture {
-                    try streamInitializer.channel.pipeline.syncOperations.addHandlers([
-                        TestProtocolViolationClientHandler()
-                    ])
-                    return streamInitializer.channel
-                }
+        let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
+            streamInitializer.channel.eventLoop.makeCompletedFuture {
+                try streamInitializer.channel.pipeline.syncOperations.addHandlers([
+                    TestProtocolViolationClientHandler()
+                ])
+                return streamInitializer.channel
             }
-            return streamChannel.flatMap { $0.closeFuture }
         }
 
-        try await clientCloseFuture.get()
+        try await streamChannelFuture.flatMap { $0.closeFuture }.get()
 
         try await clientConnectionClosedPromise.futureResult.get()
 
@@ -2029,17 +1925,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -2047,22 +1939,18 @@ final class SyncIntegrationTests: XCTestCase {
             )
         }.get()
 
-        let clientCloseFuture = clientConnectionChannel.pipeline.handler(type: HTTPConnectionHandler.self).flatMap {
-            httpHandler in
-            let streamChannel = httpHandler.createRequestStream { streamInitializer in
-                XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
-                XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
-                return streamInitializer.channel.eventLoop.makeCompletedFuture {
-                    try streamInitializer.channel.pipeline.syncOperations.addHandlers([
-                        TestBufferedDeletionClientHandler()
-                    ])
-                    return streamInitializer.channel
-                }
+        let streamChannelFuture = streamCreator.createBidirectionalStream { streamInitializer in
+            XCTAssertEqual(streamInitializer.streamID.type, .clientInitiatedBidirectional)
+            XCTAssertEqual(streamInitializer.streamID.rawValue, 0)
+            return streamInitializer.channel.eventLoop.makeCompletedFuture {
+                try streamInitializer.channel.pipeline.syncOperations.addHandlers([
+                    TestBufferedDeletionClientHandler()
+                ])
+                return streamInitializer.channel
             }
-            return streamChannel.flatMap { $0.closeFuture }
         }
 
-        try await clientCloseFuture.get()
+        try await streamChannelFuture.flatMap { $0.closeFuture }.get()
         try await allServerRequestStreamsClosedPromise.futureResult.get()
         try await serverChannel.close()
         try await noMoreConnectionsPromise.futureResult.get()
@@ -2102,17 +1990,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -2121,12 +2005,8 @@ final class SyncIntegrationTests: XCTestCase {
         }.get()
 
         // Create a stream and send stopSending, then verify the channel is still open for writes
-        let requestStreamChannel = try await clientConnectionChannel.pipeline.handler(
-            type: HTTPConnectionHandler.self
-        ).flatMap { handler in
-            handler.createRequestStream { streamInitializer in
-                streamInitializer.channel.eventLoop.makeSucceededFuture(streamInitializer.channel)
-            }
+        let requestStreamChannel = try await streamCreator.createBidirectionalStream { streamInitializer in
+            streamInitializer.channel.eventLoop.makeSucceededFuture(streamInitializer.channel)
         }.get()
 
         // Send stopSending — this should only close the input side
@@ -2183,17 +2063,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
-                connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                connectionInitializer: { connectionChannel, _ in
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -2204,18 +2080,14 @@ final class SyncIntegrationTests: XCTestCase {
         let responseBuffer = NIOLockedValueBox(ByteBuffer())
         let gotResponsePromise = clientConnectionChannel.eventLoop.makePromise(of: Void.self)
 
-        let requestStreamChannel = try await clientConnectionChannel.pipeline.handler(
-            type: HTTPConnectionHandler.self
-        ).flatMap { handler in
-            handler.createRequestStream { streamInitializer in
-                let channel = streamInitializer.channel
-                return channel.pipeline.addHandler(
-                    ReadCollectorHandler(
-                        responseBuffer: responseBuffer,
-                        gotResponsePromise: gotResponsePromise
-                    )
-                ).map { channel }
-            }
+        let requestStreamChannel = try await streamCreator.createBidirectionalStream { streamInitializer in
+            let channel = streamInitializer.channel
+            return channel.pipeline.addHandler(
+                ReadCollectorHandler(
+                    responseBuffer: responseBuffer,
+                    gotResponsePromise: gotResponsePromise
+                )
+            ).map { channel }
         }.get()
 
         // Send the request first so the server has something to respond to
@@ -2287,17 +2159,13 @@ final class SyncIntegrationTests: XCTestCase {
             logger: loggers.clientLogger
         ).get()
 
-        let clientConnectionChannel = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        let (clientConnectionChannel, streamCreator) = try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap {
             quicHandler in
             quicHandler.createOutboundConnection(
                 serverName: "\(host):\(serverPort)",
                 remoteAddress: try! .init(ipAddress: host, port: serverPort),
                 connectionInitializer: { connectionChannel, streamCreator in
-                    connectionChannel.eventLoop.makeCompletedFuture {
-                        try connectionChannel.pipeline.syncOperations.addHandler(
-                            HTTPConnectionHandler(streamCreator: streamCreator)
-                        )
-                    }
+                    connectionChannel.eventLoop.makeSucceededVoidFuture()
                 },
                 inboundStreamInitializer: { streamChannel in
                     streamChannel.eventLoop.makeSucceededVoidFuture()
@@ -2308,20 +2176,16 @@ final class SyncIntegrationTests: XCTestCase {
         let stopSendingEventReceived = clientConnectionChannel.eventLoop.makePromise(of: Void.self)
         let errorCatcher = ErrorCatchingHandler(eventLoop: clientConnectionChannel.eventLoop)
 
-        let requestStreamChannel = try await clientConnectionChannel.pipeline.handler(
-            type: HTTPConnectionHandler.self
-        ).flatMap { handler in
-            handler.createRequestStream { streamInitializer in
-                let channel = streamInitializer.channel
-                // Opt in to half-closure semantics
-                return channel.setOption(.halfCloseOnStopSending, value: true).flatMap {
-                    channel.pipeline.addHandler(errorCatcher)
-                }.flatMap {
-                    channel.pipeline.addHandler(
-                        StopSendingEventHandler(eventReceivedPromise: stopSendingEventReceived)
-                    )
-                }.map { channel }
-            }
+        let requestStreamChannel = try await streamCreator.createBidirectionalStream { streamInitializer in
+            let channel = streamInitializer.channel
+            // Opt in to half-closure semantics
+            return channel.setOption(.halfCloseOnStopSending, value: true).flatMap {
+                channel.pipeline.addHandler(errorCatcher)
+            }.flatMap {
+                channel.pipeline.addHandler(
+                    StopSendingEventHandler(eventReceivedPromise: stopSendingEventReceived)
+                )
+            }.map { channel }
         }.get()
 
         // Write some data to trigger the server's STOP_SENDING


### PR DESCRIPTION
### Motivation

New streams were propagated by the connection channel handler. However, our adopter (SwiftNIO HTTP/3) never consumed these events. SwiftNIO QUIC already offers APIs for channel initialization that can be used for this purpose (see h3).

### Modifications

* Do not propagate new stream channels via the connection handler.
* Return the connection stream creator when creating outbound connections.
* Remove `HTTPConnectionHandler` from SyncIntergrationTests.

### Result

Slim down API a bit.
