### PR TITLE
Wire up max datagram frame size

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            .upToNextMinor(from: "0.1.0"),
+            .upToNextMinor(from: "0.1.1"),
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", .upToNextMinor(from: "0.1.0")),

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
@@ -358,15 +358,14 @@ extension QUICChannelNewFlowHandler {
             transport.setFlowLinkage(linkage)
             linkage.invokeConnect(transport.reference)
 
-            // TODO: Once SwiftNetwork (a40d5771fc586e75f3534e55178398baa1db2966) is released,
-            // replace the hardcoded `UInt16.max` with the peer's advertised `max_datagram_frame_size`, read
-            // from the connection metadata via `getConnectionMetadata()` (as with `activeConnectionIDLimit`).
-            // A zero says that the peer does not accept datagrams.
+            // Propagate the announced max frame size of the peer. Assume 0 (the peer does not accept
+            // datagrams) if the value is not available on the metadata.
             //
             // Better still, use SwiftNetwork's *usable* datagram size, which already subtracts framing
             // overhead and path MTU (`QUICDatagramFlow.updateUsableDatagramFrameSize`) — passing that
             // would make the handler's size check exact instead of the current payload-only estimate.
-            datagramHandler.setBackend(to: transport, withPeerMaxDatagramFrameSize: Int(UInt16.max))
+            let remoteFrameSize = self.getConnectionMetadata()?.connectionMetadata?.remoteMaxDatagramFrameSize ?? 0
+            datagramHandler.setBackend(to: transport, withPeerMaxDatagramFrameSize: Int(remoteFrameSize))
         } catch {
             self.logger.error("\(self.logPrefix) Failed to attach QUIC datagram flow: \(error)")
         }

--- a/Tests/IntegrationTests/DatagramTests.swift
+++ b/Tests/IntegrationTests/DatagramTests.swift
@@ -344,7 +344,8 @@ struct DatagramTests {
         try await serverChannel.close()
     }
 
-    /// SwiftNetwork silently drops outbound datagrams larger than the size advertised by the peer..
+    /// A datagram larger than the peer's advertised `max_datagram_frame_size` is rejected locally,
+    /// before it reaches the transport; the connection stays open and unrelated writes still work.
     @available(anyAppleOS 26, *)
     @Test
     func oversizedDatagramIsDroppedAndConnectionStaysOpen() async throws {
@@ -363,6 +364,8 @@ struct DatagramTests {
         // The oversized datagram is not expected to arrive.
         let serverReceivedDatagrams = NIOLockedValueBox<[ByteBuffer]>([])
         let clientReceivedSmall = eventLoopGroup.any().makePromise(of: Void.self)
+        // The oversized write itself is expected to fail, before it ever reaches the transport.
+        let oversizedWriteResult = eventLoopGroup.any().makePromise(of: Void.self)
         // No errors are expected on either connection channel.
         let caughtErrors = NIOLockedValueBox<[String]>([])
 
@@ -424,14 +427,18 @@ struct DatagramTests {
         // Establish the connection with a tiny sync stream before sending datagrams.
         try await performSyncHandshake(streamCreator, signal: syncSignal, serverReceived: serverGotSync)
 
-        // Send the oversized datagram first, then a small one. Our `write` buffers and succeeds for
-        // both (they are below the hardcoded `.max` guard); SwiftNetwork drops the oversized one at
-        // packetization while the small one goes through.
-        clientConnectionChannel.writeAndFlush(oversizedPayload, promise: nil)
+        // Send the oversized datagram first, then a small one. The handler now knows the peer's real
+        // advertised limit (256), so the oversized write is rejected locally and never reaches the
+        // transport; the small one is unaffected.
+        clientConnectionChannel.writeAndFlush(oversizedPayload, promise: oversizedWriteResult)
         clientConnectionChannel.writeAndFlush(smallPayload, promise: nil)
 
+        await #expect(throws: QUICError.datagramTooLarge) {
+            try await oversizedWriteResult.futureResult.get()
+        }
+
         // The connection is proven alive if the small datagram round-trips (client -> server ->
-        // client) after the oversized one was dropped.
+        // client) after the oversized write was rejected.
         try await clientReceivedSmall.futureResult.get()
 
         let serverReceived = serverReceivedDatagrams.withLockedValue { $0 }


### PR DESCRIPTION
### Motivation

A new API in `swift-network-evolution` exposes the max datagram frame size advertised by the peer. 

### Modifications

* Update `swift-network-evolution` tag to have the new API available.
* Read the size advertised by the peer form the metadata and set if on the datagram channel handler.
* Check the error propagated by the channel handler in the corresponding test.

### Result

Better assessment of the peer's QUIC datagram support.