### PR TITLE
Uses Frame as input for GSO coalescing

### DIFF
--- a/Sources/NIOQUIC/BufferPool.swift
+++ b/Sources/NIOQUIC/BufferPool.swift
@@ -1,0 +1,164 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// A pool of `ByteBuffer`s.
+struct BufferPool: Sendable {
+    /// The pooled buffers.
+    @usableFromInline
+    internal var _buffers: [ByteBuffer]
+    /// The index into `buffers` of the index which was last used.
+    @usableFromInline
+    internal var _lastUsedIndex: Int
+
+    @usableFromInline
+    internal let _allocator: ByteBufferAllocator
+
+    /// Maximum number of buffers to store in the pool.
+    internal let capacity: Int
+
+    /// Creates a new `BufferPool`.
+    ///
+    /// - Parameters:
+    ///   - capacity: Maximum number of buffers to store in the pool.
+    ///   - allocator: An allocator for byte buffers.
+    init(capacity: Int, allocator: ByteBufferAllocator = ByteBufferAllocator()) {
+        precondition(capacity > 0)
+        self.capacity = capacity
+        self._allocator = allocator
+        self._lastUsedIndex = 0
+        self._buffers = []
+        self._buffers.reserveCapacity(capacity)
+    }
+
+    /// Returns the number of buffers in the pool.
+    var count: Int {
+        self._buffers.count
+    }
+
+    /// Provides a buffer with enough writable capacity as determined by the underlying
+    /// receive allocator to the given closure.
+    ///
+    /// - Parameters:
+    ///    - body: Closure where the caller can use the new or existing buffer
+    /// - Returns: A tuple containing the `ByteBuffer` used and the `Result` yielded by the closure provided.
+    @inlinable
+    mutating func withBuffer<Result>(
+        minimumCapacity: Int,
+        _ body: (_ buffer: inout ByteBuffer) throws -> Result
+    ) rethrows -> (ByteBuffer, Result) {
+        // Reuse an existing buffer if we can do so without CoWing.
+        if let bufferAndResult = try self._reuseExistingBuffer(minimumCapacity: minimumCapacity, body) {
+            return bufferAndResult
+        } else {
+            // No available buffers or the allocator does not offer up buffer sizes; directly
+            // allocate a new one.
+            return try self._allocateNewBuffer(minimumCapacity: minimumCapacity, body)
+        }
+    }
+
+    @inlinable
+    internal mutating func _reuseExistingBuffer<Result>(
+        minimumCapacity: Int,
+        _ body: (_ buffer: inout ByteBuffer) throws -> Result
+    ) rethrows -> (ByteBuffer, Result)? {
+        // Cycle through the buffers starting at the last used buffer.
+        let resultAndIndex = try self._buffers._loopingFirstIndexWithResult(startingAt: self._lastUsedIndex) {
+            buffer in
+            try buffer._modifyIfUniquelyOwned(minimumCapacity: minimumCapacity, body)
+        }
+
+        if let (result, index) = resultAndIndex {
+            self._lastUsedIndex = index
+            return (self._buffers[index], result)
+        } else {
+            // Couldn't reuse an existing buffer.
+            return nil
+        }
+    }
+
+    @inlinable
+    internal mutating func _allocateNewBuffer<Result>(
+        minimumCapacity: Int,
+        _ body: (_ buffer: inout ByteBuffer) throws -> Result
+    ) rethrows -> (ByteBuffer, Result) {
+        // Couldn't reuse a buffer; create a new one and store it if there's capacity.
+        var newBuffer = self._allocator.buffer(capacity: minimumCapacity)
+
+        if self._buffers.count < self.capacity {
+            self._buffers.append(newBuffer)
+            self._lastUsedIndex = self._buffers.index(before: self._buffers.endIndex)
+            return try self._modifyBuffer(atIndex: self._lastUsedIndex, body)
+        } else {
+            let result = try body(&newBuffer)
+            return (newBuffer, result)
+        }
+    }
+
+    @inlinable
+    internal mutating func _modifyBuffer<Result>(
+        atIndex index: Int,
+        _ body: (_ buffer: inout ByteBuffer) throws -> Result
+    ) rethrows -> (ByteBuffer, Result) {
+        let result = try body(&self._buffers[index])
+        return (self._buffers[index], result)
+    }
+}
+
+extension ByteBuffer {
+    @inlinable
+    internal mutating func _modifyIfUniquelyOwned<Result>(
+        minimumCapacity: Int,
+        _ body: (_ buffer: inout ByteBuffer) throws -> Result
+    ) rethrows -> Result? {
+        try self.modifyIfUniquelyOwned { buffer in
+            buffer.clear(minimumCapacity: minimumCapacity)
+            return try body(&buffer)
+        }
+    }
+}
+
+extension Array {
+    /// Iterate over all elements in the array starting at the given index and looping back to the start
+    /// if the end is reached. The `body` is applied to each element and iteration is stopped when
+    /// `body` returns a non-nil value or all elements have been iterated.
+    ///
+    /// - Returns: The result and index of the first element passed to `body` which returned
+    ///   non-nil, or `nil` if no such element exists.
+    @inlinable
+    internal mutating func _loopingFirstIndexWithResult<Result>(
+        startingAt middleIndex: Index,
+        whereNonNil body: (inout Element) throws -> Result?
+    ) rethrows -> (Result, Index)? {
+        if let result = try self._firstIndexWithResult(in: middleIndex..<self.endIndex, whereNonNil: body) {
+            return result
+        }
+
+        return try self._firstIndexWithResult(in: self.startIndex..<middleIndex, whereNonNil: body)
+    }
+
+    @inlinable
+    internal mutating func _firstIndexWithResult<Result>(
+        in indices: Range<Index>,
+        whereNonNil body: (inout Element) throws -> Result?
+    ) rethrows -> (Result, Index)? {
+        for index in indices {
+            if let result = try body(&self[index]) {
+                return (result, index)
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/NIOQUIC/GSOCoalescer.swift
+++ b/Sources/NIOQUIC/GSOCoalescer.swift
@@ -13,55 +13,105 @@
 //===----------------------------------------------------------------------===//
 
 import DequeModule
-import NIOCore
+@_spi(CustomByteBufferAllocator) import NIOCore
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
 
 /// Groups an ordered burst of outbound datagrams for one peer into runs which can be sent to the
 /// kernel as a single UDP Generic Segmentation Offload write.
-struct GSOCoalescer {
+@available(anyAppleOS 26, *)
+struct GSOCoalescer: ~Copyable {
     /// The maximum number of segments to coalesce.
     var maxSegments: Int
 
     /// The maximum size of a coalesced datagram.
     var maxCoalescedSize: Int
 
-    private var buffers: Deque<ByteBuffer>
+    /// Frames to coalesce.
+    private var frames: UniqueDeque<Frame>
+
+    /// The address of the remote peer to send datagrams to.
     private let remoteAddress: SocketAddress
 
-    init(remoteAddress: SocketAddress, maxSegments: Int = 64, maxCoalescedSize: Int = 65535) {
+    /// A pool of byte buffers.
+    private var pool: BufferPool
+
+    init(
+        remoteAddress: SocketAddress,
+        maxSegments: Int = 64,
+        maxCoalescedSize: Int = 65535,
+        bufferPoolCapacity: Int = 8
+    ) {
         self.remoteAddress = remoteAddress
         self.maxSegments = maxSegments
         self.maxCoalescedSize = maxCoalescedSize
-        self.buffers = Deque()
-        self.buffers.reserveCapacity(16)
+
+        self.frames = UniqueDeque<Frame>()
+        self.frames.reserveCapacity(16)
+
+        self.pool = BufferPool(capacity: bufferPoolCapacity, allocator: ByteBufferAllocator())
     }
 
     var isEmpty: Bool {
-        self.buffers.isEmpty
+        self.frames.isEmpty
     }
 
-    mutating func append(_ buffer: ByteBuffer) {
-        if buffer.readableBytes > 0 {
-            self.buffers.append(buffer)
+    mutating func finalizeAllFramesAsFailed() {
+        while var frame = self.frames.popFirst() {
+            frame.finalize(success: false)
         }
+    }
+
+    mutating func append(frames: consuming FrameArray) {
+        self.frames.reserveCapacity(self.frames.count + frames.count)
+
+        while var frame = frames.popFirst() {
+            if frame.unclaimedLength == 0 {
+                frame.finalize(success: true)
+            } else {
+                self.frames.append(frame)
+            }
+        }
+    }
+
+    private mutating func datagram(from frame: consuming Frame) -> AddressedEnvelope<ByteBuffer> {
+        let buffer: ByteBuffer
+
+        if let config = frame.takeOwnershipOfCustomFinalizerBuffer() {
+            frame.finalize(success: true)
+            buffer = ByteBuffer(
+                takingOwnershipOf: config.bufferPointer,
+                allocator: FrameMemory.allocator,
+                readerIndex: config.readerOffset,
+                writerIndex: config.writerOffset
+            )
+        } else {
+            var buf = ByteBuffer()
+            buf.reserveCapacity(frame.unclaimedLength)
+            frame.span?.withUnsafeBufferPointer { _ = buf.writeBytes($0) }
+            frame.finalize(success: true)
+            buffer = buf
+        }
+
+        return AddressedEnvelope(remoteAddress: self.remoteAddress, data: buffer)
     }
 
     /// Removes and returns the next run of pending datagrams, or `nil` if there are none left.
     mutating func next() -> AddressedEnvelope<ByteBuffer>? {
-        if self.buffers.isEmpty {
+        if self.frames.isEmpty {
             return nil
-        } else if self.maxSegments == 1, let buffer = self.buffers.popFirst() {
-            return AddressedEnvelope(remoteAddress: self.remoteAddress, data: buffer)
+        } else if self.maxSegments == 1, let frame = self.frames.popFirst() {
+            return self.datagram(from: frame)
         }
 
-        // Try to coalesce as many sequential buffers as possible without exceeding:
+        // Try to coalesce as many sequential frames as possible without exceeding:
         // - the max segment length,
         // - the max coalesced size
         //
-        // Buffers must be the same length to coalesce although the final buffer in a
+        // Frames must be the same length to coalesce although the final frame in a
         // run may be shorter than the rest.
-        var index = self.buffers.startIndex
-        let segmentSize = self.buffers[index].readableBytes
-        self.buffers.formIndex(after: &index)
+        var index = self.frames.startIndex
+        let segmentSize = self.frames[index].unclaimedLength
+        self.frames.formIndex(after: &index)
 
         var totalSize = segmentSize
         var runLength = 1
@@ -70,10 +120,10 @@ struct GSOCoalescer {
         // segment in a run.
         let effectiveMaxSegments = min(self.maxSegments, max(1, self.maxCoalescedSize / segmentSize))
 
-        while index != self.buffers.endIndex, runLength < effectiveMaxSegments {
-            let size = self.buffers[index].readableBytes
+        while index != self.frames.endIndex, runLength < effectiveMaxSegments {
+            let size = self.frames[index].unclaimedLength
 
-            // Bigger; end run without including this buffer.
+            // Bigger; end run without including this frame.
             if size > segmentSize { break }
 
             totalSize &+= size
@@ -83,35 +133,33 @@ struct GSOCoalescer {
             if size < segmentSize { break }
 
             // Same size; continue iterating.
-            self.buffers.formIndex(after: &index)
+            self.frames.formIndex(after: &index)
         }
 
         if runLength == 1 {
             // Nothing to coalesce; so just remove and return.
+            let frame = self.frames.popFirst()!
+            return self.datagram(from: frame)
+        } else {
+            let (buffer, ()) = self.pool.withBuffer(minimumCapacity: totalSize) { buffer in
+                while runLength > 0 {
+                    runLength &-= 1
+
+                    var frame = frames.popFirst()!
+                    frame.span?.withUnsafeBufferPointer { _ = buffer.writeBytes($0) }
+                    frame.finalize(success: true)
+                }
+            }
+
             return AddressedEnvelope(
                 remoteAddress: self.remoteAddress,
-                data: self.buffers.removeFirst()
+                data: buffer,
+                metadata: AddressedEnvelope.Metadata(
+                    ecnState: .transportNotCapable,
+                    packetInfo: nil,
+                    segmentSize: segmentSize
+                )
             )
         }
-
-        // Coalesce the run into the first datagram's buffer.
-        var coalesced = self.buffers.removeFirst()
-        coalesced.reserveCapacity(minimumWritableBytes: totalSize &- segmentSize)
-        runLength &-= 1
-
-        while runLength > 0 {
-            runLength &-= 1
-            coalesced.writeImmutableBuffer(self.buffers.removeFirst())
-        }
-
-        return AddressedEnvelope(
-            remoteAddress: self.remoteAddress,
-            data: coalesced,
-            metadata: AddressedEnvelope.Metadata(
-                ecnState: .transportNotCapable,
-                packetInfo: nil,
-                segmentSize: segmentSize
-            )
-        )
     }
 }

--- a/Sources/NIOQUIC/GSOCoalescer.swift
+++ b/Sources/NIOQUIC/GSOCoalescer.swift
@@ -76,13 +76,13 @@ struct GSOCoalescer: ~Copyable {
     private mutating func datagram(from frame: consuming Frame) -> AddressedEnvelope<ByteBuffer> {
         let buffer: ByteBuffer
 
-        if let config = frame.takeOwnershipOfCustomFinalizerBuffer() {
+        if let frameInternals = frame.takeOwnershipOfCustomFinalizerBuffer() {
             frame.finalize(success: true)
             buffer = ByteBuffer(
-                takingOwnershipOf: config.bufferPointer,
+                takingOwnershipOf: frameInternals.bufferPointer,
                 allocator: FrameMemory.allocator,
-                readerIndex: config.readerOffset,
-                writerIndex: config.writerOffset
+                readerIndex: frameInternals.readerOffset,
+                writerIndex: frameInternals.writerOffset
             )
         } else {
             var buf = ByteBuffer()

--- a/Tests/NIOQUICTests/BufferPoolTests.swift
+++ b/Tests/NIOQUICTests/BufferPoolTests.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import Testing
+
+@testable import NIOQUIC
+
+struct BufferPoolTests {
+    @Test
+    func poolFillsToCapacity() {
+        var pool = BufferPool(capacity: 3)
+        #expect(pool.count == 0)
+        #expect(pool.capacity == 3)
+
+        // The pool recycles buffers which are unique. Store each buffer to ensure that's not the
+        // case.
+        let buffers: [ByteBuffer] = (1...pool.capacity).map { _ in
+            let (buffer, _) = pool.withBuffer(minimumCapacity: 1024) {
+                #expect($0.readableBytes == 0)
+                #expect($0.writableBytes == 1024)
+            }
+            return buffer
+        }
+
+        let bufferIDs = Set(buffers.map { $0.storagePointerIntegerValue() })
+        #expect(buffers.count == bufferIDs.count)
+
+        // Keep the buffers alive.
+        withExtendedLifetime(buffers) {
+            for _ in 1...pool.capacity {
+                let (buffer, _) = pool.withBuffer(minimumCapacity: 1024) {
+                    #expect($0.readableBytes == 0)
+                    #expect($0.writableBytes == 1024)
+                }
+                #expect(pool.count == pool.capacity)
+                #expect(!bufferIDs.contains(buffer.storagePointerIntegerValue()))
+            }
+        }
+    }
+
+    @Test
+    func buffersAreRecycled() {
+        var pool = BufferPool(capacity: 3)
+
+        let (_, storageID) = pool.withBuffer(minimumCapacity: 1024) { buffer in
+            buffer.storagePointerIntegerValue()
+        }
+
+        #expect(pool.count == 1)
+
+        for _ in 0..<100 {
+            _ = pool.withBuffer(minimumCapacity: 1024) { buffer in
+                #expect(buffer.storagePointerIntegerValue() == storageID)
+            }
+            #expect(pool.count == 1)
+        }
+    }
+
+    @Test
+    func firstAvailableBufferUsed() {
+        var pool = BufferPool(capacity: 3)
+
+        var buffers: [ByteBuffer] = (0..<pool.capacity).map { _ in
+            let (buffer, _) = pool.withBuffer(minimumCapacity: 1024) { _ in }
+            return buffer
+        }
+
+        let bufferIDs = Set(buffers.map { $0.storagePointerIntegerValue() })
+        #expect(bufferIDs.count == pool.capacity)
+
+        // Drop the ref to the middle buffer.
+        buffers.remove(at: 1)
+
+        _ = pool.withBuffer(minimumCapacity: 1024) { buffer in
+            #expect(bufferIDs.contains(buffer.storagePointerIntegerValue()))
+        }
+    }
+
+    @Test
+    func buffersAreClearedBetweenCalls() {
+        var pool = BufferPool(capacity: 3)
+
+        // The pool recycles buffers which are unique. Store each buffer to ensure that's not the
+        // case.
+        var buffers: [ByteBuffer] = (1...pool.capacity).map { _ in
+            let (buffer, _) = pool.withBuffer(minimumCapacity: 1024) {
+                $0.writeRepeatingByte(42, count: 1024)
+            }
+            return buffer
+        }
+
+        // Grab the storage pointers; check against them below.
+        var storagePointers = Set(buffers.map { $0.storagePointerIntegerValue() })
+        #expect(storagePointers.count == pool.capacity)
+
+        // Drop the buffer storage refs so they can be reused.
+        buffers.removeAll()
+
+        // Loop of the pool again.
+        var moreBuffers: [ByteBuffer] = storagePointers.map { _ in
+            let (buffer, _) = pool.withBuffer(minimumCapacity: 1024) {
+                let storagePointer = $0.storagePointerIntegerValue()
+                #expect(storagePointers.remove(storagePointer) != nil)
+                #expect($0.readerIndex == 0)
+                #expect($0.writerIndex == 0)
+            }
+            return buffer
+        }
+        moreBuffers.removeAll()
+    }
+}
+
+extension ByteBuffer {
+    func storagePointerIntegerValue() -> UInt {
+        var pointer: UInt = 0
+        self.withVeryUnsafeBytes { ptr in
+            pointer = UInt(bitPattern: ptr.baseAddress!)
+        }
+        return pointer
+    }
+}

--- a/Tests/NIOQUICTests/GSOCoalescerTests.swift
+++ b/Tests/NIOQUICTests/GSOCoalescerTests.swift
@@ -15,11 +15,13 @@
 import NIOCore
 import Testing
 
-@testable import NIOQUIC
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import NIOQUIC
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import SwiftNetwork
 
 struct GSOCoalescerTests {
     private static let peer = try! SocketAddress(ipAddress: "127.0.0.1", port: 4433)
 
+    @available(anyAppleOS 26, *)
     private func makeCoalescer(
         maxSegments: Int = 64,
         maxCoalescedSize: Int = 65535
@@ -31,11 +33,33 @@ struct GSOCoalescerTests {
         )
     }
 
-    private func buffer(_ size: Int) -> ByteBuffer {
-        ByteBuffer(repeating: UInt8(size % 256), count: size)
+    /// Builds a batch of frames of the given packet sizes, each filled with a distinct byte.
+    ///
+    /// Frames are allocated with `allocation` bytes (defaulting to the packet size) to mimic the
+    /// QUIC stack, which allocates a full-MSS frame and then collapses it down to the length of
+    /// the packet it actually wrote.
+    @available(anyAppleOS 26, *)
+    private func frames(_ sizes: [Int], allocation: Int? = nil) -> FrameArray {
+        var array = FrameArray(capacity: sizes.count)
+        for (index, size) in sizes.enumerated() {
+            let allocation = allocation ?? size
+            var frame = Frame(allocatingCustomFinalizerBufferOfSize: allocation)
+            if allocation != size {
+                let collapsed = frame.collapse(to: size)
+                #expect(collapsed)
+            }
+            if var span = frame.mutableSpan {
+                for spanIndex in span.indices {
+                    span[spanIndex] = UInt8(truncatingIfNeeded: index + 1)
+                }
+            }
+            array.add(frame: frame)
+        }
+        return array
     }
 
     /// Drains the coalescer into a list of (segment size, total size) pairs.
+    @available(anyAppleOS 26, *)
     private func drain(_ coalescer: inout GSOCoalescer) -> [(segmentSize: Int?, totalSize: Int)] {
         var runs: [(segmentSize: Int?, totalSize: Int)] = []
         while let envelope = coalescer.next() {
@@ -47,82 +71,97 @@ struct GSOCoalescerTests {
         return runs
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func emptyCoalescer() {
         var coalescer = self.makeCoalescer()
-        #expect(coalescer.isEmpty)
+        let isEmpty = coalescer.isEmpty
+        #expect(isEmpty)
         #expect(coalescer.next() == nil)
     }
 
+    @available(anyAppleOS 26, *)
     @Test
-    func emptyBufferIsIgnored() {
+    func emptyBatchIsIgnored() {
         var coalescer = self.makeCoalescer()
-        coalescer.append(ByteBuffer())
-        #expect(coalescer.isEmpty)
+        coalescer.append(frames: FrameArray())
+        let isEmpty = coalescer.isEmpty
+        #expect(isEmpty)
         #expect(coalescer.next() == nil)
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func singleDatagramIsNotSegmented() {
         var coalescer = self.makeCoalescer()
-        coalescer.append(self.buffer(1200))
+        coalescer.append(frames: self.frames([1200]))
 
         let runs = self.drain(&coalescer)
         #expect(runs.map { $0.segmentSize } == [nil])
         #expect(runs.map { $0.totalSize } == [1200])
-        #expect(coalescer.isEmpty)
+        let isEmpty = coalescer.isEmpty
+        #expect(isEmpty)
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func equalSizedDatagramsCoalesce() {
         var coalescer = self.makeCoalescer()
-        for _ in 0..<5 {
-            coalescer.append(self.buffer(1200))
-        }
+        coalescer.append(frames: self.frames(Array(repeating: 1200, count: 5)))
 
         let runs = self.drain(&coalescer)
         #expect(runs.map { $0.segmentSize } == [1200])
         #expect(runs.map { $0.totalSize } == [6000])
     }
 
+    /// The QUIC stack hands back frames allocated at full MSS regardless of how many bytes the
+    /// packet written into them uses: the run must be sized by the packet, not the allocation.
+    @available(anyAppleOS 26, *)
+    @Test
+    func packetLengthNotAllocationSizeDrivesTheRun() {
+        var coalescer = self.makeCoalescer()
+        coalescer.append(frames: self.frames([1200, 1200, 900, 1200], allocation: 1400))
+
+        let runs = self.drain(&coalescer)
+        #expect(runs.map { $0.segmentSize } == [1200, nil])
+        #expect(runs.map { $0.totalSize } == [3300, 1200])
+    }
+
+    @available(anyAppleOS 26, *)
     @Test
     func shortDatagramEndsRun() {
         var coalescer = self.makeCoalescer()
-        coalescer.append(self.buffer(1200))
-        coalescer.append(self.buffer(1200))
-        coalescer.append(self.buffer(500))
-        coalescer.append(self.buffer(1200))
+        coalescer.append(frames: self.frames([1200, 1200, 500, 1200]))
 
         let runs = self.drain(&coalescer)
         #expect(runs.map { $0.segmentSize } == [1200, nil])
         #expect(runs.map { $0.totalSize } == [2900, 1200])
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func largerDatagramStartsNewRun() {
         var coalescer = self.makeCoalescer()
-        coalescer.append(self.buffer(800))
-        coalescer.append(self.buffer(800))
-        coalescer.append(self.buffer(1200))
-        coalescer.append(self.buffer(1200))
+        coalescer.append(frames: self.frames([800, 800, 1200, 1200]))
 
         let runs = self.drain(&coalescer)
         #expect(runs.map { $0.segmentSize } == [800, 1200])
         #expect(runs.map { $0.totalSize } == [1600, 2400])
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func runIsCappedAtMaxSegments() {
         var coalescer = self.makeCoalescer()
-        for _ in 0..<(coalescer.maxSegments + 3) {
-            coalescer.append(self.buffer(100))
-        }
+        let maxSegments = coalescer.maxSegments
+        coalescer.append(frames: self.frames(Array(repeating: 100, count: maxSegments + 3)))
 
         let runs = self.drain(&coalescer)
         #expect(runs.map { $0.segmentSize } == [100, 100])
-        #expect(runs.map { $0.totalSize } == [coalescer.maxSegments * 100, 300])
+        #expect(runs.map { $0.totalSize } == [maxSegments * 100, 300])
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func runIsCappedAtMaxCoalescedSize() throws {
         let maxSegments = 64
@@ -134,9 +173,7 @@ struct GSOCoalescerTests {
         )
 
         // 64 * 1400 = 89600 bytes: more than maxCoalescedSize
-        for _ in 0..<coalescer.maxSegments {
-            coalescer.append(self.buffer(1400))
-        }
+        coalescer.append(frames: self.frames(Array(repeating: 1400, count: maxSegments)))
 
         let runs = self.drain(&coalescer)
         try #require(runs.count == 2)
@@ -148,36 +185,34 @@ struct GSOCoalescerTests {
         #expect(runs[1].segmentSize == 1400)
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func oversizedDatagramIsEmittedAlone() {
         var coalescer = self.makeCoalescer()
-        let oversized = coalescer.maxCoalescedSize + 1
-        coalescer.append(self.buffer(oversized))
-        coalescer.append(self.buffer(1200))
+        let oversized = coalescer.maxCoalescedSize + 1  // read before the borrow: GSOCoalescer is ~Copyable
+        coalescer.append(frames: self.frames([oversized, 1200]))
 
         let runs = self.drain(&coalescer)
         #expect(runs.map { $0.segmentSize } == [nil, nil])
         #expect(runs.map { $0.totalSize } == [oversized, 1200])
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func maxSegmentsOfOneNeverCoalesces() {
         var coalescer = GSOCoalescer(remoteAddress: Self.peer, maxSegments: 1)
-        for _ in 0..<3 {
-            coalescer.append(self.buffer(1200))
-        }
+        coalescer.append(frames: self.frames([1200, 1200, 1200]))
 
         let runs = self.drain(&coalescer)
         #expect(runs.map { $0.segmentSize } == [nil, nil, nil])
         #expect(runs.map { $0.totalSize } == [1200, 1200, 1200])
     }
 
+    @available(anyAppleOS 26, *)
     @Test
     func coalescedRunPreservesBytesInOrder() {
         var coalescer = self.makeCoalescer()
-        for byte in UInt8(1)...UInt8(3) {
-            coalescer.append(ByteBuffer(repeating: byte, count: 4))
-        }
+        coalescer.append(frames: self.frames([4, 4, 4]))
 
         let envelope = coalescer.next()
         #expect(envelope?.metadata?.segmentSize == 4)


### PR DESCRIPTION
Motivation:

In 05cf814 a `ByteBuffer` based coalescer was added for GSO. It occurred to me afterwards that there were two more optimisation that could be made.

The first is to consume `Frame` directly rather than going via an intermediate `ByteBuffer`. The other is reusing a pool of byte buffers rather than coalescing into the first buffer. As coalescing is done in the read loop there should be relatively few buffers used (if coalescing is successful) meaning we can reuse them between read cycles and save the allocation costs.

Modifications:

- Add `BufferPool`, a stripped down and simplified version of NIOs `NIOPooledRecvBufferAllocator`.
- Change the coalescer to store frames

Result:

GSO will be cheaper when we wire it up