### PR TITLE
Fix Conformance to InboundStreamHandler

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1142,7 +1142,7 @@ extension QUICChannelStreamHandler: UpperProtocolHandler {
 }
 
 @available(anyAppleOS 26, *)
-extension QUICChannelStreamHandler: InboundStreamHandler {
+extension QUICChannelStreamHandler {
     func attachLowerStreamProtocolToExistingFlow(
         listener: StreamListenerLinkage,
         flowReference: ProtocolInstanceReference

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1141,6 +1141,16 @@ extension QUICChannelStreamHandler: UpperProtocolHandler {
     }
 }
 
+@available(anyAppleOS 26, *)
+extension QUICChannelStreamHandler: InboundStreamHandler {
+    func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError) {
+        throw NetworkError.posix(ENOTSUP)
+    }
+}
+
 // MARK: - `Channel` and `ChannelCore` conformance
 
 @available(anyAppleOS 26, *)


### PR DESCRIPTION
### Motivation

This is more of a warning for when the tag is next bumped up that there was a change that went in recently to SwiftNetwork that will cause an protocol conformance breakage for InboundStreamHandler:

https://github.com/apple/swift-network-evolution/commit/c7adf0f68e243d120a949935b23f9ab82acd0316

This change is a suggested fix for when the time is right.

### Modifications

Conformance for InboundStreamHandler in QUICChannelStreamHandler.

### Result

Builds as expected.
