### PR TITLE
Add lifecycle state machine to conn channel

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel+Lifecycle.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel+Lifecycle.swift
@@ -220,10 +220,14 @@ extension QUICConnectionChannel {
             }
         }
 
-        /// Record that an inbound stream initializer finished. Decrements the gate; the
-        /// caller then runs `reconcileLifecycle()`, which fires any now-unblocked deferred
-        /// `channelInactive` via ``reconcile()``.
+        /// Record that an inbound stream initializer finished.
+        ///
+        /// Decrements the in-flight initializer count; this is used to hold up channel inactive
+        /// on the connection channel while streams are being initialized. At the end of the
+        /// outbound packet draining loop the channel should call ``reconcile()`` which may then
+        /// lead to the connection becoming inactive.
         mutating func streamInitializerFinished() {
+            assert(self.inFlightInitializers > 0)
             self.inFlightInitializers &-= 1
         }
 
@@ -236,10 +240,10 @@ extension QUICConnectionChannel {
             case fireInactive(error: (any Error)?)
         }
 
-        /// Reconcile the current lifecycle by applying a pending state.
+        /// Reconcile the current lifecycle by applying a pending state change.
         ///
-        /// The channel should call this in a loop until it returns `nil` when it has drained
-        /// its connection.
+        /// When the channel has finished consuming outbound data from the connection it should
+        /// call this in a loop and apply side effects until this returns `nil`.
         mutating func reconcile() -> Action? {
             switch self.state {
             case .initialized:

--- a/Sources/NIOQUIC/QUICConnectionChannel+Lifecycle.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel+Lifecycle.swift
@@ -1,0 +1,280 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel {
+    /// Lifecycle of a ``QUICConnectionChannel``.
+    ///
+    /// Tracks a few different things:
+    /// - ``state``: the committed channel state (idle → ... → closed).
+    /// - ``pending``: pending state that hasn't been applied yet (because the channel
+    ///   is draining the connection.)
+    /// - ``inFlightInitializers``: the number of stream initializers in flight, used
+    ///   to (potentially) hold up channel inactive.
+    struct Lifecycle {
+        enum State: Equatable {
+            case idle
+            case initializing
+            case initialized
+            case activated
+            case closing(inactiveFired: Bool)
+            case closed
+        }
+
+        struct Pending {
+            /// The connection activated.
+            var activate: Bool
+            /// The connection closed.
+            var close: PendingClose?
+
+            init() {
+                self.activate = false
+                self.close = nil
+            }
+        }
+
+        enum PendingClose {
+            case cleanly
+            case withError(any Error)
+
+            var error: (any Error)? {
+                switch self {
+                case .cleanly:
+                    return nil
+                case .withError(let error):
+                    return error
+                }
+            }
+        }
+
+        /// The lifecycle state.
+        private(set) var state: State
+        // private(set) as tests read the state.
+
+        /// Pending state to be applied by ``reconcile()``.
+        private var pending: Pending
+
+        /// The number of inbound stream initializers currently in progress. This is tracked so
+        /// that channel inactive is fired after all streams are initialized.
+        private var inFlightInitializers: Int
+
+        init() {
+            self.state = .idle
+            self.pending = Pending()
+            self.inFlightInitializers = 0
+        }
+
+        /// Move from `.idle` to `.initializing`. Returns whether the transition was valid.
+        mutating func initialize() -> Bool {
+            switch self.state {
+            case .idle:
+                self.state = .initializing
+                return true
+            case .initializing, .initialized, .activated, .closing, .closed:
+                return false
+            }
+        }
+
+        enum OnInitialized: Equatable {
+            /// The initializer completed successfully; the channel is waiting to be activated.
+            case awaitingActivation
+            /// The connection closed while the initializer was running; activation won't fire.
+            case closedDuringInit
+        }
+
+        /// The user's initializer finished.
+        @discardableResult
+        mutating func initialized() -> OnInitialized {
+            switch self.state {
+            case .initializing:
+                self.state = .initialized
+                return .awaitingActivation
+
+            case .closing, .closed:
+                // The channel was closed while the user's initializer was still in flight.
+                // Stay on the close path; activation won't fire.
+                return .closedDuringInit
+
+            case .idle, .initialized, .activated:
+                fatalError("Internal inconsistency")
+            }
+        }
+
+        enum OnBeginClosing: Equatable {
+            /// This call moved the channel onto the close path.
+            case beganClosing
+            /// A close was already in flight.
+            case alreadyClosing
+            /// The channel was already fully closed.
+            case alreadyClosed
+        }
+
+        /// Commit the channel to closing.
+        ///
+        /// The channel must later call ``reconcile()`` to get the side effects of
+        /// closing. The return value dictates whether the channel should proceed with
+        /// closing the underlying connection.
+        @discardableResult
+        mutating func beginClosing(error: (any Error)?) -> OnBeginClosing {
+            switch self.state {
+            case .idle, .initializing, .initialized, .activated:
+                self.pending.close = error.map { .withError($0) } ?? .cleanly
+                self.state = .closing(inactiveFired: false)
+                return .beganClosing
+            case .closing:
+                return .alreadyClosing
+            case .closed:
+                return .alreadyClosed
+            }
+        }
+
+        /// Mark the channel as fully closed.
+        mutating func closed() {
+            switch self.state {
+            case .idle, .initializing, .initialized, .activated, .closing:
+                self.state = .closed
+            case .closed:
+                ()  // Already closed.
+            }
+        }
+
+        enum OnForceClose: Equatable {
+            /// No close committed to firing `channelInactive` yet; force teardown now.
+            case forceThroughNow
+            /// Another path already committed to firing `channelInactive` and may be
+            /// mid-flight. Don't re-run the completion side effects.
+            case alreadyCommitted
+            /// The channel was already fully closed.
+            case alreadyClosed
+        }
+
+        /// Force the channel onto the close path without waiting for a graceful drain.
+        ///
+        /// The escape hatch: deliberately bypasses ``reconcile()`` (it must not wait on the
+        /// stream gate or QUIC ack). Sets `inactiveFired` on the force-through path so the
+        /// `.closing` flag stays honest while `completeChannelInactive` runs.
+        mutating func forceClosing() -> OnForceClose {
+            let onForceClose: OnForceClose
+
+            switch self.state {
+            case .idle, .initializing, .initialized, .activated:
+                self.state = .closing(inactiveFired: true)
+                onForceClose = .forceThroughNow
+
+            case .closing(let inactiveFired):
+                if inactiveFired {
+                    onForceClose = .alreadyCommitted
+                } else {
+                    self.state = .closing(inactiveFired: true)
+                    onForceClose = .forceThroughNow
+                }
+
+            case .closed:
+                onForceClose = .alreadyClosed
+            }
+
+            return onForceClose
+        }
+
+        // MARK: Signals
+
+        /// The connection activated. Call ``reconcile()`` to apply the state change.
+        mutating func connectionActivated() {
+            self.pending.activate = true
+        }
+
+        /// The connection closed spontaneously. Call ``reconcile()`` to apply the state change.
+        mutating func connectionClosed(error: (any Error)?) {
+            self.pending.close = error.map { .withError($0) } ?? .cleanly
+        }
+
+        // MARK: Streams
+
+        /// Record that an inbound stream initializer started.
+        ///
+        /// `channelInactive` is held until all in-flight initializers finish.
+        mutating func willInitializeStream() {
+            assert(self.canInitStream, "can't initialize a stream after channelInactive")
+            self.inFlightInitializers &+= 1
+        }
+
+        private var canInitStream: Bool {
+            switch self.state {
+            case .idle, .initializing, .initialized, .activated:
+                return true
+            case .closing(let inactiveFired):
+                return !inactiveFired
+            case .closed:
+                return false
+            }
+        }
+
+        /// Record that an inbound stream initializer finished. Decrements the gate; the
+        /// caller then runs `reconcileLifecycle()`, which fires any now-unblocked deferred
+        /// `channelInactive` via ``reconcile()``.
+        mutating func streamInitializerFinished() {
+            self.inFlightInitializers &-= 1
+        }
+
+        // MARK: Reconcile
+
+        enum Action {
+            /// Fire `channelActive`, complete the ready promise (if applicable), resume reads.
+            case fireActive
+            /// Fire `channelInactive` after firing the error (if present).
+            case fireInactive(error: (any Error)?)
+        }
+
+        /// Reconcile the current lifecycle by applying a pending state.
+        ///
+        /// The channel should call this in a loop until it returns `nil` when it has drained
+        /// its connection.
+        mutating func reconcile() -> Action? {
+            switch self.state {
+            case .initialized:
+                if self.pending.activate {
+                    self.state = .activated
+                    self.pending.activate = false
+                    return .fireActive
+                }  // else: no pending signal
+
+            case .idle, .initializing, .activated, .closing, .closed:
+                ()
+            }
+
+            guard let close = self.pending.close else { return nil }
+
+            let action: Action?
+
+            switch self.state {
+            case .idle, .initializing, .initialized, .activated, .closing(inactiveFired: false):
+                if self.inFlightInitializers == 0 {
+                    self.pending.close = nil
+                    self.state = .closing(inactiveFired: true)
+                    action = .fireInactive(error: close.error)
+                } else {
+                    // Delay the inactive until streams finish initializing.
+                    self.state = .closing(inactiveFired: false)
+                    action = nil
+                }
+
+            case .closing(inactiveFired: true), .closed:
+                action = nil
+            }
+
+            return action
+        }
+
+    }
+}

--- a/Tests/NIOQUICTests/QUICConnectionChannelLifecycleTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelLifecycleTests.swift
@@ -1,0 +1,399 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import NIOQUIC
+
+struct QUICConnectionChannelLifecycleTests {
+    @available(anyAppleOS 26, *)
+    typealias StateTag = QUICConnectionChannel.Lifecycle.StateTag
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func initializeFromIdle() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        #expect(lifecycle.initialize() == true)
+        #expect(lifecycle.state.tag == .initializing)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test(arguments: [StateTag.initializing, .initialized, .activated, .closing, .closed])
+    func initializeFromOtherStatesIsRejected(initialState: StateTag) {
+        var lifecycle = QUICConnectionChannel.Lifecycle(initialState)
+        #expect(lifecycle.initialize() == false)
+        #expect(lifecycle.state.tag == initialState)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func initializedFromInitializing() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.initializing)
+        #expect(lifecycle.initialized() == .awaitingActivation)
+        #expect(lifecycle.state.tag == .initialized)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test(arguments: [StateTag.closing, .closed])
+    func initializedFromCloseStatesIsNoOp(initialState: StateTag) {
+        var lifecycle = QUICConnectionChannel.Lifecycle(initialState)
+        #expect(lifecycle.initialized() == .closedDuringInit)
+        #expect(lifecycle.state.tag == initialState)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test(arguments: [StateTag.idle, .initializing, .initialized, .activated])
+    func beginClosingFromOpenStates(initialState: StateTag) {
+        var lifecycle = QUICConnectionChannel.Lifecycle(initialState)
+        #expect(lifecycle.beginClosing(error: nil) == .beganClosing)
+        #expect(lifecycle.state.tag == .closing)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func beginClosingFromClosingIsAlreadyClosing() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.closing)
+        #expect(lifecycle.beginClosing(error: nil) == .alreadyClosing)
+        #expect(lifecycle.state.tag == .closing)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func beginClosingFromClosedIsAlreadyClosed() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.closed)
+        #expect(lifecycle.beginClosing(error: nil) == .alreadyClosed)
+        #expect(lifecycle.state.tag == .closed)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test(arguments: [StateTag.idle, .initializing, .initialized, .activated, .closing])
+    func closedFromAnyOpenState(initialState: StateTag) {
+        var lifecycle = QUICConnectionChannel.Lifecycle(initialState)
+        lifecycle.closed()
+        #expect(lifecycle.state.tag == .closed)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func closedFromClosedIsIdempotent() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.closed)
+        lifecycle.closed()
+        #expect(lifecycle.state.tag == .closed)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func happyPath() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        #expect(lifecycle.initialize() == true)
+        #expect(lifecycle.initialized() == .awaitingActivation)
+        lifecycle.connectionActivated()
+        #expect(lifecycle.reconcile().isFireActive)
+        #expect(lifecycle.state.tag == .activated)
+        #expect(lifecycle.beginClosing(error: nil) == .beganClosing)
+        lifecycle.closed()
+        #expect(lifecycle.state.tag == .closed)
+    }
+
+    // MARK: - reconcile()
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func reconcileWithNothingPending() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        #expect(lifecycle.reconcile() == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func activationPendingUntilInitialized() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        _ = lifecycle.initialize()
+        lifecycle.connectionActivated()
+        #expect(lifecycle.reconcile() == nil)
+        #expect(lifecycle.state.tag == .initializing)
+
+        // Reoncile causes the transition.
+        lifecycle.initialized()
+        #expect(lifecycle.reconcile().isFireActive)
+        #expect(lifecycle.state.tag == .activated)
+        // Consumed: no repeat activation.
+        #expect(lifecycle.reconcile() == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func activationThenCloseFireInOrder() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        _ = lifecycle.initialize()
+        lifecycle.initialized()
+        lifecycle.connectionActivated()
+        lifecycle.connectionClosed(error: nil)
+
+        // Activation must happen before inactive.
+        #expect(lifecycle.reconcile().isFireActive)
+        #expect(lifecycle.reconcile().isFireInactive)
+        #expect(lifecycle.reconcile() == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func closeErrorIsCarriedThrough() {
+        struct Boom: Error {}
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        lifecycle.connectionClosed(error: Boom())
+        switch lifecycle.reconcile() {
+        case .fireInactive(let error):
+            #expect(error is Boom)
+        case .fireActive, .none:
+            Issue.record("expected .fireInactive")
+        }
+    }
+
+    // MARK: - Inactive defer
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func driveFiresInactiveWhenNoInitializersInFlight() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        lifecycle.connectionClosed(error: nil)
+        #expect(lifecycle.reconcile().isFireInactive)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func driveInactiveIsIdempotent() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        lifecycle.connectionClosed(error: nil)
+        #expect(lifecycle.reconcile().isFireInactive)
+        #expect(lifecycle.reconcile() == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func inactiveDefersUntilInitializersDrain() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        lifecycle.willInitializeStream()
+        lifecycle.willInitializeStream()
+        lifecycle.connectionClosed(error: nil)
+
+        // Held while initializers are in flight.
+        #expect(lifecycle.reconcile() == nil)
+        lifecycle.streamInitializerFinished()
+        #expect(lifecycle.reconcile() == nil)
+        // Fires once the last one drains.
+        lifecycle.streamInitializerFinished()
+        #expect(lifecycle.reconcile().isFireInactive)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func deferredInactiveCarriesError() {
+        struct Boom: Error {}
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        lifecycle.willInitializeStream()
+        lifecycle.connectionClosed(error: Boom())
+        #expect(lifecycle.reconcile() == nil)
+
+        lifecycle.streamInitializerFinished()
+        switch lifecycle.reconcile() {
+        case .fireInactive(let error):
+            #expect(error is Boom)
+        case .fireActive, .none:
+            Issue.record("expected .fireInactive")
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func beginClosingErrorIsCarriedThrough() {
+        struct Boom: Error {}
+        var lifecycle = QUICConnectionChannel.Lifecycle(.activated)
+        lifecycle.beginClosing(error: Boom())
+        switch lifecycle.reconcile() {
+        case .fireInactive(let error):
+            #expect(error is Boom)
+        case .fireActive, .none:
+            Issue.record("expected .fireInactive")
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func beginClosingMovesToClosingAndDriveFires() {
+        // A close from an active channel lands on `.closing`, then reconcile fires inactive.
+        var lifecycle = QUICConnectionChannel.Lifecycle(.activated)
+        #expect(lifecycle.beginClosing(error: nil) == .beganClosing)
+        #expect(lifecycle.state.tag == .closing)
+        #expect(lifecycle.reconcile().isFireInactive)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func driveAfterClosedIsNoOp() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.closed)
+        lifecycle.connectionClosed(error: nil)
+        #expect(lifecycle.reconcile() == nil)
+        #expect(lifecycle.state.tag == .closed)
+    }
+
+    // MARK: - forceClosing()
+
+    @available(anyAppleOS 26, *)
+    @Test(arguments: [StateTag.idle, .initializing, .initialized, .activated])
+    func forceClosingFromOpenStatesForcesThroughNow(initialState: StateTag) {
+        var lifecycle = QUICConnectionChannel.Lifecycle(initialState)
+        #expect(lifecycle.forceClosing() == .forceThroughNow)
+        #expect(lifecycle.state.tag == .closing)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func forceClosingFromClosingWithoutInactiveCommittedForcesThroughNow() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.closing)
+        #expect(lifecycle.forceClosing() == .forceThroughNow)
+        #expect(lifecycle.state.tag == .closing)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func forceClosingWhileInactiveDeferredForcesThroughNow() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        lifecycle.willInitializeStream()
+        lifecycle.connectionClosed(error: nil)
+        #expect(lifecycle.reconcile() == nil)
+        #expect(lifecycle.forceClosing() == .forceThroughNow)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func forceClosingAfterDeferredInactiveFiredDoesNotReCommit() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.idle)
+        lifecycle.willInitializeStream()
+        lifecycle.connectionClosed(error: nil)
+        #expect(lifecycle.reconcile() == nil)
+        lifecycle.streamInitializerFinished()
+        #expect(lifecycle.reconcile().isFireInactive)
+
+        #expect(lifecycle.forceClosing() == .alreadyCommitted)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func forceClosingAfterInactiveFiredDoesNotReCommit() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.activated)
+        lifecycle.connectionClosed(error: nil)
+        #expect(lifecycle.reconcile().isFireInactive)
+
+        #expect(lifecycle.forceClosing() == .alreadyCommitted)
+        #expect(lifecycle.state.tag == .closing)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func forceClosingFromClosedIsAlreadyClosed() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.closed)
+        #expect(lifecycle.forceClosing() == .alreadyClosed)
+        #expect(lifecycle.state.tag == .closed)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func forceClosingSetsInactiveFiredSoASecondForceIsAlreadyCommitted() {
+        var lifecycle = QUICConnectionChannel.Lifecycle(.activated)
+        #expect(lifecycle.forceClosing() == .forceThroughNow)
+        #expect(lifecycle.forceClosing() == .alreadyCommitted)
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel.Lifecycle {
+    // Like Lifecycle.State, but without associated data. Allows tests to do
+    // equality checks on the tag (associated data only includes errors).
+    enum StateTag {
+        case idle
+        case initializing
+        case initialized
+        case activated
+        case closing
+        case closed
+    }
+
+    init(_ desiredState: StateTag) {
+        self = Self()
+
+        switch desiredState {
+        case .idle:
+            ()
+        case .initializing:
+            _ = self.initialize()
+        case .initialized:
+            _ = self.initialize()
+            self.initialized()
+        case .activated:
+            _ = self.initialize()
+            self.initialized()
+            self.connectionActivated()
+            _ = self.reconcile()
+        case .closing:
+            _ = self.initialize()
+            self.beginClosing(error: nil)
+        case .closed:
+            _ = self.initialize()
+            self.beginClosing(error: nil)
+            self.closed()
+        }
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel.Lifecycle.State {
+    fileprivate var tag: QUICConnectionChannel.Lifecycle.StateTag {
+        switch self {
+        case .idle:
+            return .idle
+        case .initializing:
+            return .initializing
+        case .initialized:
+            return .initialized
+        case .activated:
+            return .activated
+        case .closing:
+            return .closing
+        case .closed:
+            return .closed
+        }
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionChannel.Lifecycle.Action? {
+    fileprivate var isFireActive: Bool {
+        switch self {
+        case .fireActive:
+            return true
+        case .fireInactive, .none:
+            return false
+        }
+    }
+
+    fileprivate var isFireInactive: Bool {
+        switch self {
+        case .fireInactive:
+            return true
+        case .fireActive, .none:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The connection channel needs to maintain a small amount of lifecycle state to know when to fire various pipeline operations and so on. This change adds a Lifecycle state machine which isn't yet wired up to the channel.

Modifications:

- Add a Lifecycle state machine

Result:

More things in place.