### PR TITLE
Add connection, registrar, and transport interfaces

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -60,6 +60,15 @@ final class QUICConnectionChannel: @unchecked Sendable {
 
     // **IMPORTANT:** see note at the top of this class about these fields.
 
+    /// The underlying SwiftNetwork-backed QUIC connection.
+    private let _connection: Connection
+
+    /// A registrar for connection IDs.
+    private let _registrar: ConnectionIDRegistrar
+
+    /// A view into the QUIC handler in the UDP channel, for outbound operations.
+    private let _transport: Transport
+
     /// Whether auto-read is enabled on this channel.
     private var _autoRead: Bool
 
@@ -76,6 +85,9 @@ final class QUICConnectionChannel: @unchecked Sendable {
 
     init(
         udpChannel: any Channel,
+        connection: Connection,
+        registrar: ConnectionIDRegistrar,
+        transport: Transport,
         isServer: Bool
     ) {
         self.parent = udpChannel
@@ -84,13 +96,15 @@ final class QUICConnectionChannel: @unchecked Sendable {
         self.allocator = udpChannel.allocator
         self.closePromise = udpChannel.eventLoop.makePromise()
 
-        // force unwraps will be removed in a later PR (a not-yet-introduced provides them)
-        self._localAddress = udpChannel.localAddress!
-        self._remoteAddress = udpChannel.remoteAddress!
+        self._localAddress = connection.localAddress
+        self._remoteAddress = connection.remoteAddress
         self._isWritable = Atomic(true)
         self._isActive = Atomic(false)
         self.isServer = isServer
 
+        self._connection = connection
+        self._registrar = registrar
+        self._transport = transport
         self._autoRead = true
 
         self._pipeline = ChannelPipeline(channel: self)

--- a/Sources/NIOQUIC/QUICConnectionIDRegistrar.swift
+++ b/Sources/NIOQUIC/QUICConnectionIDRegistrar.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@available(anyAppleOS 26, *)
+public protocol QUICConnectionIDRegistrar {
+    /// Associate `newID` to the same connection as `existingID`.
+    ///
+    /// - Parameters:
+    ///   - newID: A connection ID to associate with an existing ID.
+    ///   - existingID: A connection ID which already exists.
+    /// - Returns: whether the association was made. Returns `false` if `existingID`
+    ///   doesn't exist (i.e. connection closed) or `newID` collides with an existing ID.
+    func associate(_ newID: QUICConnectionID, with existingID: QUICConnectionID) -> Bool
+
+    /// Retires `connectionID`.
+    ///
+    /// - Parameter connectionID: The ID to retire.
+    /// - Returns: `false` if it wasn't registered.
+    func retire(_ connectionID: QUICConnectionID) -> Bool
+
+    /// Generates a new connection ID.
+    ///
+    /// - Returns: A new connection ID.
+    func generateID() -> QUICConnectionID
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel {
+    enum ConnectionIDRegistrar: QUICConnectionIDRegistrar {
+        case test(any QUICConnectionIDRegistrar)
+
+        func associate(_ newID: QUICConnectionID, with existingID: QUICConnectionID) -> Bool {
+            switch self {
+            case .test(let registrar):
+                return registrar.associate(newID, with: existingID)
+            }
+        }
+
+        func retire(_ connectionID: QUICConnectionID) -> Bool {
+            switch self {
+            case .test(let registrar):
+                return registrar.retire(connectionID)
+            }
+        }
+
+        func generateID() -> QUICConnectionID {
+            switch self {
+            case .test(let registrar):
+                return registrar.generateID()
+            }
+        }
+    }
+}

--- a/Sources/NIOQUIC/QUICConnectionProtocol.swift
+++ b/Sources/NIOQUIC/QUICConnectionProtocol.swift
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOQUICHelpers
+
+/// The connection channel's view of its underlying connection.
+@available(anyAppleOS 26, *)
+protocol QUICConnectionProtocol {
+    /// The local address of the connection.
+    var localAddress: SocketAddress { get }
+    /// The remote address of the peer.
+    var remoteAddress: SocketAddress { get }
+
+    /// Hands a datagram to the connection's inbound queue.
+    ///
+    /// The datagram is enqueued but not processed: call ``receivePacketsComplete()``
+    /// once the current read batch is done to have the QUIC stack consume the
+    /// queue.
+    ///
+    /// - Parameter packet: The datagram received from the peer.
+    /// - Returns: The number of bytes accepted from `packet`.
+    @discardableResult
+    func receivePacket(_ packet: ByteBuffer) -> Int
+
+    /// Signals that the current read batch is complete and the queued datagrams
+    /// should be processed by the QUIC stack.
+    func receivePacketsComplete()
+
+    /// Pops the next finalized datagram the connection wants sent to the peer.
+    ///
+    /// Call repeatedly until it returns `nil` to drain all pending output.
+    ///
+    /// - Returns: The next datagram to send, or `nil` if none are queued.
+    func nextPacketToSend() -> ByteBuffer?
+
+    /// Initiates a locally-requested close of the connection.
+    ///
+    /// The `CONNECTION_CLOSE` frame (if any) is finalized synchronously; the
+    /// caller should drain output with ``nextPacketToSend()`` afterwards. The
+    /// returned action tells the caller whether it initiated the close (and so
+    /// must drive `channelInactive`) or the connection was already closing.
+    /// Spontaneous (peer- or idle-initiated) closes are *not* reported here —
+    /// they arrive via ``QUICConnectionChannel/ConnectionView/connectionClosed(error:)``.
+    ///
+    /// - Parameters:
+    ///   - isApplicationClose: `true` to send an application close, `false` for a
+    ///     transport close.
+    ///   - errorCode: The error code to send to the peer.
+    ///   - reason: The reason phrase to send to the peer.
+    /// - Returns: Whether the close was initiated, false otherwise (i.e. already closing).
+    func close(
+        isApplicationClose: Bool,
+        errorCode: Int64,
+        reason: String
+    ) -> Bool
+
+    /// Closes all streams on the connection and returns a future per stream that
+    /// completes once that stream's teardown finishes.
+    ///
+    /// - Returns: One future per closed stream.
+    func closeAllStreams() -> [EventLoopFuture<Void>]
+
+    /// Fans a quiesce signal (`ChannelShouldQuiesceEvent`) to every stream.
+    func quiesceStreams()
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel {
+    /// The channel's connection, either the real SwiftNetwork-backed connection
+    /// (statically dispatched) or an existential test conformance.
+    enum Connection {
+        case test(any QUICConnectionProtocol)
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel.Connection: QUICConnectionProtocol {
+    var localAddress: SocketAddress {
+        switch self {
+        case .test(let connection):
+            connection.localAddress
+        }
+    }
+
+    var remoteAddress: SocketAddress {
+        switch self {
+        case .test(let connection):
+            connection.remoteAddress
+        }
+    }
+
+    @discardableResult
+    func receivePacket(_ packet: ByteBuffer) -> Int {
+        switch self {
+        case .test(let connection):
+            connection.receivePacket(packet)
+        }
+    }
+
+    func receivePacketsComplete() {
+        switch self {
+        case .test(let connection):
+            connection.receivePacketsComplete()
+        }
+    }
+
+    func nextPacketToSend() -> ByteBuffer? {
+        switch self {
+        case .test(let connection):
+            connection.nextPacketToSend()
+        }
+    }
+
+    func close(isApplicationClose: Bool, errorCode: Int64, reason: String) -> Bool {
+        switch self {
+        case .test(let connection):
+            return connection.close(
+                isApplicationClose: isApplicationClose,
+                errorCode: errorCode,
+                reason: reason
+            )
+        }
+    }
+
+    func closeAllStreams() -> [EventLoopFuture<Void>] {
+        switch self {
+        case .test(let connection):
+            connection.closeAllStreams()
+        }
+    }
+
+    func quiesceStreams() {
+        switch self {
+        case .test(let connection):
+            connection.quiesceStreams()
+        }
+    }
+}

--- a/Sources/NIOQUIC/QUICTransport.swift
+++ b/Sources/NIOQUIC/QUICTransport.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// The channel's view of its UDP outbound side.
+///
+/// ``QUICConnectionChannel`` writes finalized datagrams, flushes, and requests
+/// reads through this seam rather than holding a concrete
+/// ``QUICHandler/ChildView`` directly. This lets the outbound side be
+/// substituted (for example, a recording double) when testing the channel in
+/// isolation. The production conformer is ``QUICHandler/ChildView``.
+@available(anyAppleOS 26, *)
+protocol QUICTransport {
+    /// Write a single addressed datagram to the UDP channel.
+    func writeDatagram(_ envelope: AddressedEnvelope<ByteBuffer>, promise: EventLoopPromise<Void>?)
+
+    /// Flush any datagrams written but not yet sent.
+    func flush()
+
+    /// Request a read from the UDP channel.
+    func read()
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel {
+    enum Transport: QUICTransport {
+        case test(any QUICTransport)
+
+        func writeDatagram(_ envelope: AddressedEnvelope<ByteBuffer>, promise: EventLoopPromise<Void>?) {
+            switch self {
+            case .test(let transport):
+                transport.writeDatagram(envelope, promise: promise)
+            }
+        }
+
+        func flush() {
+            switch self {
+            case .test(let transport):
+                transport.flush()
+            }
+        }
+
+        func read() {
+            switch self {
+            case .test(let transport):
+                transport.read()
+            }
+        }
+    }
+}

--- a/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
@@ -20,12 +20,21 @@ import Testing
 
 struct QUICConnectionChannelTests {
     @available(anyAppleOS 26, *)
-    private func makeChannel(isSever: Bool = true) throws -> QUICConnectionChannel {
+    private func makeChannel(
+        localAddress: SocketAddress = try! SocketAddress(ipAddress: "127.0.0.1", port: 8080),
+        remoteAddress: SocketAddress = try! SocketAddress(ipAddress: "127.0.0.1", port: 8081),
+        isSever: Bool = true
+    ) throws -> QUICConnectionChannel {
         let parent = EmbeddedChannel()
-        try parent.localAddress = SocketAddress(ipAddress: "127.0.0.1", port: 8080)
-        try parent.remoteAddress = SocketAddress(ipAddress: "127.0.0.1", port: 8081)
+        let connection = NoOpConnection(localAddress: localAddress, remoteAddress: remoteAddress)
 
-        return QUICConnectionChannel(udpChannel: parent, isServer: isSever)
+        return QUICConnectionChannel(
+            udpChannel: parent,
+            connection: .test(connection),
+            registrar: .test(NoOpRegistrar()),
+            transport: .test(NoOpTransport()),
+            isServer: isSever
+        )
     }
 
     @available(anyAppleOS 26, *)
@@ -80,5 +89,76 @@ struct QUICConnectionChannelTests {
         #expect(throws: ChannelError.self) {
             try channel.syncOptions!.setOption(.backlog, value: 43)
         }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func address() throws {
+        let local = try SocketAddress(ipAddress: "127.0.0.1", port: 1234)
+        let remote = try SocketAddress(ipAddress: "127.0.0.1", port: 5678)
+
+        let channel = try self.makeChannel(localAddress: local, remoteAddress: remote)
+        #expect(channel.localAddress == local)
+        #expect(channel.remoteAddress == remote)
+    }
+}
+
+struct NoOpTransport: QUICTransport {
+    func writeDatagram(_ envelope: AddressedEnvelope<ByteBuffer>, promise: EventLoopPromise<Void>?) {
+        promise?.succeed()
+    }
+
+    func flush() {
+    }
+
+    func read() {
+    }
+}
+
+@available(anyAppleOS 26, *)
+struct NoOpRegistrar: QUICConnectionIDRegistrar {
+    func associate(_ newID: QUICConnectionID, with existingID: QUICConnectionID) -> Bool {
+        true
+    }
+
+    func retire(_ connectionID: QUICConnectionID) -> Bool {
+        true
+    }
+
+    func generateID() -> QUICConnectionID {
+        .zero
+    }
+}
+
+@available(anyAppleOS 26, *)
+struct NoOpConnection: QUICConnectionProtocol {
+    let localAddress: SocketAddress
+    let remoteAddress: SocketAddress
+
+    init(localAddress: SocketAddress, remoteAddress: SocketAddress) {
+        self.localAddress = localAddress
+        self.remoteAddress = remoteAddress
+    }
+
+    func receivePacket(_ packet: ByteBuffer) -> Int {
+        0
+    }
+
+    func receivePacketsComplete() {
+    }
+
+    func nextPacketToSend() -> ByteBuffer? {
+        nil
+    }
+
+    func close(isApplicationClose: Bool, errorCode: Int64, reason: String) -> Bool {
+        true
+    }
+
+    func closeAllStreams() -> [EventLoopFuture<Void>] {
+        []
+    }
+
+    func quiesceStreams() {
     }
 }


### PR DESCRIPTION
Motivation:

The connection channel has to talk to a few different objects: the underlying QUIC connection, a connection ID registrar (for routing), and a transport (for writing outbound datagrams).

This PR introduces a few interfaces and wrapper types which currently only hold existential 'test' variants of each. In the fullness of time each variant will hold a concrete type of each as well to get static method dispatch for prod code while allowing enough flexibility for testing.

Modifications:

- Add protocols and enum wrappers for the registrar, connection, and transport
- Have the connection hold one of each

Result:

More pieces