### PR TITLE
Add support for QUIC datagrams

### DIFF
--- a/Sources/NIOQUIC/QUICDatagramHandler.swift
+++ b/Sources/NIOQUIC/QUICDatagramHandler.swift
@@ -1,0 +1,315 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOCore
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// The negotiation state of the QUIC datagram extension (RFC 9221) for a connection.
+enum QUICDatagramNegotiationState {
+    /// The peer's `max_datagram_frame_size` transport parameter is not yet known.
+    /// Early writes will be buffered until the peer's advertisement is received.
+    case waitingForPeerAdvertisement(earlyWrites: TinyArray<(ByteBuffer, EventLoopPromise<Void>?)>)
+    /// The peer advertised a `max_datagram_frame_size` of 0: it does not support datagrams.
+    /// Buffered early writes will be discarded (and their promises failed).
+    case peerDoesNotAcceptDatagrams
+    /// The peer accepts datagrams up to `maximumSize` bytes.
+    case peerAcceptsDatagrams(maximumSize: Int)
+}
+
+/// `QUICDatagramHandler` is the bridge between SwiftNIOQUIC's pipeline and a QUIC
+/// datagram transport (RFC 9221). It is a NIO `ChannelDuplexHandler` that forwards datagrams
+/// between the pipeline and whichever `QUICDatagramProtocol`-conforming transport is currently
+/// installed as its backend.
+@available(anyAppleOS 26, *)
+final class QUICDatagramHandler: ChannelDuplexHandler {
+    typealias LowerProtocol = OutboundDatagramLinkage
+
+    typealias InboundIn = Any
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = Any
+
+    private var context: ChannelHandlerContext?
+
+    /// The active datagram backend, or `.none` before one has been installed.
+    private var transport: Transport
+
+    private var logPrefix: String
+    private let logger: Logger
+
+    private var state: QUICDatagramNegotiationState = .waitingForPeerAdvertisement(earlyWrites: .init())
+
+    init(role: Role, logger: Logger) {
+        self.logPrefix = "[\(role.description)][DatagramHandler]"
+        self.logger = logger
+        self.transport = .none
+    }
+
+    func log(_ message: @autoclosure () -> String) {
+        #if DEBUG
+        self.logger.trace("\(self.logPrefix) \(message())")
+        #endif
+    }
+
+    /// Installs a `QUICDatagramProtocol` conforming backend for testing, applying the peer's
+    /// advertised `max_datagram_frame_size` the same way `setBackend(to:withPeerMaxDatagramFrameSize:)`
+    /// does. Writes buffered before this call are resolved against `size`.
+    func setTestBackend(to transport: any QUICDatagramProtocol, peerMaxDatagramFrameSize size: Int) {
+        transport.setReader(reader: self)
+        self.transport = .test(transport)
+        self.setPeerMaxDatagramFrameSize(size)
+        if let context = self.context {
+            self.flush(context: context)
+        }
+    }
+
+    /// Installs the SwiftNetwork-backed transport once the peer's `max_datagram_frame_size` is known.
+    ///
+    /// - Parameters:
+    ///   - transport: The transport to send and receive datagrams through.
+    ///   - size: The peer's advertised `max_datagram_frame_size`. `0` means the peer does not
+    ///     accept datagrams. Must be >= 0.
+    func setBackend(to transport: QUICDatagramTransport, withPeerMaxDatagramFrameSize size: Int) {
+        transport.setReader(reader: self)
+        self.transport = .swiftNetwork(transport)
+        self.setPeerMaxDatagramFrameSize(size)
+        if let context = self.context {
+            self.flush(context: context)
+        }
+    }
+}
+
+// MARK: - Transport
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    /// The handler's QUIC transport, either the real SwiftNetwork-backed transport
+    /// (statically dispatched) or an existential test conformance.
+    enum Transport {
+        /// No transport has been installed yet.
+        case none
+        /// Installed via `setTestBackend(to:withPeerMaxDatagramFrameSize:)`.
+        case test(any QUICDatagramProtocol)
+        /// Installed via `setBackend(to:withPeerMaxDatagramFrameSize:)`.
+        case swiftNetwork(QUICDatagramTransport)
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler.Transport: QUICDatagramProtocol {
+    /// Write a datagram to the transport.
+    ///
+    /// Note that writes are unreliable.
+    ///
+    /// - Precondition: A backend must have been installed; traps on `.none`.
+    func write(datagram: NIOCore.ByteBuffer) -> Bool {
+        switch self {
+        case .none:
+            fatalError("state violation: cannot perform a write before assigning a transport")
+        case .test(let testTransport):
+            testTransport.write(datagram: datagram)
+        case .swiftNetwork(let swiftNetworkTransport):
+            swiftNetworkTransport.write(datagram: datagram)
+        }
+    }
+
+    /// A no-op on `.none`, so flushing before a backend is installed is safe.
+    func flush() {
+        switch self {
+        case .none:
+            break
+        case .test(let testTransport):
+            testTransport.flush()
+        case .swiftNetwork(let swiftNetworkTransport):
+            swiftNetworkTransport.flush()
+        }
+    }
+
+    /// A no-op on `.none`, so closing before a backend is installed is safe.
+    func close() {
+        switch self {
+        case .none:
+            break
+        case .test(let testTransport):
+            testTransport.close()
+        case .swiftNetwork(let swiftNetworkTransport):
+            swiftNetworkTransport.close()
+        }
+    }
+
+    /// Set yourself as a reader of incoming datagrams.
+    ///
+    /// - Precondition: A backend must have been installed; traps on `.none`.
+    func setReader(reader: any QUICDatagramReaderProtocol) {
+        switch self {
+        case .none:
+            fatalError("state violation: cannot set a reader before assigning a transport")
+        case .test(let testTransport):
+            testTransport.setReader(reader: reader)
+        case .swiftNetwork(let swiftNetworkTransport):
+            swiftNetworkTransport.setReader(reader: reader)
+        }
+    }
+}
+
+// MARK: - NIO lifecycle + passthrough
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    func handlerAdded(context: ChannelHandlerContext) {
+        self.context = context
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        // Fail open writes (peer datagram size was never set).
+        if case .waitingForPeerAdvertisement(let earlyWrites) = self.state {
+            for (_, promise) in earlyWrites {
+                promise?.fail(ChannelError.ioOnClosedChannel)
+            }
+        }
+        self.transport.close()
+        self.context = nil
+    }
+
+    /// Passes inbound reads from further up the pipeline straight through.
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        context.fireChannelRead(data)
+    }
+}
+
+// MARK: - Outbound datagrams
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    /// Buffers a datagram write, applying the current negotiation state:
+    /// held until the peer's advertised size is known, failed if the peer rejects datagrams
+    /// or the datagram exceeds the peer's advertised size, otherwise handed to the transport.
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let buffer = self.unwrapOutboundIn(data)
+        switch self.state {
+        case .waitingForPeerAdvertisement(var earlyWrites):
+            // The handshake has not finished and the peer's advertised size is yet unknown.
+            earlyWrites.append((buffer, promise))
+            self.state = .waitingForPeerAdvertisement(earlyWrites: earlyWrites)
+        case .peerDoesNotAcceptDatagrams:
+            // Nope. Drop it.
+            promise?.fail(QUICError.peerDoesNotAcceptDatagrams)
+        case .peerAcceptsDatagrams(let maximumSize):
+            // Reject early if the datagram exceeds the peer's advertised limit, then hand it to the
+            // transport (which may still fail the write, e.g. a transport-level size constraint).
+            //
+            // Note: this is an estimate. `max_datagram_frame_size` bounds the whole DATAGRAM frame
+            // (type + length + payload), but we compare only the payload length, so a datagram that
+            // passes here can still be too large once framed. The transport enforces the real limit.
+            guard buffer.readableBytes <= maximumSize else {
+                promise?.fail(QUICError.datagramTooLarge)
+                return
+            }
+            if self.transport.write(datagram: buffer) {
+                promise?.succeed()
+            } else {
+                promise?.fail(QUICError.datagramWriteFailed)
+            }
+        }
+    }
+
+    /// Flushes buffered datagrams to the transport, then forwards the flush down the pipeline.
+    func flush(context: ChannelHandlerContext) {
+        self.transport.flush()
+        context.flush()
+    }
+}
+
+// MARK: - Inbound datagrams
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler: QUICDatagramReaderProtocol {
+    /// Forwards a datagram received from the transport into the NIO pipeline.
+    func read(datagram: NIOCore.ByteBuffer) {
+        // The SwiftNetwork backend already checks that incoming packets
+        // do not surpass our advertised limit and will (per RFC) close
+        // the connection with a PROTOCOL_ERROR in that case.
+        let buffer = self.wrapInboundOut(datagram)
+        self.context?.fireChannelRead(buffer)
+    }
+
+    /// Forwards a transport error into the NIO pipeline.
+    func error(error: any Error) {
+        self.context?.fireErrorCaught(error)
+    }
+}
+
+// MARK: - QUICDatagramProtocol
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    /// Applies the peer's advertised `max_datagram_frame_size`, transitioning out of
+    /// `.waitingForPeerAdvertisement` and resolving any writes buffered while waiting.
+    ///
+    /// - Precondition: Must only be called once per connection; the peer only advertises this once.
+    private func setPeerMaxDatagramFrameSize(_ size: Int) {
+        switch self.state {
+        case .waitingForPeerAdvertisement(let earlyWrites):
+            // Filter previously buffered messages to account for advertised size
+            if size == 0 {
+                self.state = .peerDoesNotAcceptDatagrams
+                for (_, promise) in earlyWrites {
+                    promise?.fail(QUICError.peerDoesNotAcceptDatagrams)
+                }
+            } else {
+                self.state = .peerAcceptsDatagrams(maximumSize: size)
+                for (buffer, promise) in earlyWrites {
+                    // Same estimated size check as `write` (payload-only, ignores frame overhead;
+                    // the transport enforces the real limit).
+                    guard buffer.readableBytes <= size else {
+                        promise?.fail(QUICError.datagramTooLarge)
+                        continue
+                    }
+                    if self.transport.write(datagram: buffer) {
+                        promise?.succeed()
+                    } else {
+                        promise?.fail(QUICError.datagramWriteFailed)
+                    }
+                }
+            }
+        case .peerDoesNotAcceptDatagrams:
+            assertionFailure("peer max datagram size must not be updated more than once")
+            self.logger.error(
+                "\(self.logPrefix) received peer max datagram size more than once",
+                metadata: [
+                    "knownSize": "0",
+                    "newSize": "\(size)",
+                ]
+            )
+        case .peerAcceptsDatagrams(let knownSize):
+            assertionFailure("peer max datagram size must not be updated more than once")
+            self.logger.error(
+                "\(self.logPrefix) received peer max datagram size more than once",
+                metadata: [
+                    "knownSize": "\(knownSize)",
+                    "newSize": "\(size)",
+                ]
+            )
+        }
+    }
+}

--- a/Sources/NIOQUIC/QUICDatagramHandler.swift
+++ b/Sources/NIOQUIC/QUICDatagramHandler.swift
@@ -16,14 +16,6 @@ import Logging
 import NIOCore
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#elseif canImport(Musl)
-import Musl
-#endif
-
 /// The negotiation state of the QUIC datagram extension (RFC 9221) for a connection.
 enum QUICDatagramNegotiationState {
     /// The peer's `max_datagram_frame_size` transport parameter is not yet known.

--- a/Sources/NIOQUIC/QUICDatagramProtocol.swift
+++ b/Sources/NIOQUIC/QUICDatagramProtocol.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// The datagram transport interface `QUICDatagramHandler` writes to and reads from.
+///
+/// This exists so `QUICDatagramHandler` does not depend on the SwiftNetwork-backed
+/// `QUICDatagramTransport` directly: production code is backed by `QUICDatagramTransport`, while
+/// tests can install a a testing `setTestBackend(transport:)`.
+@available(anyAppleOS 26, *)
+protocol QUICDatagramProtocol {
+
+    /// Buffers `datagram` to be sent on the next `flush()`.
+    ///
+    /// The peer's advertised `max_datagram_frame_size` is checked by `QUICDatagramHandler`
+    /// *before* this is called (that path fails with `QUICError.datagramTooLarge`), so the return
+    /// value is the transport's own accept/reject signal.
+    ///
+    /// - Returns: `true` if the datagram was accepted and buffered for the next `flush()`; `false`
+    ///   if the transport could not accept it (a transport-level constraint), which the handler
+    ///   surfaces to the caller as `QUICError.datagramWriteFailed`.
+    func write(datagram: ByteBuffer) -> Bool
+
+    /// Sends any datagrams buffered since the last `flush()`.
+    func flush()
+
+    /// Detaches the underlying flow and clears the current reader.
+    func close()
+
+    /// Sets the delegate that receives datagrams and errors from this transport.
+    func setReader(reader: any QUICDatagramReaderProtocol)
+
+}
+
+/// Receive datagrams and errors from a `QUICDatagramProtocol` conformance.
+@available(anyAppleOS 26, *)
+protocol QUICDatagramReaderProtocol: AnyObject {
+    /// Called once per datagram received from the peer.
+    func read(datagram: ByteBuffer)
+
+    /// Called when the underlying transport reports an error.
+    func error(error: any Error)
+}

--- a/Sources/NIOQUIC/QUICError.swift
+++ b/Sources/NIOQUIC/QUICError.swift
@@ -36,6 +36,9 @@ public struct QUICError: Error, Hashable, Sendable {
         case failedToRetireConnectionID
         case streamWriteFailed
         case streamHandlerNotFound
+        case datagramTooLarge
+        case datagramWriteFailed
+        case peerDoesNotAcceptDatagrams
         case unknownError(Int)
     }
 
@@ -107,6 +110,21 @@ public struct QUICError: Error, Hashable, Sendable {
 
     /// Indicates that the transport rejected a stream write.
     public static let streamWriteFailed: Self = .init(code: .streamWriteFailed)
+
+    /// Indicates that a datagram exceeded the peer's advertised `max_datagram_frame_size`.
+    ///
+    /// - Warning: This is based on an estimate. The check compares only the datagram payload length
+    ///   against the advertised limit and does not account for DATAGRAM frame overhead (frame type
+    ///   and length fields), so a datagram that passes the check may still be too large once framed.
+    ///   The transport enforces the exact on-the-wire size.
+    public static let datagramTooLarge: Self = .init(code: .datagramTooLarge)
+
+    /// Indicates that the transport failed to write a datagram, e.g. because it exceeded a
+    /// size constraint enforced by the transport.
+    public static let datagramWriteFailed: Self = .init(code: .datagramWriteFailed)
+
+    /// Inidicates that the peer advertised a maximum datagram size of 0.
+    public static let peerDoesNotAcceptDatagrams: Self = .init(code: .peerDoesNotAcceptDatagrams)
 
     /// Indicates an unknown error
     public static func unknownError(_ code: Int) -> Self { .init(code: .unknownError(code)) }

--- a/Sources/NIOQUIC/QUICHandler+Multiplexer.swift
+++ b/Sources/NIOQUIC/QUICHandler+Multiplexer.swift
@@ -102,6 +102,8 @@ extension QUICHandler {
                     inboundStreamInitializer: self.inboundStreamInitializer
                 )
                 try channel.pipeline.syncOperations.addHandler(connectionChannelHandler)
+                let datagramChannelHandler = QUICDatagramHandler(role: role, logger: logger)
+                try channel.pipeline.syncOperations.addHandler(datagramChannelHandler)
 
                 if let connectionDurationTimer = metrics?.connectionCloseMetrics?.connectionDuration {
                     let connectionDurationHandler = ChannelDurationHandler(durationTimer: connectionDurationTimer)
@@ -171,6 +173,8 @@ extension QUICHandler {
                                 )
 
                             try channel.pipeline.syncOperations.addHandler(connectionChannelHandler)
+                            let datagramChannelHandler = QUICDatagramHandler(role: self.role, logger: logger)
+                            try channel.pipeline.syncOperations.addHandler(datagramChannelHandler)
 
                             if let connectionDurationTimer = metrics?.connectionCloseMetrics?.connectionDuration {
                                 let connectionDurationHandler = ChannelDurationHandler(

--- a/Sources/NIOQUIC/QUICHandler.swift
+++ b/Sources/NIOQUIC/QUICHandler.swift
@@ -305,6 +305,9 @@ public final class QUICHandler {
 
                     try channel.pipeline.syncOperations.addHandler(connectionChannelHandler)
 
+                    let datagramChannelHandler = QUICDatagramHandler(role: role, logger: logger)
+                    try channel.pipeline.syncOperations.addHandler(datagramChannelHandler)
+
                     if let connectionDurationTimer = metrics?.connectionCloseMetrics?.connectionDuration {
                         let connectionDurationHandler = ChannelDurationHandler(
                             durationTimer: connectionDurationTimer
@@ -840,10 +843,12 @@ extension QUICHandler: ChannelInboundHandler {
                     metrics: self.metrics,
                     inboundStreamInitializer: inboundStreamInitializer
                 )
+                let datagramChannelHandler = QUICDatagramHandler(role: role, logger: self.logger)
                 let streamCreator = connectionChannelHandler.makeStreamCreator(role: role)
 
                 return channel.eventLoop.makeCompletedFuture {
                     try channel.pipeline.syncOperations.addHandler(connectionChannelHandler)
+                    try channel.pipeline.syncOperations.addHandler(datagramChannelHandler)
 
                     if let connectionDurationTimer = self.metrics?.connectionCloseMetrics?.connectionDuration {
                         let connectionDurationHandler = ChannelDurationHandler(durationTimer: connectionDurationTimer)

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
@@ -62,6 +62,8 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
     private var connectionView: SwiftNetworkQUICConnection.NewFlowView!
     private var lowerProtocol = LowerProtocol(reference: .init())
 
+    private var datagramListener: DatagramListenerLinkage
+
     // Internal mutable state
     var keepAliveInterval: Duration?
 
@@ -75,6 +77,7 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
         localAddress: SocketAddress,
         role: Role,
         streamListenerProtocol: StreamListenerLinkage,
+        datagramListenerProtocol: DatagramListenerLinkage,
         keepAliveInterval: Duration? = nil
     ) {
         self.local = local
@@ -88,6 +91,7 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
         self.keepAliveInterval = keepAliveInterval
         self.logPrefix = "[\(self.role.description)][NewFlowHandler]"
         self.localAddress = localAddress
+        self.datagramListener = datagramListenerProtocol
         do throws(NetworkError) {
             self.lowerProtocol = try streamListenerProtocol.invokeAttachNewStreamFlowProtocol(
                 self.reference,
@@ -161,7 +165,12 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
     // Received connected event
     func handleConnectedEvent(_ from: SwiftNetwork.ProtocolInstanceReference) {
         log("connected received")
-        self.connectionView.connected()
+        if self.connectionView.connected() {
+            // Only attach if the connection setup succeeded. The state machine
+            // in the connection will reject repeated events and connected
+            // events while the connection is already closing.
+            self.attachDatagramFlow()
+        }
     }
 
     // Received disconnected event
@@ -299,6 +308,67 @@ extension QUICChannelNewFlowHandler: UpperProtocolHandler {
 
         self.fromExternal {
             self.lowerProtocol.invokeApplicationEvent(self.reference, event: event)
+        }
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICChannelNewFlowHandler {
+    /// Attach the datagram flow once the connection is established.
+    ///
+    /// Note: This must run after the peer's transport parameters are applied: SwiftNetwork computes the
+    /// flow's usable datagram size only at attach time (`updateUsableDatagramFrameSize`), from
+    /// `remoteMaxDatagramFrameSize`, which is `0` until the handshake completes. Attaching earlier
+    /// freezes the usable size at `0` and datagrams can never be sent.
+    private func attachDatagramFlow() {
+        guard
+            let datagramHandler = try? self.connectionChannel?.pipeline.syncOperations.handler(
+                type: QUICDatagramHandler.self
+            )
+        else {
+            self.logger.warning("\(self.logPrefix) No datagram channel handler found in pipeline")
+            return
+        }
+
+        do {
+            let transport = QUICDatagramTransport(
+                role: self.role,
+                logger: self.logger,
+                context: self.context
+            )
+
+            var swiftNetworkParameters = SwiftNetwork.Parameters()
+            swiftNetworkParameters.context = self.context
+            let swiftNetworkPath = SwiftNetwork.PathProperties(parameters: swiftNetworkParameters)
+            let quicOptions = QUICStreamProtocol.options()
+            guard let perProtocolOptions = quicOptions.perProtocolOptions else {
+                throw QUICError.invalidConfiguration
+            }
+            perProtocolOptions.isDatagram = true
+            quicOptions.setProtocolInstance(self.datagramListener.reference)
+            swiftNetworkParameters.defaultStack.prepend(applicationProtocol: quicOptions)
+
+            let linkage = try self.datagramListener.invokeAttachUpperDatagramProtocolToNewFlow(
+                transport.reference,
+                remote: nil,
+                local: nil,
+                parameters: swiftNetworkParameters,
+                path: swiftNetworkPath
+            )
+            transport.setFlowLinkage(linkage)
+            linkage.invokeConnect(transport.reference)
+
+            // TODO: Once SwiftNetwork (a40d5771fc586e75f3534e55178398baa1db2966) is released,
+            // replace the hardcoded `UInt16.max` with the peer's advertised `max_datagram_frame_size`, read
+            // from the connection metadata via `getConnectionMetadata()` (as with `activeConnectionIDLimit`).
+            // A zero says that the peer does not accept datagrams.
+            //
+            // Better still, use SwiftNetwork's *usable* datagram size, which already subtracts framing
+            // overhead and path MTU (`QUICDatagramFlow.updateUsableDatagramFrameSize`) — passing that
+            // would make the handler's size check exact instead of the current payload-only estimate.
+            datagramHandler.setBackend(to: transport, withPeerMaxDatagramFrameSize: Int(UInt16.max))
+        } catch {
+            self.logger.error("\(self.logPrefix) Failed to attach QUIC datagram flow: \(error)")
         }
     }
 }

--- a/Sources/NIOQUIC/SwiftNetwork/QUICConfiguration.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICConfiguration.swift
@@ -111,6 +111,8 @@ public struct QUICConfiguration: Sendable {
     public var qLogConfiguration: QLogConfiguration?
     /// Configure verification of the peer's certificate. Only supported by the client.
     public var peerCertificateVerification: CertificateVerification
+    /// Maximum datagram frame size in bytes. Set to 0 to disable datagrams. Defaults to UInt16.max.
+    public var maxDatagramFrameSize: UInt16  // TODO: Make this an Int
 
     private init(
         role: Role,
@@ -131,7 +133,8 @@ public struct QUICConfiguration: Sendable {
         sendRetry: Bool,
         keyLogPath: String?,
         qLogConfiguration: QLogConfiguration?,
-        peerCertificateVerification: CertificateVerification
+        peerCertificateVerification: CertificateVerification,
+        maxDatagramFrameSize: UInt16
     ) {
         self.role = role
         self.serverName = serverName
@@ -152,6 +155,7 @@ public struct QUICConfiguration: Sendable {
         self.keyLogPath = keyLogPath
         self.qLogConfiguration = qLogConfiguration
         self.peerCertificateVerification = peerCertificateVerification
+        self.maxDatagramFrameSize = maxDatagramFrameSize
     }
 
     /// Factory method to initialise a `QUICConfiguration` for servers.
@@ -179,7 +183,8 @@ public struct QUICConfiguration: Sendable {
         keepAliveInterval: Duration? = nil,
         sendRetry: Bool = false,
         keyLogPath: String? = nil,
-        qLogConfiguration: QLogConfiguration? = nil
+        qLogConfiguration: QLogConfiguration? = nil,
+        maxDatagramFrameSize: UInt16 = .max
     ) -> Self {
         self.init(
             role: .server,
@@ -200,7 +205,8 @@ public struct QUICConfiguration: Sendable {
             sendRetry: sendRetry,
             keyLogPath: keyLogPath,
             qLogConfiguration: qLogConfiguration,
-            peerCertificateVerification: .noVerification
+            peerCertificateVerification: .noVerification,
+            maxDatagramFrameSize: maxDatagramFrameSize
         )
     }
 
@@ -229,7 +235,8 @@ public struct QUICConfiguration: Sendable {
         forceVersionNegotiation: Bool = false,
         keyLogPath: String? = nil,
         qLogConfiguration: QLogConfiguration? = nil,
-        peerCertificateVerification: CertificateVerification = .fullVerification
+        peerCertificateVerification: CertificateVerification = .fullVerification,
+        maxDatagramFrameSize: UInt16 = .max
     ) -> Self {
         self.init(
             role: .client,
@@ -250,7 +257,8 @@ public struct QUICConfiguration: Sendable {
             sendRetry: false,
             keyLogPath: keyLogPath,
             qLogConfiguration: qLogConfiguration,
-            peerCertificateVerification: peerCertificateVerification
+            peerCertificateVerification: peerCertificateVerification,
+            maxDatagramFrameSize: maxDatagramFrameSize
         )
     }
 }

--- a/Sources/NIOQUIC/SwiftNetwork/QUICDatagramTransport.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICDatagramTransport.swift
@@ -47,7 +47,7 @@ final class QUICDatagramTransport: ProtocolInstanceContainer, InboundDatagramHan
     private var bufferedDatagrams: TinyArray<ByteBuffer> = []
 
     /// The delegate notified of inbound datagrams and errors, set via `setReader(reader:)`.
-    private var quicDatagramReader: any QUICDatagramReaderProtocol?
+    private var quicDatagramReader: (any QUICDatagramReaderProtocol)?
 
     init(role: Role, logger: Logger, context: NetworkContext) {
         self.logPrefix = "[\(role.description)][DatagramHandler]"

--- a/Sources/NIOQUIC/SwiftNetwork/QUICDatagramTransport.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICDatagramTransport.swift
@@ -1,0 +1,215 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOCore
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// Implementation of `QUICDatagramProtocol` backed by a SwiftNetwork QUIC datagram flow.
+///
+/// Conforms to SwiftNetwork's `InboundDatagramHandler` to receive inbound datagram events and
+/// `ProtocolInstanceContainer` to be addressable as a protocol instance; `QUICDatagramHandler`
+/// talks to it only through `QUICDatagramProtocol`.
+@available(anyAppleOS 26, *)
+final class QUICDatagramTransport: ProtocolInstanceContainer, InboundDatagramHandler {
+    typealias LowerProtocol = OutboundDatagramLinkage
+
+    internal var reference = ProtocolInstanceReference()
+    internal var eventManager = ProtocolEventManager()
+    /// The datagram flow this transport sends and receives on. Replaced with a live linkage by
+    /// `setFlowLinkage(_:)` once the flow has been attached.
+    internal var lower: OutboundDatagramLinkage = .init(reference: .init())
+    internal var context: SwiftNetwork.NetworkContext
+
+    internal var logPrefix: String
+    internal let logger: Logger
+
+    /// Datagrams written since the last successful `flush()`.
+    private var bufferedDatagrams: TinyArray<ByteBuffer> = []
+
+    /// The delegate notified of inbound datagrams and errors, set via `setReader(reader:)`.
+    private var quicDatagramReader: any QUICDatagramReaderProtocol?
+
+    init(role: Role, logger: Logger, context: NetworkContext) {
+        self.logPrefix = "[\(role.description)][DatagramHandler]"
+        self.logger = logger
+        self.context = context
+        self.reference = ProtocolInstanceReference(custom: self)
+    }
+
+    /// Installs the flow linkage returned by attaching this transport to a new datagram flow.
+    func setFlowLinkage(_ linkage: OutboundDatagramLinkage) {
+        self.lower = linkage
+    }
+
+    func log(_ message: @autoclosure () -> String) {
+        #if DEBUG
+        self.logger.trace("\(self.logPrefix) \(message())")
+        #endif
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramTransport: QUICDatagramProtocol {
+
+    /// Buffers `datagram` for the next `flush()`, always returning `true`.
+    ///
+    /// Datagram delivery is unreliable: buffering here always succeeds, but the datagram may still
+    /// be dropped later. SwiftNetwork enforces the real on-the-wire size at packetization (the
+    /// peer's `max_datagram_frame_size` and the path MTU), so this method does not itself
+    /// reject oversized datagrams.
+    func write(datagram: NIOCore.ByteBuffer) -> Bool {
+        self.bufferedDatagrams.append(datagram)
+        return true
+    }
+
+    /// Sends all buffered datagrams if the flow is connected.
+    func flush() {
+        guard self.bufferedDatagrams.count > 0, lower.isConnected else {
+            return
+        }
+
+        do {
+            self.log("writing \(self.bufferedDatagrams.count) QUIC datagrams")
+            var frameArray = FrameArray(capacity: self.bufferedDatagrams.count)
+            for var datagram in self.bufferedDatagrams {
+                datagram.withUnsafeMutableReadableBytesWithStorageManagement2 { buffer, owner in
+                    frameArray.add(frame: Frame(customBuffer: buffer, owner: owner))
+                }
+            }
+            try lower.invokeSendDatagrams(self.reference, datagrams: frameArray)
+            self.bufferedDatagrams.removeAll(where: { _ in true })
+        } catch {
+            self.logger.error("QUIC send datagrams: \(error)")
+            self.quicDatagramReader?.error(error: error)
+        }
+    }
+
+    /// Clears the reader and detaches the underlying flow.
+    func close() {
+        // Log dropped datagrams.
+        if !self.bufferedDatagrams.isEmpty {
+            self.logger.debug(
+                "\(self.logPrefix) dropping \(self.bufferedDatagrams.count) unflushed datagrams on close"
+            )
+        }
+
+        // Cleanup linkage with SwiftNetwork.
+        do throws(NetworkError) {
+            try lower.invokeDetach(self.reference)
+        } catch {
+            self.logger.error("datagram flow detach failed: \(error)")
+        }
+        self.reference = ProtocolInstanceReference()
+
+        // Remove reference to reader.
+        self.quicDatagramReader = nil
+    }
+
+    /// Register a reader for datagrams.
+    ///
+    /// This can only hold one endpoint. Each call overwrite the previously set reader.
+    func setReader(reader: any QUICDatagramReaderProtocol) {
+        self.quicDatagramReader = reader
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramTransport {
+    /// Drains all datagrams currently available on the flow and forwards each to the reader.
+    /// Does nothing if no reader has been set.
+    func handleInboundDataAvailableEvent(_ from: ProtocolInstanceReference) {
+        guard let reader = self.quicDatagramReader else {
+            self.log("handle inbound data, but no reader set")
+            return
+        }
+
+        do throws(NetworkError) {
+            while var frames = try lower.invokeReceiveDatagrams(self.reference, maximumDatagramCount: .max),
+                frames.count > 0
+            {
+                frames.iterateMutableFrames { frame in
+                    frame.span?.withUnsafeBufferPointer { spanBuffer in
+                        var datagram = ByteBuffer()
+                        datagram.writeWithUnsafeMutableBytes(
+                            minimumWritableBytes: spanBuffer.count
+                        ) { buffer in
+                            buffer.copyMemory(from: UnsafeRawBufferPointer(spanBuffer))
+                            return spanBuffer.count
+                        }
+                        reader.read(datagram: datagram)
+                    }
+                    frame.finalize(success: true)
+                    return true
+                }
+            }
+        } catch {
+            self.logger.error("QUIC datagram receive error: \(error)")
+        }
+    }
+}
+
+// Connection events are already handled by the `QUICChannelNewFlowHandler`.
+@available(anyAppleOS 26, *)
+extension QUICDatagramTransport {
+    func attachLowerDatagramProtocol(
+        _ lowerProtocol: SwiftNetwork.ProtocolInstanceReference,
+        remote: SwiftNetwork.Endpoint?,
+        local: SwiftNetwork.Endpoint?,
+        parameters: SwiftNetwork.Parameters?,
+        path: SwiftNetwork.PathProperties?
+    ) throws(SwiftNetwork.NetworkError) {
+        throw NetworkError.posix(ENOTSUP)
+    }
+
+    func handleOutboundRoomAvailableEvent(_ from: SwiftNetwork.ProtocolInstanceReference) {
+        // nop
+    }
+
+    func attachLowerProtocol(
+        _ lowerProtocol: SwiftNetwork.ProtocolInstanceReference,
+        remote: SwiftNetwork.Endpoint?,
+        local: SwiftNetwork.Endpoint?,
+        parameters: SwiftNetwork.Parameters?,
+        path: SwiftNetwork.PathProperties?
+    ) throws(SwiftNetwork.NetworkError) {
+        throw NetworkError.posix(ENOTSUP)
+    }
+
+    func handleConnectedEvent(_ from: SwiftNetwork.ProtocolInstanceReference) {
+        log("received connected event")
+        // Defer connection-level handling to `SwiftNetworkQUICConnection`.
+        self.flush()
+    }
+
+    func handleDisconnectedEvent(_ from: SwiftNetwork.ProtocolInstanceReference, error: SwiftNetwork.NetworkError?) {
+        log("received disconnected event, error \(error.debugDescription)")
+        // Defer connection-level handling to `SwiftNetworkQUICConnection`.
+    }
+
+    func handleNetworkProtocolEvent(
+        _ from: SwiftNetwork.ProtocolInstanceReference,
+        event: SwiftNetwork.NetworkProtocolEvent
+    ) {
+        // nop
+    }
+}

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamOptions+QUICConfiguration.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamOptions+QUICConfiguration.swift
@@ -33,6 +33,7 @@ extension QUICProtocol {
         options.connectionOptions.maximumConcurrentBidirectionalStreams = config.initialMaxStreamsBidi
         options.connectionOptions.initialMaxStreamsUnidirectional = UInt64(config.initialMaxStreamsUni)
         options.connectionOptions.maximumConcurrentUnidirectionalStreams = config.initialMaxStreamsUni
+        options.connectionOptions.maxDatagramFrameSize = config.maxDatagramFrameSize
 
         guard let perProtocolOptions = options.perProtocolOptions else {
             throw QUICError.invalidConfiguration

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -95,6 +95,8 @@ final class SwiftNetworkQUICConnection {
     private var streamInputHandlers: [QUICStreamID: QUICChannelStreamHandler] = [:]
     private var pendingInitialClientStream: QUICChannelStreamHandler?
 
+    private var datagramHandler: QUICDatagramHandler?
+
     private var connectionStateMachine = QUICConnectionStateMachine()
 
     private var finalizedOutput: Deque<ByteBuffer> = []
@@ -355,7 +357,8 @@ final class SwiftNetworkQUICConnection {
 
         let localEndpoint = localAddress.toEndpoint()
         let remoteEndpoint = remoteAddress.toEndpoint()
-        let listenerLinkage = StreamListenerLinkage(reference: self.swiftNetworkQUICConnection.reference)
+        let streamListenerLinkage = StreamListenerLinkage(reference: self.swiftNetworkQUICConnection.reference)
+        let datagramListenerLinkage = DatagramListenerLinkage(reference: self.swiftNetworkQUICConnection.reference)
 
         let newFlowHandler = QUICChannelNewFlowHandler(
             local: localEndpoint,
@@ -366,7 +369,8 @@ final class SwiftNetworkQUICConnection {
             remoteAddress: remoteAddress,
             localAddress: localAddress,
             role: self.role,
-            streamListenerProtocol: listenerLinkage,
+            streamListenerProtocol: streamListenerLinkage,
+            datagramListenerProtocol: datagramListenerLinkage,
             // Keep-alive is driven by the connection flow handler on the server, but by the
             // initial client stream on the client (set up below).
             keepAliveInterval: self.role == .server ? configuration.keepAliveInterval : nil
@@ -1204,7 +1208,7 @@ extension SwiftNetworkQUICConnection {
     }
 
     /// Handle connected events from SwiftNetwork for connection-level handlers (e.g., newFlowHandler).
-    private func handleConnectionConnected() {
+    private func handleConnectionConnected() -> Bool {
         let action = self.connectionStateMachine.receiveConnectedEvent()
         switch action {
         case .logConnectionEstablished:
@@ -1215,7 +1219,7 @@ extension SwiftNetworkQUICConnection {
                 metadata: ["state": "\(self.connectionStateMachine.stateDescription)"]
             )
             // Do not announce connection IDs again.
-            return
+            return false
         }
 
         // Generate additional CIDs for the peer after handshake completes.
@@ -1243,7 +1247,7 @@ extension SwiftNetworkQUICConnection {
                 switch action {
                 case .closeInitiated, .alreadyClosed:
                     // No follow-up decisions to make. We just need to close the connection.
-                    return
+                    return false
                 }
             case .announce(let count):
                 for _ in 0..<count {
@@ -1254,6 +1258,7 @@ extension SwiftNetworkQUICConnection {
         } else {
             log("Will not announce new connection IDs because no generator was configured")
         }
+        return true
     }
 
     /// Handle disconnected events from SwiftNetwork for connection-level handlers (e.g., newFlowHandler).
@@ -1539,7 +1544,7 @@ extension SwiftNetworkQUICConnection {
             self.connection = connection
         }
 
-        func connected() {
+        func connected() -> Bool {
             self.connection.handleConnectionConnected()
         }
 

--- a/Tests/IntegrationTests/DatagramTests.swift
+++ b/Tests/IntegrationTests/DatagramTests.swift
@@ -313,9 +313,7 @@ struct DatagramTests {
         // Establish the connection with a tiny sync stream before sending datagrams.
         try await performSyncHandshake(streamCreator, signal: syncSignal, serverReceived: serverGotSync)
 
-        // The connection must stay open for this test; record it if it ever closes. Observing the
-        // close via a callback (not by awaiting `closeFuture`, which ignores task cancellation) keeps
-        // the later grace wait from hanging.
+        // The connection must stay open for this test; record it if it ever closes.
         clientConnectionChannel.closeFuture.whenComplete { _ in
             clientConnectionClosed.withLockedValue { $0 = true }
         }

--- a/Tests/IntegrationTests/DatagramTests.swift
+++ b/Tests/IntegrationTests/DatagramTests.swift
@@ -1,0 +1,633 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
+import Testing
+
+@testable import NIOQUIC
+
+@Suite(.serialized)
+struct DatagramTests {
+
+    func getChannelLoggers() -> (serverLogger: Logger, clientLogger: Logger) {
+        var clientLogger = Logger(label: "Client")
+        clientLogger.logLevel = .info
+        var serverLogger = Logger(label: "Server")
+        serverLogger.logLevel = .info
+        return (serverLogger, clientLogger)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func datagramRoundTrip() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        let loggers = getChannelLoggers()
+        let host = "127.0.0.1"
+        let payload = ByteBuffer(string: "hello datagram")
+        let syncSignal = ByteBuffer(string: "ready")
+
+        let noMoreConnectionsPromise = eventLoopGroup.any().makePromise(of: Void.self)
+        let serverReceivedSyncPromise = eventLoopGroup.any().makePromise(of: Void.self)
+        let serverReceivedPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
+        let clientReceivedEchoPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
+
+        let serverChannel = try await createServerChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.serverLogger,
+            inboundConnectionInitializer: { connectionChannel, streamCreator in
+                connectionChannel.eventLoop.makeCompletedFuture {
+                    try connectionChannel.pipeline.syncOperations.addHandler(
+                        DatagramCapture(onDatagram: { buffer in
+                            serverReceivedPromise.succeed(buffer)
+                            connectionChannel.writeAndFlush(buffer, promise: nil)
+                        })
+                    )
+                }
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.pipeline.eventLoop.makeCompletedFuture {
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        SyncSignalHandler(receivedPromise: serverReceivedSyncPromise)
+                    )
+                }
+            },
+            noMoreConnections: {
+                noMoreConnectionsPromise.succeed()
+            }
+        ).get()
+        let serverPort = serverChannel.localAddress!.port!
+
+        let clientChannel = try await createClientChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.clientLogger
+        ).get()
+
+        let (clientConnectionChannel, streamCreator) = try await connectOutbound(
+            clientChannel,
+            host: host,
+            port: serverPort
+        ) { connectionChannel, _ in
+            connectionChannel.eventLoop.makeCompletedFuture {
+                try connectionChannel.pipeline.syncOperations.addHandler(
+                    DatagramCapture(onDatagram: { clientReceivedEchoPromise.succeed($0) })
+                )
+            }
+        }
+
+        // Open a tiny synchronization stream first. Once the server reads it, the connection was established.
+        try await performSyncHandshake(streamCreator, signal: syncSignal, serverReceived: serverReceivedSyncPromise)
+
+        clientConnectionChannel.writeAndFlush(payload, promise: nil)
+
+        let serverReceived = try await serverReceivedPromise.futureResult.get()
+        #expect(serverReceived == payload)
+
+        let clientReceived = try await clientReceivedEchoPromise.futureResult.get()
+        #expect(clientReceived == payload)
+
+        try await serverChannel.close()
+        try await noMoreConnectionsPromise.futureResult.get()
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func datagramsSentBeforeConnectionEstablishmentAreBuffered() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        let loggers = getChannelLoggers()
+        let host = "127.0.0.1"
+        let payload = ByteBuffer(string: "server speaks first")
+
+        let noMoreConnectionsPromise = eventLoopGroup.any().makePromise(of: Void.self)
+        let clientReceivedPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
+
+        let datagramSentPromise = eventLoopGroup.any().makePromise(of: Void.self)
+
+        let serverChannel = try await createServerChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.serverLogger,
+            inboundConnectionInitializer: { connectionChannel, streamCreator in
+                connectionChannel.eventLoop.makeCompletedFuture {
+                    try connectionChannel.pipeline.syncOperations.addHandler(
+                        DirectlySendADatagramHandler(datagramPayload: payload, eventLoopPromise: datagramSentPromise)
+                    )
+                }
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            noMoreConnections: {
+                noMoreConnectionsPromise.succeed()
+            }
+        ).get()
+        let serverPort = serverChannel.localAddress!.port!
+
+        let clientChannel = try await createClientChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.clientLogger
+        ).get()
+
+        _ = try await connectOutbound(clientChannel, host: host, port: serverPort) { connectionChannel, _ in
+            connectionChannel.eventLoop.makeCompletedFuture {
+                try connectionChannel.pipeline.syncOperations.addHandler(
+                    DatagramCapture(onDatagram: { clientReceivedPromise.succeed($0) })
+                )
+            }
+        }
+
+        try await datagramSentPromise.futureResult.get()
+
+        let clientReceived = try await clientReceivedPromise.futureResult.get()
+        #expect(clientReceived == payload)
+
+        try await serverChannel.close()
+        try await noMoreConnectionsPromise.futureResult.get()
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func streamRoundTripWithDatagramsEnabled() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        let loggers = getChannelLoggers()
+        let host = "127.0.0.1"
+        let request = ByteBuffer(string: "GET /foo")
+        let response = ByteBuffer(string: "<b>Success</b>")
+
+        let noMoreConnectionsPromise = eventLoopGroup.any().makePromise(of: Void.self)
+        let serverReceivedPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
+        let clientReceivedPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
+
+        let serverChannel = try await createServerChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.serverLogger,
+            inboundConnectionInitializer: { connectionChannel, streamCreator in
+                connectionChannel.eventLoop.makeSucceededVoidFuture()
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.pipeline.eventLoop.makeCompletedFuture {
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        StreamEchoHandler(
+                            expectedRequest: request,
+                            response: response,
+                            receivedPromise: serverReceivedPromise
+                        )
+                    )
+                }
+            },
+            noMoreConnections: {
+                noMoreConnectionsPromise.succeed()
+            }
+        ).get()
+        let serverPort = serverChannel.localAddress!.port!
+
+        let clientChannel = try await createClientChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.clientLogger
+        ).get()
+
+        let (_, streamCreator) = try await connectOutbound(clientChannel, host: host, port: serverPort)
+
+        let streamChannel = try await streamCreator.createBidirectionalStream { streamInitializer in
+            streamInitializer.channel.eventLoop.makeCompletedFuture {
+                try streamInitializer.channel.pipeline.syncOperations.addHandler(
+                    ResponseCapture(response: response, receivedPromise: clientReceivedPromise)
+                )
+                streamInitializer.channel.writeAndFlush(request, promise: nil)
+                return streamInitializer.channel
+            }
+        }.get()
+
+        try await streamChannel.closeFuture.get()
+
+        let serverReceived = try await serverReceivedPromise.futureResult.get()
+        #expect(serverReceived == request)
+
+        let clientReceived = try await clientReceivedPromise.futureResult.get()
+        #expect(clientReceived == response)
+
+        try await serverChannel.close()
+        try await noMoreConnectionsPromise.futureResult.get()
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func unidirectionalDatagramAdvertisement() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        let loggers = getChannelLoggers()
+        let host = "127.0.0.1"
+        let syncSignal = ByteBuffer(string: "ready")
+        let clientToServer = ByteBuffer(string: "client to server datagram")
+        let serverToClient = ByteBuffer(string: "server to client datagram")
+
+        let serverGotSync = eventLoopGroup.any().makePromise(of: Void.self)
+
+        let serverConnectionChannelPromise = eventLoopGroup.any().makePromise(of: (any Channel).self)
+        let serverReceivedClientToServer = eventLoopGroup.any().makePromise(of: Void.self)
+        // Expected to stay empty.
+        let clientReceivedDatagrams = NIOLockedValueBox<[ByteBuffer]>([])
+        // No errors are expected on either connection channel.
+        let caughtErrors = NIOLockedValueBox<[String]>([])
+
+        // Server advertises datagram support (.max); client advertises none (0).
+        let serverChannel = try await createServerChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.serverLogger,
+            maxDatagramFrameSize: .max,
+            inboundConnectionInitializer: { connectionChannel, streamCreator in
+                connectionChannel.eventLoop.makeCompletedFuture {
+                    try connectionChannel.pipeline.syncOperations.addHandler(
+                        ErrorRecordingHandler(errors: caughtErrors)
+                    )
+                    try connectionChannel.pipeline.syncOperations.addHandler(
+                        DatagramCapture(onDatagram: { buffer in
+                            if buffer == clientToServer {
+                                serverReceivedClientToServer.succeed()
+                            }
+                        })
+                    )
+                    serverConnectionChannelPromise.succeed(connectionChannel)
+                }
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        SyncSignalHandler(receivedPromise: serverGotSync)
+                    )
+                }
+            },
+            noMoreConnections: {}
+        ).get()
+        let serverPort = serverChannel.localAddress!.port!
+
+        let clientChannel = try await createClientChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.clientLogger,
+            maxDatagramFrameSize: 0
+        ).get()
+
+        let clientConnectionClosed = NIOLockedValueBox<Bool>(false)
+        let (clientConnectionChannel, streamCreator) = try await connectOutbound(
+            clientChannel,
+            host: host,
+            port: serverPort
+        ) { connectionChannel, _ in
+            connectionChannel.eventLoop.makeCompletedFuture {
+                try connectionChannel.pipeline.syncOperations.addHandler(ErrorRecordingHandler(errors: caughtErrors))
+                try connectionChannel.pipeline.syncOperations.addHandler(
+                    DatagramCapture(onDatagram: { buffer in
+                        clientReceivedDatagrams.withLockedValue { $0.append(buffer) }
+                    })
+                )
+            }
+        }
+
+        // Establish the connection with a tiny sync stream before sending datagrams.
+        try await performSyncHandshake(streamCreator, signal: syncSignal, serverReceived: serverGotSync)
+
+        // The connection must stay open for this test; record it if it ever closes. Observing the
+        // close via a callback (not by awaiting `closeFuture`, which ignores task cancellation) keeps
+        // the later grace wait from hanging.
+        clientConnectionChannel.closeFuture.whenComplete { _ in
+            clientConnectionClosed.withLockedValue { $0 = true }
+        }
+
+        // client -> server: allowed, because the server advertised support.
+        clientConnectionChannel.writeAndFlush(clientToServer, promise: nil)
+        try await serverReceivedClientToServer.futureResult.get()
+
+        // server -> client: dropped on send, because the client advertised 0.
+        let serverConnectionChannel = try await serverConnectionChannelPromise.futureResult.get()
+        serverConnectionChannel.writeAndFlush(serverToClient, promise: nil)
+
+        // Give the datagram a chance to (not) arrive; the connection should stay open.
+        try await Task.sleep(for: .seconds(2))
+
+        let clientReceived = clientReceivedDatagrams.withLockedValue { $0 }
+        #expect(
+            clientReceived.isEmpty,
+            "server must not deliver datagrams to the client (client advertised 0)"
+        )
+        #expect(
+            !clientConnectionClosed.withLockedValue { $0 },
+            "the connection should stay open when the server sends toward a peer that advertised 0"
+        )
+        let errors = caughtErrors.withLockedValue { $0 }
+        #expect(errors.isEmpty, "unexpected error(s) on a connection channel: \(errors)")
+
+        try await serverChannel.close()
+    }
+
+    /// SwiftNetwork silently drops outbound datagrams larger than the size advertised by the peer..
+    @available(anyAppleOS 26, *)
+    @Test
+    func oversizedDatagramIsDroppedAndConnectionStaysOpen() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        let loggers = getChannelLoggers()
+        let host = "127.0.0.1"
+        let syncSignal = ByteBuffer(string: "ready")
+
+        // The server accepts DATAGRAM frames up to 256 bytes. The oversized payload clearly exceeds
+        // that while still fitting a single QUIC packet; the small payload is comfortably under it.
+        let serverMaxDatagramFrameSize: UInt16 = 256
+        let oversizedPayload = ByteBuffer(repeating: UInt8(ascii: "x"), count: 800)
+        let smallPayload = ByteBuffer(string: "small datagram")
+
+        let serverGotSync = eventLoopGroup.any().makePromise(of: Void.self)
+        // The oversized datagram is not expected to arrive.
+        let serverReceivedDatagrams = NIOLockedValueBox<[ByteBuffer]>([])
+        let clientReceivedSmall = eventLoopGroup.any().makePromise(of: Void.self)
+        // No errors are expected on either connection channel.
+        let caughtErrors = NIOLockedValueBox<[String]>([])
+
+        let serverChannel = try await createServerChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.serverLogger,
+            maxDatagramFrameSize: serverMaxDatagramFrameSize,
+            inboundConnectionInitializer: { connectionChannel, streamCreator in
+                connectionChannel.eventLoop.makeCompletedFuture {
+                    try connectionChannel.pipeline.syncOperations.addHandler(
+                        ErrorRecordingHandler(errors: caughtErrors)
+                    )
+                    try connectionChannel.pipeline.syncOperations.addHandler(
+                        DatagramCapture(onDatagram: { buffer in
+                            serverReceivedDatagrams.withLockedValue { $0.append(buffer) }
+                            // Echo it back so the client can prove the connection still works.
+                            connectionChannel.writeAndFlush(buffer, promise: nil)
+                        })
+                    )
+                }
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.eventLoop.makeCompletedFuture {
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        SyncSignalHandler(receivedPromise: serverGotSync)
+                    )
+                }
+            },
+            noMoreConnections: {}
+        ).get()
+        let serverPort = serverChannel.localAddress!.port!
+
+        let clientChannel = try await createClientChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.clientLogger
+        ).get()
+
+        let (clientConnectionChannel, streamCreator) = try await connectOutbound(
+            clientChannel,
+            host: host,
+            port: serverPort
+        ) { connectionChannel, _ in
+            connectionChannel.eventLoop.makeCompletedFuture {
+                try connectionChannel.pipeline.syncOperations.addHandler(ErrorRecordingHandler(errors: caughtErrors))
+                try connectionChannel.pipeline.syncOperations.addHandler(
+                    DatagramCapture(onDatagram: { buffer in
+                        if buffer == smallPayload {
+                            clientReceivedSmall.succeed()
+                        }
+                    })
+                )
+            }
+        }
+
+        // Establish the connection with a tiny sync stream before sending datagrams.
+        try await performSyncHandshake(streamCreator, signal: syncSignal, serverReceived: serverGotSync)
+
+        // Send the oversized datagram first, then a small one. Our `write` buffers and succeeds for
+        // both (they are below the hardcoded `.max` guard); SwiftNetwork drops the oversized one at
+        // packetization while the small one goes through.
+        clientConnectionChannel.writeAndFlush(oversizedPayload, promise: nil)
+        clientConnectionChannel.writeAndFlush(smallPayload, promise: nil)
+
+        // The connection is proven alive if the small datagram round-trips (client -> server ->
+        // client) after the oversized one was dropped.
+        try await clientReceivedSmall.futureResult.get()
+
+        let serverReceived = serverReceivedDatagrams.withLockedValue { $0 }
+        #expect(
+            !serverReceived.contains(oversizedPayload),
+            "oversized datagram must be dropped on send, not delivered to the server"
+        )
+        #expect(
+            serverReceived.contains(smallPayload),
+            "server should receive the small datagram"
+        )
+        let errors = caughtErrors.withLockedValue { $0 }
+        #expect(errors.isEmpty, "unexpected error(s) on a connection channel: \(errors)")
+
+        try await serverChannel.close()
+    }
+}
+
+/// Opens an outbound QUIC connection on `clientChannel` to `host:port`, running
+/// `connectionInitializer` on the connection channel. The client never accepts inbound streams in
+/// these tests.
+@available(anyAppleOS 26, *)
+func connectOutbound(
+    _ clientChannel: any Channel,
+    host: String,
+    port: Int,
+    connectionInitializer: @escaping @Sendable (any Channel, QUICStreamCreator) -> EventLoopFuture<Void> = {
+        connectionChannel,
+        _ in connectionChannel.eventLoop.makeSucceededVoidFuture()
+    }
+) async throws -> (any Channel, QUICStreamCreator) {
+    try await clientChannel.pipeline.handler(type: QUICHandler.self).flatMap { quicHandler in
+        quicHandler.createOutboundConnection(
+            serverName: "\(host):\(port)",
+            remoteAddress: try! .init(ipAddress: host, port: port),
+            connectionInitializer: connectionInitializer,
+            inboundStreamInitializer: { _ in fatalError() }
+        )
+    }.get()
+}
+
+/// Opens a bidirectional stream, writes `signal`, and waits for the server to report receipt via
+/// `serverReceived` — a lightweight handshake proving the connection reached the connected state.
+@available(anyAppleOS 26, *)
+func performSyncHandshake(
+    _ streamCreator: QUICStreamCreator,
+    signal: ByteBuffer,
+    serverReceived: EventLoopPromise<Void>
+) async throws {
+    let stream = try await streamCreator.createBidirectionalStream { streamInitializer in
+        streamInitializer.channel.eventLoop.makeSucceededFuture(streamInitializer.channel)
+    }.get()
+    stream.writeAndFlush(signal, promise: nil)
+    try await serverReceived.futureResult.get()
+}
+
+/// Succeeds `receivedPromise` on the first byte of stream data. Used purely as a
+/// synchronization signal to prove a connection has reached the connected state.
+@available(anyAppleOS 26, *)
+private final class SyncSignalHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    private let receivedPromise: EventLoopPromise<Void>
+
+    init(receivedPromise: EventLoopPromise<Void>) {
+        self.receivedPromise = receivedPromise
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.receivedPromise.succeed()
+    }
+}
+
+/// Captures inbound QUIC datagrams delivered on the connection channel.
+@available(anyAppleOS 26, *)
+final class DatagramCapture: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    let onDatagram: @Sendable (ByteBuffer) -> Void
+
+    init(onDatagram: @escaping @Sendable (ByteBuffer) -> Void) {
+        self.onDatagram = onDatagram
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let buffer = self.unwrapInboundIn(data)
+        self.onDatagram(buffer)
+    }
+}
+
+/// Sets `flag` to `true` on the first stream read.
+@available(anyAppleOS 26, *)
+private final class StreamReadFlagHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    private let flag: NIOLockedValueBox<Bool>
+
+    init(flag: NIOLockedValueBox<Bool>) {
+        self.flag = flag
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.flag.withLockedValue { $0 = true }
+    }
+}
+
+/// Echoes a fixed response once it has received the expected request bytes,
+/// then closes the stream.
+@available(anyAppleOS 26, *)
+private final class StreamEchoHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    private let expectedRequest: ByteBuffer
+    private let response: ByteBuffer
+    private let receivedPromise: EventLoopPromise<ByteBuffer>
+    private var requestBuffer = ByteBuffer()
+
+    init(expectedRequest: ByteBuffer, response: ByteBuffer, receivedPromise: EventLoopPromise<ByteBuffer>) {
+        self.expectedRequest = expectedRequest
+        self.response = response
+        self.receivedPromise = receivedPromise
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.requestBuffer.writeImmutableBuffer(self.unwrapInboundIn(data))
+        guard self.requestBuffer.readableBytes >= self.expectedRequest.readableBytes else {
+            return
+        }
+        self.receivedPromise.succeed(self.requestBuffer)
+        context.writeAndFlush(self.wrapOutboundOut(self.response), promise: nil)
+        context.close(mode: .output, promise: nil)
+    }
+}
+
+/// Captures the first response buffer received on a request stream.
+@available(anyAppleOS 26, *)
+private final class ResponseCapture: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    private let response: ByteBuffer
+    private let receivedPromise: EventLoopPromise<ByteBuffer>
+    private var responseBuffer = ByteBuffer()
+
+    init(response: ByteBuffer, receivedPromise: EventLoopPromise<ByteBuffer>) {
+        self.response = response
+        self.receivedPromise = receivedPromise
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.responseBuffer.writeImmutableBuffer(self.unwrapInboundIn(data))
+        guard self.responseBuffer.readableBytes >= self.response.readableBytes else {
+            return
+        }
+        self.receivedPromise.succeed(self.responseBuffer)
+        context.close(promise: nil)
+    }
+}
+
+@available(anyAppleOS 26, *)
+private final class DirectlySendADatagramHandler: ChannelOutboundHandler {
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    private let datagramPayload: ByteBuffer
+    private let eventLoopPromise: EventLoopPromise<Void>
+
+    init(datagramPayload: ByteBuffer, eventLoopPromise: EventLoopPromise<Void>) {
+        self.datagramPayload = datagramPayload
+        self.eventLoopPromise = eventLoopPromise
+    }
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        let buffer = self.wrapOutboundOut(self.datagramPayload)
+        context.writeAndFlush(buffer, promise: self.eventLoopPromise)
+    }
+}
+
+/// Records any error that reaches it (thread-safe) and forwards it. `Issue.record` can't be used
+/// from here — `errorCaught` runs on an event-loop thread outside the test's task, so under the
+/// concurrent test execution our CI uses the issue would misattribute. Tests assert on the recorded
+/// errors from their own task instead.
+@available(anyAppleOS 26, *)
+private final class ErrorRecordingHandler: ChannelInboundHandler {
+    typealias InboundIn = Any
+
+    let errors: NIOLockedValueBox<[String]>
+
+    init(errors: NIOLockedValueBox<[String]>) {
+        self.errors = errors
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
+        self.errors.withLockedValue { $0.append("\(error)") }
+        context.fireErrorCaught(error)
+    }
+}

--- a/Tests/IntegrationTests/SyncTestSetup.swift
+++ b/Tests/IntegrationTests/SyncTestSetup.swift
@@ -39,6 +39,7 @@ func createServerChannel(
     host: String,
     port: Int,
     logger: Logger,
+    maxDatagramFrameSize: UInt16 = .max,
     udpChannelInitializer: @Sendable @escaping (any Channel) throws -> Void = { _ in },
     inboundConnectionInitializer:
         @Sendable @escaping (any Channel, NIOQUIC.QUICStreamCreator) -> EventLoopFuture<Void>,
@@ -53,7 +54,8 @@ func createServerChannel(
             privateKeyFilePath: Bundle.module.url(forResource: "privateKey", withExtension: "der")!.path
         ),
         applicationProtocols: ["http/0.9"],
-        keyLogPath: "/tmp/quic-sync-integration-tests-keylogs"
+        keyLogPath: "/tmp/quic-sync-integration-tests-keylogs",
+        maxDatagramFrameSize: maxDatagramFrameSize
     )
     return createQUICChannel(
         eventLoopGroup: eventLoopGroup,
@@ -79,13 +81,15 @@ func createClientChannel(
     host: String,
     port: Int,
     logger: Logger,
+    maxDatagramFrameSize: UInt16 = .max,
     udpChannelInitializer: @Sendable @escaping (any Channel) throws -> Void = { _ in }
 ) -> EventLoopFuture<any Channel> {
     let quicConfiguration = QUICConfiguration.client(
         verificationConfiguration: .rawPublicKeys(
             publicKeyFilePath: Bundle.module.url(forResource: "publicKey", withExtension: "der")!.path
         ),
-        applicationProtocols: ["http/0.9"]
+        applicationProtocols: ["http/0.9"],
+        maxDatagramFrameSize: maxDatagramFrameSize
     )
 
     return createQUICChannel(

--- a/Tests/NIOQUICTests/QUICDatagramHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICDatagramHandlerTests.swift
@@ -1,0 +1,348 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOConcurrencyHelpers
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import NIOQUIC
+
+/// Unit tests for `QUICDatagramHandler` driven through the `setTestBackend` seam and a
+/// `DatagramTestTransport`, so the negotiation state machine and datagram passthrough can be
+/// exercised in an `EmbeddedChannel` without a real SwiftNetwork flow.
+@Suite
+struct QUICDatagramHandlerTests {
+
+    // MARK: - Buffering before the peer advertisement
+
+    @available(anyAppleOS 26, *)
+    @Test("Writes buffered before the peer advertisement flush once the peer accepts")
+    func bufferedWritesFlushWhenPeerAccepts() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            let first = ByteBuffer(string: "first")
+            let second = ByteBuffer(string: "second")
+
+            // No backend installed yet: both writes are held, not handed to any transport.
+            let firstResult = Self.write(channel, first)
+            let secondResult = Self.write(channel, second)
+            #expect(Self.outcome(firstResult) == nil)
+            #expect(Self.outcome(secondResult) == nil)
+            #expect(transport.writtenDatagrams.isEmpty)
+
+            // Peer advertises a limit that fits both: the buffered writes flush in order and succeed.
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+            #expect(transport.writtenDatagrams == [first, second])
+            #expect(Self.succeeded(firstResult))
+            #expect(Self.succeeded(secondResult))
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("Writes buffered before the peer advertisement fail when the peer advertises 0")
+    func bufferedWritesFailWhenPeerRejects() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            let result = Self.write(channel, ByteBuffer(string: "buffered"))
+            #expect(Self.outcome(result) == nil)
+
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 0)
+            #expect(Self.failedQUICError(result) == .peerDoesNotAcceptDatagrams)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A buffered write larger than the advertised limit fails as datagramTooLarge")
+    func bufferedOversizedWriteFailsAsTooLarge() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            // Buffered while waiting, then the peer accepts a smaller limit than this datagram.
+            let result = Self.write(channel, ByteBuffer(repeating: UInt8(ascii: "x"), count: 200))
+            #expect(Self.outcome(result) == nil)
+
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+            // Peer *does* accept datagrams, this one just does not fit: distinct from "not accepted".
+            #expect(Self.failedQUICError(result) == .datagramTooLarge)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A buffered write exactly at the advertised limit is accepted")
+    func bufferedWriteAtExactLimitSucceeds() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            // The size check is `<=` and payload-only (ignores frame overhead), so a payload equal to
+            // the advertised limit is accepted here; the transport enforces the exact framed size.
+            let payload = ByteBuffer(repeating: UInt8(ascii: "x"), count: 100)
+            let result = Self.write(channel, payload)
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+            #expect(Self.succeeded(result))
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    // MARK: - Steady-state writes (peer advertisement already known)
+
+    @available(anyAppleOS 26, *)
+    @Test("A write within the advertised limit is handed to the transport and succeeds")
+    func writeWithinLimitSucceeds() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let payload = ByteBuffer(string: "datagram")
+            let result = Self.write(channel, payload)
+            #expect(Self.succeeded(result))
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A write larger than the advertised limit fails as datagramTooLarge and is not sent")
+    func oversizedWriteFailsAsTooLarge() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let result = Self.write(channel, ByteBuffer(repeating: UInt8(ascii: "x"), count: 200))
+            #expect(Self.failedQUICError(result) == .datagramTooLarge)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A write exactly at the advertised limit is accepted")
+    func writeAtExactLimitSucceeds() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            // `<=`, payload-only (ignores frame overhead): a payload equal to the advertised limit is
+            // accepted here; the transport enforces the exact framed size.
+            let payload = ByteBuffer(repeating: UInt8(ascii: "x"), count: 100)
+            let result = Self.write(channel, payload)
+            #expect(Self.succeeded(result))
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A within-limit write the transport rejects fails as datagramWriteFailed")
+    func transportRejectionFails() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            transport.writeResult = false
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            // The datagram passes the size check, so it is handed to the transport, which rejects it.
+            let payload = ByteBuffer(string: "datagram")
+            let result = Self.write(channel, payload)
+            #expect(Self.failedQUICError(result) == .datagramWriteFailed)
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A write fails as peerDoesNotAcceptDatagrams when the peer advertised 0")
+    func writeFailsWhenPeerRejects() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 0)
+
+            let result = Self.write(channel, ByteBuffer(string: "datagram"))
+            #expect(Self.failedQUICError(result) == .peerDoesNotAcceptDatagrams)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    // MARK: - Inbound
+
+    @available(anyAppleOS 26, *)
+    @Test("An inbound datagram from the transport is fired as a channelRead")
+    func inboundDatagramIsDeliveredAsChannelRead() throws {
+        try Self.withHandler { _, handler, transport, recorder in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let payload = ByteBuffer(string: "inbound")
+            transport.deliverInbound(payload)
+            #expect(recorder.reads == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A transport error is fired as an errorCaught")
+    func transportErrorIsFiredAsErrorCaught() throws {
+        try Self.withHandler { _, handler, transport, recorder in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            transport.deliverError(TestError())
+            #expect(recorder.errors.count == 1)
+            #expect(recorder.errors.first is TestError)
+        }
+    }
+
+    // MARK: - Teardown
+
+    @available(anyAppleOS 26, *)
+    @Test("Removing the handler while still waiting fails buffered writes")
+    func handlerRemovalFailsBufferedWrites() throws {
+        try Self.withHandler { channel, _, _, _ in
+            // Buffered while waiting, no backend ever installed.
+            let result = Self.write(channel, ByteBuffer(string: "buffered"))
+            #expect(Self.outcome(result) == nil)
+
+            // `close0` defers `removeHandlers` (and thus `handlerRemoved`) via `eventLoop.execute`,
+            // so drain the loop to make it run before asserting. The harness's later `finish()` then
+            // throws `.alreadyClosed` (channel is closed), which its `try?` swallows.
+            channel.close(promise: nil)
+            (channel.eventLoop as! EmbeddedEventLoop).run()
+            #expect(Self.failedChannelError(result) == .ioOnClosedChannel)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("Removing the handler after a backend is installed closes the transport")
+    func handlerRemovalClosesTransport() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            channel.close(promise: nil)
+            (channel.eventLoop as! EmbeddedEventLoop).run()
+            #expect(transport.closeCount == 1)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A channel flush propagates to the transport")
+    func flushPropagatesToTransport() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let flushesBefore = transport.flushCount
+            _ = Self.write(channel, ByteBuffer(string: "datagram"))
+            #expect(transport.flushCount > flushesBefore)
+        }
+    }
+}
+
+// MARK: - Test harness
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandlerTests {
+    /// Builds an `EmbeddedChannel` with a `QUICDatagramHandler` under test and a downstream
+    /// `DatagramRecorder`, plus a `DatagramTestTransport` the body installs via `setTestBackend`.
+    static func withHandler(
+        role: Role = .client,
+        body: (EmbeddedChannel, QUICDatagramHandler, DatagramTestTransport, DatagramRecorder) throws -> Void
+    ) throws {
+        let channel = EmbeddedChannel()
+        let handler = QUICDatagramHandler(role: role, logger: Logger(label: "test"))
+        let recorder = DatagramRecorder()
+        try channel.pipeline.syncOperations.addHandlers([handler, recorder])
+        let transport = DatagramTestTransport()
+        defer { _ = try? channel.finish() }
+        try body(channel, handler, transport, recorder)
+    }
+
+    /// Writes and flushes `buffer` on the channel, returning the write's future so the test can
+    /// inspect whether it succeeded, failed, or is still buffered.
+    static func write(_ channel: EmbeddedChannel, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+        let promise = channel.eventLoop.makePromise(of: Void.self)
+        channel.writeAndFlush(buffer, promise: promise)
+        return promise.futureResult
+    }
+
+    /// The resolved result of `future`, or `nil` if it is still pending. Safe to read synchronously
+    /// because `EmbeddedChannel` runs the pipeline single-threaded and in-line, so the datagram
+    /// handler's promises are resolved before this returns, and `whenComplete` on an already-resolved
+    /// future fires immediately. This would be racy against a real threaded `EventLoopGroup`.
+    static func outcome(_ future: EventLoopFuture<Void>) -> Result<Void, any Error>? {
+        let box = NIOLockedValueBox<Result<Void, any Error>?>(nil)
+        future.whenComplete { result in box.withLockedValue { $0 = result } }
+        return box.withLockedValue { $0 }
+    }
+
+    static func succeeded(_ future: EventLoopFuture<Void>) -> Bool {
+        if case .success = Self.outcome(future) { return true }
+        return false
+    }
+
+    static func failedQUICError(_ future: EventLoopFuture<Void>) -> QUICError? {
+        guard case .failure(let error) = Self.outcome(future) else { return nil }
+        return error as? QUICError
+    }
+
+    static func failedChannelError(_ future: EventLoopFuture<Void>) -> ChannelError? {
+        guard case .failure(let error) = Self.outcome(future) else { return nil }
+        return error as? ChannelError
+    }
+}
+
+/// A `QUICDatagramProtocol` test double: records outbound datagrams and lets tests inject inbound
+/// datagrams and errors back through the reader the handler installs.
+@available(anyAppleOS 26, *)
+final class DatagramTestTransport: QUICDatagramProtocol {
+    private(set) var writtenDatagrams: [ByteBuffer] = []
+    private(set) var flushCount = 0
+    private(set) var closeCount = 0
+    private var reader: (any QUICDatagramReaderProtocol)?
+
+    /// What `write(datagram:)` returns. Flip to `false` to simulate the transport rejecting a
+    /// datagram that passed the size check.
+    var writeResult = true
+
+    func write(datagram: ByteBuffer) -> Bool {
+        self.writtenDatagrams.append(datagram)
+        return self.writeResult
+    }
+
+    func flush() {
+        self.flushCount += 1
+    }
+
+    func close() {
+        self.closeCount += 1
+        // Mirror the production transport: dropping the reader breaks the handler <-> transport cycle.
+        self.reader = nil
+    }
+
+    func setReader(reader: any QUICDatagramReaderProtocol) {
+        self.reader = reader
+    }
+
+    /// Test-only: simulate an inbound datagram arriving from the peer.
+    func deliverInbound(_ datagram: ByteBuffer) {
+        self.reader?.read(datagram: datagram)
+    }
+
+    /// Test-only: simulate the transport reporting an error.
+    func deliverError(_ error: any Error) {
+        self.reader?.error(error: error)
+    }
+}
+
+/// Records the inbound datagrams and errors the handler fires down the pipeline.
+final class DatagramRecorder: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    var reads: [ByteBuffer] = []
+    var errors: [any Error] = []
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.reads.append(self.unwrapInboundIn(data))
+        context.fireChannelRead(data)
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
+        self.errors.append(error)
+        context.fireErrorCaught(error)
+    }
+}
+
+private struct TestError: Error {}


### PR DESCRIPTION
### Motivation

QUIC datagrams extends QUIC with unreliable datagrams, defined in RFC 9221. SwiftQUIC support them and SwiftNIO QUIC should too.

### Modifications

Add a new channel handler that sits in the connection channel and sends and receives QUIC datagrams via SwiftQUIC. Writes in the channel turn into outgoing datagrams while reads deliver incoming datagrams.

**Note:** The current implementation does not propatate the peer's advertised limit and always assumes a 65k frame size. This will be updated in a follow-up.

### Results

Support for sending and receiving QUIC datagrams.