### PR TITLE
Add QUIC datagram CH with a test backend

### DIFF
--- a/Sources/NIOQUIC/QUICDatagramHandler.swift
+++ b/Sources/NIOQUIC/QUICDatagramHandler.swift
@@ -70,9 +70,6 @@ final class QUICDatagramHandler: ChannelDuplexHandler {
         transport.setReader(reader: self)
         self.transport = .test(transport)
         self.setPeerMaxDatagramFrameSize(size)
-        if let context = self.context {
-            self.flush(context: context)
-        }
     }
 }
 
@@ -256,6 +253,9 @@ extension QUICDatagramHandler {
                     } else {
                         promise?.fail(QUICError.datagramWriteFailed)
                     }
+                }
+                if earlyWrites.count > 0 {
+                    self.transport.flush()
                 }
             }
         case .peerDoesNotAcceptDatagrams:

--- a/Sources/NIOQUIC/QUICDatagramHandler.swift
+++ b/Sources/NIOQUIC/QUICDatagramHandler.swift
@@ -1,0 +1,281 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOCore
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+/// The negotiation state of the QUIC datagram extension (RFC 9221) for a connection.
+enum QUICDatagramNegotiationState {
+    /// The peer's `max_datagram_frame_size` transport parameter is not yet known.
+    /// Early writes will be buffered until the peer's advertisement is received.
+    case waitingForPeerAdvertisement(earlyWrites: TinyArray<(ByteBuffer, EventLoopPromise<Void>?)>)
+    /// The peer advertised a `max_datagram_frame_size` of 0: it does not support datagrams.
+    /// Buffered early writes will be discarded (and their promises failed).
+    case peerDoesNotAcceptDatagrams
+    /// The peer accepts datagrams up to `maximumSize` bytes.
+    case peerAcceptsDatagrams(maximumSize: Int)
+}
+
+/// `QUICDatagramHandler` is the bridge between SwiftNIOQUIC's pipeline and a QUIC
+/// datagram transport (RFC 9221). It is a NIO `ChannelDuplexHandler` that forwards datagrams
+/// between the pipeline and whichever `QUICDatagramProtocol`-conforming transport is currently
+/// installed as its backend.
+@available(anyAppleOS 26, *)
+final class QUICDatagramHandler: ChannelDuplexHandler {
+    typealias LowerProtocol = OutboundDatagramLinkage
+
+    typealias InboundIn = Any
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = Any
+
+    private var context: ChannelHandlerContext?
+
+    /// The active datagram backend, or `.none` before one has been installed.
+    private var transport: Transport
+
+    private var logPrefix: String
+    private let logger: Logger
+
+    private var state: QUICDatagramNegotiationState = .waitingForPeerAdvertisement(earlyWrites: .init())
+
+    init(role: Role, logger: Logger) {
+        self.logPrefix = "[\(role.description)][DatagramHandler]"
+        self.logger = logger
+        self.transport = .none
+    }
+
+    func log(_ message: @autoclosure () -> String) {
+        #if DEBUG
+        self.logger.trace("\(self.logPrefix) \(message())")
+        #endif
+    }
+
+    /// Installs a `QUICDatagramProtocol` conforming backend for testing, applying the peer's
+    /// advertised `max_datagram_frame_size` the same way `setBackend(to:withPeerMaxDatagramFrameSize:)`
+    /// does. Writes buffered before this call are resolved against `size`.
+    func setTestBackend(to transport: any QUICDatagramProtocol, peerMaxDatagramFrameSize size: Int) {
+        transport.setReader(reader: self)
+        self.transport = .test(transport)
+        self.setPeerMaxDatagramFrameSize(size)
+        if let context = self.context {
+            self.flush(context: context)
+        }
+    }
+}
+
+// MARK: - Transport
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    /// The handler's QUIC transport, either the real SwiftNetwork-backed transport
+    /// (not yet implemented, statically dispatched) or an existential test conformance.
+    enum Transport {
+        /// No transport has been installed yet.
+        case none
+        /// Installed via `setTestBackend(to:withPeerMaxDatagramFrameSize:)`.
+        case test(any QUICDatagramProtocol)
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler.Transport: QUICDatagramProtocol {
+    /// Write a datagram to the transport.
+    ///
+    /// Note that writes are unreliable.
+    ///
+    /// - Precondition: A backend must have been installed; traps on `.none`.
+    func write(datagram: NIOCore.ByteBuffer) -> Bool {
+        switch self {
+        case .none:
+            fatalError("state violation: cannot perform a write before assigning a transport")
+        case .test(let testTransport):
+            testTransport.write(datagram: datagram)
+        }
+    }
+
+    /// A no-op on `.none`, so flushing before a backend is installed is safe.
+    func flush() {
+        switch self {
+        case .none:
+            break
+        case .test(let testTransport):
+            testTransport.flush()
+        }
+    }
+
+    /// A no-op on `.none`, so closing before a backend is installed is safe.
+    func close() {
+        switch self {
+        case .none:
+            break
+        case .test(let testTransport):
+            testTransport.close()
+        }
+    }
+
+    /// Set yourself as a reader of incoming datagrams.
+    ///
+    /// - Precondition: A backend must have been installed; traps on `.none`.
+    func setReader(reader: any QUICDatagramReaderProtocol) {
+        switch self {
+        case .none:
+            fatalError("state violation: cannot set a reader before assigning a transport")
+        case .test(let testTransport):
+            testTransport.setReader(reader: reader)
+        }
+    }
+}
+
+// MARK: - NIO lifecycle + passthrough
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    func handlerAdded(context: ChannelHandlerContext) {
+        self.context = context
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        // Fail open writes (peer datagram size was never set).
+        if case .waitingForPeerAdvertisement(let earlyWrites) = self.state {
+            for (_, promise) in earlyWrites {
+                promise?.fail(ChannelError.ioOnClosedChannel)
+            }
+        }
+        self.transport.close()
+        self.context = nil
+    }
+
+    /// Passes inbound reads from further up the pipeline straight through.
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        context.fireChannelRead(data)
+    }
+}
+
+// MARK: - Outbound datagrams
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    /// Buffers a datagram write, applying the current negotiation state:
+    /// held until the peer's advertised size is known, failed if the peer rejects datagrams
+    /// or the datagram exceeds the peer's advertised size, otherwise handed to the transport.
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let buffer = self.unwrapOutboundIn(data)
+        switch self.state {
+        case .waitingForPeerAdvertisement(var earlyWrites):
+            // The handshake has not finished and the peer's advertised size is yet unknown.
+            earlyWrites.append((buffer, promise))
+            self.state = .waitingForPeerAdvertisement(earlyWrites: earlyWrites)
+        case .peerDoesNotAcceptDatagrams:
+            // Nope. Drop it.
+            promise?.fail(QUICError.peerDoesNotAcceptDatagrams)
+        case .peerAcceptsDatagrams(let maximumSize):
+            // Reject early if the datagram exceeds the peer's advertised limit, then hand it to the
+            // transport (which may still fail the write, e.g. a transport-level size constraint).
+            //
+            // Note: this is an estimate. `max_datagram_frame_size` bounds the whole DATAGRAM frame
+            // (type + length + payload), but we compare only the payload length, so a datagram that
+            // passes here can still be too large once framed. The transport enforces the real limit.
+            guard buffer.readableBytes <= maximumSize else {
+                promise?.fail(QUICError.datagramTooLarge)
+                return
+            }
+            if self.transport.write(datagram: buffer) {
+                promise?.succeed()
+            } else {
+                promise?.fail(QUICError.datagramWriteFailed)
+            }
+        }
+    }
+
+    /// Flushes buffered datagrams to the transport, then forwards the flush down the pipeline.
+    func flush(context: ChannelHandlerContext) {
+        self.transport.flush()
+        context.flush()
+    }
+}
+
+// MARK: - Inbound datagrams
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler: QUICDatagramReaderProtocol {
+    /// Forwards a datagram received from the transport into the NIO pipeline.
+    func read(datagram: NIOCore.ByteBuffer) {
+        // The backend is required to check incoming datagram frame
+        // sizes and propagate the violation to the connection.
+        let buffer = self.wrapInboundOut(datagram)
+        self.context?.fireChannelRead(buffer)
+    }
+
+    /// Forwards a transport error into the NIO pipeline.
+    func error(error: any Error) {
+        self.context?.fireErrorCaught(error)
+    }
+}
+
+// MARK: - QUICDatagramProtocol
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandler {
+    /// Applies the peer's advertised `max_datagram_frame_size`, transitioning out of
+    /// `.waitingForPeerAdvertisement` and resolving any writes buffered while waiting.
+    ///
+    /// - Precondition: Must only be called once per connection; the peer only advertises this once.
+    private func setPeerMaxDatagramFrameSize(_ size: Int) {
+        switch self.state {
+        case .waitingForPeerAdvertisement(let earlyWrites):
+            // Filter previously buffered messages to account for advertised size
+            if size == 0 {
+                self.state = .peerDoesNotAcceptDatagrams
+                for (_, promise) in earlyWrites {
+                    promise?.fail(QUICError.peerDoesNotAcceptDatagrams)
+                }
+            } else {
+                self.state = .peerAcceptsDatagrams(maximumSize: size)
+                for (buffer, promise) in earlyWrites {
+                    // Same estimated size check as `write` (payload-only, ignores frame overhead;
+                    // the transport enforces the real limit).
+                    guard buffer.readableBytes <= size else {
+                        promise?.fail(QUICError.datagramTooLarge)
+                        continue
+                    }
+                    if self.transport.write(datagram: buffer) {
+                        promise?.succeed()
+                    } else {
+                        promise?.fail(QUICError.datagramWriteFailed)
+                    }
+                }
+            }
+        case .peerDoesNotAcceptDatagrams:
+            assertionFailure("peer max datagram size must not be updated more than once")
+            self.logger.error(
+                "\(self.logPrefix) received peer max datagram size more than once",
+                metadata: [
+                    "knownSize": "0",
+                    "newSize": "\(size)",
+                ]
+            )
+        case .peerAcceptsDatagrams(let knownSize):
+            assertionFailure("peer max datagram size must not be updated more than once")
+            self.logger.error(
+                "\(self.logPrefix) received peer max datagram size more than once",
+                metadata: [
+                    "knownSize": "\(knownSize)",
+                    "newSize": "\(size)",
+                ]
+            )
+        }
+    }
+}

--- a/Sources/NIOQUIC/QUICDatagramProtocol.swift
+++ b/Sources/NIOQUIC/QUICDatagramProtocol.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// The datagram transport interface `QUICDatagramHandler` writes to and reads from.
+///
+/// This exists so `QUICDatagramHandler` does not depend on the SwiftNetwork-backed
+/// `QUICDatagramTransport` directly: production code is backed by `QUICDatagramTransport`, while
+/// tests can install a a testing `setTestBackend(transport:)`.
+@available(anyAppleOS 26, *)
+protocol QUICDatagramProtocol {
+
+    /// Buffers `datagram` to be sent on the next `flush()`.
+    ///
+    /// The peer's advertised `max_datagram_frame_size` is checked by `QUICDatagramHandler`
+    /// *before* this is called (that path fails with `QUICError.datagramTooLarge`), so the return
+    /// value is the transport's own accept/reject signal.
+    ///
+    /// - Returns: `true` if the datagram was accepted and buffered for the next `flush()`; `false`
+    ///   if the transport could not accept it (a transport-level constraint), which the handler
+    ///   surfaces to the caller as `QUICError.datagramWriteFailed`.
+    func write(datagram: ByteBuffer) -> Bool
+
+    /// Sends any datagrams buffered since the last `flush()`.
+    func flush()
+
+    /// Detaches the underlying flow and clears the current reader.
+    func close()
+
+    /// Sets the delegate that receives datagrams and errors from this transport.
+    func setReader(reader: any QUICDatagramReaderProtocol)
+
+}
+
+/// Receive datagrams and errors from a `QUICDatagramProtocol` conformance.
+@available(anyAppleOS 26, *)
+protocol QUICDatagramReaderProtocol: AnyObject {
+    /// Called once per datagram received from the peer.
+    ///
+    /// - Precondition: The propagated datagram must adhere to the frame size
+    ///     limits advertised by this peer.
+    func read(datagram: ByteBuffer)
+
+    /// Called when the underlying transport reports an error.
+    func error(error: any Error)
+}

--- a/Sources/NIOQUIC/QUICError.swift
+++ b/Sources/NIOQUIC/QUICError.swift
@@ -36,6 +36,9 @@ public struct QUICError: Error, Hashable, Sendable {
         case failedToRetireConnectionID
         case streamWriteFailed
         case streamHandlerNotFound
+        case datagramTooLarge
+        case datagramWriteFailed
+        case peerDoesNotAcceptDatagrams
         case unknownError(Int)
     }
 
@@ -107,6 +110,21 @@ public struct QUICError: Error, Hashable, Sendable {
 
     /// Indicates that the transport rejected a stream write.
     public static let streamWriteFailed: Self = .init(code: .streamWriteFailed)
+
+    /// Indicates that a datagram exceeded the peer's advertised `max_datagram_frame_size`.
+    ///
+    /// - Warning: This is based on an estimate. The check compares only the datagram payload length
+    ///   against the advertised limit and does not account for DATAGRAM frame overhead (frame type
+    ///   and length fields), so a datagram that passes the check may still be too large once framed.
+    ///   The transport enforces the exact on-the-wire size.
+    public static let datagramTooLarge: Self = .init(code: .datagramTooLarge)
+
+    /// Indicates that the transport failed to write a datagram, e.g. because it exceeded a
+    /// size constraint enforced by the transport.
+    public static let datagramWriteFailed: Self = .init(code: .datagramWriteFailed)
+
+    /// Inidicates that the peer advertised a maximum datagram size of 0.
+    public static let peerDoesNotAcceptDatagrams: Self = .init(code: .peerDoesNotAcceptDatagrams)
 
     /// Indicates an unknown error
     public static func unknownError(_ code: Int) -> Self { .init(code: .unknownError(code)) }

--- a/Tests/NIOQUICTests/QUICDatagramHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICDatagramHandlerTests.swift
@@ -1,0 +1,348 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOConcurrencyHelpers
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import NIOQUIC
+
+/// Unit tests for `QUICDatagramHandler` driven through the `setTestBackend` seam and a
+/// `DatagramTestTransport`, so the negotiation state machine and datagram passthrough can be
+/// exercised in an `EmbeddedChannel` without a real SwiftNetwork flow.
+@Suite
+struct QUICDatagramHandlerTests {
+
+    // MARK: - Buffering before the peer advertisement
+
+    @available(anyAppleOS 26, *)
+    @Test("Writes buffered before the peer advertisement flush once the peer accepts")
+    func bufferedWritesFlushWhenPeerAccepts() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            let first = ByteBuffer(string: "first")
+            let second = ByteBuffer(string: "second")
+
+            // No backend installed yet: both writes are held, not handed to any transport.
+            let firstResult = Self.write(channel, first)
+            let secondResult = Self.write(channel, second)
+            #expect(Self.outcome(firstResult) == nil)
+            #expect(Self.outcome(secondResult) == nil)
+            #expect(transport.writtenDatagrams.isEmpty)
+
+            // Peer advertises a limit that fits both: the buffered writes flush in order and succeed.
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+            #expect(transport.writtenDatagrams == [first, second])
+            #expect(Self.succeeded(firstResult))
+            #expect(Self.succeeded(secondResult))
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("Writes buffered before the peer advertisement fail when the peer advertises 0")
+    func bufferedWritesFailWhenPeerRejects() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            let result = Self.write(channel, ByteBuffer(string: "buffered"))
+            #expect(Self.outcome(result) == nil)
+
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 0)
+            #expect(Self.failedQUICError(result) == .peerDoesNotAcceptDatagrams)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A buffered write larger than the advertised limit fails as datagramTooLarge")
+    func bufferedOversizedWriteFailsAsTooLarge() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            // Buffered while waiting, then the peer accepts a smaller limit than this datagram.
+            let result = Self.write(channel, ByteBuffer(repeating: UInt8(ascii: "x"), count: 200))
+            #expect(Self.outcome(result) == nil)
+
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+            // Peer *does* accept datagrams, this one just does not fit: distinct from "not accepted".
+            #expect(Self.failedQUICError(result) == .datagramTooLarge)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A buffered write exactly at the advertised limit is accepted")
+    func bufferedWriteAtExactLimitSucceeds() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            // The size check is `<=` and payload-only (ignores frame overhead), so a payload equal to
+            // the advertised limit is accepted here; the transport enforces the exact framed size.
+            let payload = ByteBuffer(repeating: UInt8(ascii: "x"), count: 100)
+            let result = Self.write(channel, payload)
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+            #expect(Self.succeeded(result))
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    // MARK: - Steady-state writes (peer advertisement already known)
+
+    @available(anyAppleOS 26, *)
+    @Test("A write within the advertised limit is handed to the transport and succeeds")
+    func writeWithinLimitSucceeds() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let payload = ByteBuffer(string: "datagram")
+            let result = Self.write(channel, payload)
+            #expect(Self.succeeded(result))
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A write larger than the advertised limit fails as datagramTooLarge and is not sent")
+    func oversizedWriteFailsAsTooLarge() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let result = Self.write(channel, ByteBuffer(repeating: UInt8(ascii: "x"), count: 200))
+            #expect(Self.failedQUICError(result) == .datagramTooLarge)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A write exactly at the advertised limit is accepted")
+    func writeAtExactLimitSucceeds() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            // `<=`, payload-only (ignores frame overhead): a payload equal to the advertised limit is
+            // accepted here; the transport enforces the exact framed size.
+            let payload = ByteBuffer(repeating: UInt8(ascii: "x"), count: 100)
+            let result = Self.write(channel, payload)
+            #expect(Self.succeeded(result))
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A within-limit write the transport rejects fails as datagramWriteFailed")
+    func transportRejectionFails() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            transport.writeResult = false
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            // The datagram passes the size check, so it is handed to the transport, which rejects it.
+            let payload = ByteBuffer(string: "datagram")
+            let result = Self.write(channel, payload)
+            #expect(Self.failedQUICError(result) == .datagramWriteFailed)
+            #expect(transport.writtenDatagrams == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A write fails as peerDoesNotAcceptDatagrams when the peer advertised 0")
+    func writeFailsWhenPeerRejects() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 0)
+
+            let result = Self.write(channel, ByteBuffer(string: "datagram"))
+            #expect(Self.failedQUICError(result) == .peerDoesNotAcceptDatagrams)
+            #expect(transport.writtenDatagrams.isEmpty)
+        }
+    }
+
+    // MARK: - Inbound
+
+    @available(anyAppleOS 26, *)
+    @Test("An inbound datagram from the transport is fired as a channelRead")
+    func inboundDatagramIsDeliveredAsChannelRead() throws {
+        try Self.withHandler { _, handler, transport, recorder in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let payload = ByteBuffer(string: "inbound")
+            transport.deliverInbound(payload)
+            #expect(recorder.reads == [payload])
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A transport error is fired as an errorCaught")
+    func transportErrorIsFiredAsErrorCaught() throws {
+        try Self.withHandler { _, handler, transport, recorder in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            transport.deliverError(TestError())
+            #expect(recorder.errors.count == 1)
+            #expect(recorder.errors.first is TestError)
+        }
+    }
+
+    // MARK: - Teardown
+
+    @available(anyAppleOS 26, *)
+    @Test("Removing the handler while still waiting fails buffered writes")
+    func handlerRemovalFailsBufferedWrites() throws {
+        try Self.withHandler { channel, _, _, _ in
+            // Buffered while waiting, no backend ever installed.
+            let result = Self.write(channel, ByteBuffer(string: "buffered"))
+            #expect(Self.outcome(result) == nil)
+
+            // `close0` defers `removeHandlers` (and thus `handlerRemoved`) via `eventLoop.execute`,
+            // so drain the loop to make it run before asserting. The harness's later `finish()` then
+            // throws `.alreadyClosed` (channel is closed), which its `try?` swallows.
+            channel.close(promise: nil)
+            (channel.eventLoop as! EmbeddedEventLoop).run()
+            #expect(Self.failedChannelError(result) == .ioOnClosedChannel)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("Removing the handler after a backend is installed closes the transport")
+    func handlerRemovalClosesTransport() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            channel.close(promise: nil)
+            (channel.eventLoop as! EmbeddedEventLoop).run()
+            #expect(transport.closeCount == 1)
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("A channel flush propagates to the transport")
+    func flushPropagatesToTransport() throws {
+        try Self.withHandler { channel, handler, transport, _ in
+            handler.setTestBackend(to: transport, peerMaxDatagramFrameSize: 100)
+
+            let flushesBefore = transport.flushCount
+            _ = Self.write(channel, ByteBuffer(string: "datagram"))
+            #expect(transport.flushCount > flushesBefore)
+        }
+    }
+}
+
+// MARK: - Test harness
+
+@available(anyAppleOS 26, *)
+extension QUICDatagramHandlerTests {
+    /// Builds an `EmbeddedChannel` with a `QUICDatagramHandler` under test and a downstream
+    /// `DatagramRecorder`, plus a `DatagramTestTransport` the body installs via `setTestBackend`.
+    static func withHandler(
+        role: Role = .client,
+        body: (EmbeddedChannel, QUICDatagramHandler, DatagramTestTransport, DatagramRecorder) throws -> Void
+    ) throws {
+        let channel = EmbeddedChannel()
+        let handler = QUICDatagramHandler(role: role, logger: Logger(label: "test"))
+        let recorder = DatagramRecorder()
+        try channel.pipeline.syncOperations.addHandlers([handler, recorder])
+        let transport = DatagramTestTransport()
+        defer { _ = try? channel.finish() }
+        try body(channel, handler, transport, recorder)
+    }
+
+    /// Writes and flushes `buffer` on the channel, returning the write's future so the test can
+    /// inspect whether it succeeded, failed, or is still buffered.
+    static func write(_ channel: EmbeddedChannel, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+        let promise = channel.eventLoop.makePromise(of: Void.self)
+        channel.writeAndFlush(buffer, promise: promise)
+        return promise.futureResult
+    }
+
+    /// The resolved result of `future`, or `nil` if it is still pending. Safe to read synchronously
+    /// because `EmbeddedChannel` runs the pipeline single-threaded and in-line, so the datagram
+    /// handler's promises are resolved before this returns, and `whenComplete` on an already-resolved
+    /// future fires immediately. This would be racy against a real threaded `EventLoopGroup`.
+    static func outcome(_ future: EventLoopFuture<Void>) -> Result<Void, any Error>? {
+        let box = NIOLockedValueBox<Result<Void, any Error>?>(nil)
+        future.whenComplete { result in box.withLockedValue { $0 = result } }
+        return box.withLockedValue { $0 }
+    }
+
+    static func succeeded(_ future: EventLoopFuture<Void>) -> Bool {
+        if case .success = Self.outcome(future) { return true }
+        return false
+    }
+
+    static func failedQUICError(_ future: EventLoopFuture<Void>) -> QUICError? {
+        guard case .failure(let error) = Self.outcome(future) else { return nil }
+        return error as? QUICError
+    }
+
+    static func failedChannelError(_ future: EventLoopFuture<Void>) -> ChannelError? {
+        guard case .failure(let error) = Self.outcome(future) else { return nil }
+        return error as? ChannelError
+    }
+}
+
+/// A `QUICDatagramProtocol` test double: records outbound datagrams and lets tests inject inbound
+/// datagrams and errors back through the reader the handler installs.
+@available(anyAppleOS 26, *)
+final class DatagramTestTransport: QUICDatagramProtocol {
+    private(set) var writtenDatagrams: [ByteBuffer] = []
+    private(set) var flushCount = 0
+    private(set) var closeCount = 0
+    private var reader: (any QUICDatagramReaderProtocol)?
+
+    /// What `write(datagram:)` returns. Flip to `false` to simulate the transport rejecting a
+    /// datagram that passed the size check.
+    var writeResult = true
+
+    func write(datagram: ByteBuffer) -> Bool {
+        self.writtenDatagrams.append(datagram)
+        return self.writeResult
+    }
+
+    func flush() {
+        self.flushCount += 1
+    }
+
+    func close() {
+        self.closeCount += 1
+        // Mirror the production transport: dropping the reader breaks the handler <-> transport cycle.
+        self.reader = nil
+    }
+
+    func setReader(reader: any QUICDatagramReaderProtocol) {
+        self.reader = reader
+    }
+
+    /// Test-only: simulate an inbound datagram arriving from the peer.
+    func deliverInbound(_ datagram: ByteBuffer) {
+        self.reader?.read(datagram: datagram)
+    }
+
+    /// Test-only: simulate the transport reporting an error.
+    func deliverError(_ error: any Error) {
+        self.reader?.error(error: error)
+    }
+}
+
+/// Records the inbound datagrams and errors the handler fires down the pipeline.
+final class DatagramRecorder: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    var reads: [ByteBuffer] = []
+    var errors: [any Error] = []
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.reads.append(self.unwrapInboundIn(data))
+        context.fireChannelRead(data)
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
+        self.errors.append(error)
+        context.fireErrorCaught(error)
+    }
+}
+
+private struct TestError: Error {}


### PR DESCRIPTION
### Motivation

RFC 9221 extends QUIC with unreliable datagrams. SwiftQUIC supports them and SwiftNIO QUIC should too. This adds a channel handler, but defers the implementation of backend.

### Modifications

Add `QUICDatagramHandler`, a channel handler to send and receive QUIC datagrams with a configurable backend. The only supported backend at the moment is a test backend.

The channel handler can be installed before the connection is fully established as it does not forward datagrams to the backend until the connection was established and the frame size advertised by the peer is known.

### Results

Prepare QUIC datagram support for SwiftNIO QUIC.