### PR TITLE
Always complete a stream channel's close promise

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1366,17 +1366,17 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
         // its close promise must still be completed.
         let wasActive = self._isActive.exchange(false, ordering: .sequentiallyConsistent)
 
-        // Put calls to _close on the next runloop tick because it calls fireChannelInactive
+        if let error {
+            self.pipeline.fireErrorCaught(error)
+        }
+
+        if wasActive {
+            self.pipeline.fireChannelInactive()
+            self.pipeline.fireChannelUnregistered()
+        }
+
+        // Complete the promise on the next loop tick.
         self.eventLoop.assumeIsolated().execute {
-            if let error {
-                self.pipeline.fireErrorCaught(error)
-            }
-
-            if wasActive {
-                self.pipeline.fireChannelInactive()
-                self.pipeline.fireChannelUnregistered()
-            }
-
             self.removeHandlers(pipeline: self.pipeline)
             self._closePromise.succeed(())
             promise?.succeed()

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -118,6 +118,9 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     /// Defaults to `true`. This value can be updated by calling `setOption`.
     private var autoRead: Bool = true
 
+    /// Whether `_close` has already run.
+    private var isClosed: Bool = false
+
     private var originalMetadata: ProtocolMetadata<QUICProtocol>?
     private var connectedEventHandler: ((QUICStreamID?) -> Void)?
     private var disconnectedEventHandler: ((NetworkError?) -> Void)?
@@ -668,6 +671,11 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         }
     }
 
+    /// Closes the channel if it isn't yet closed.
+    func closeIfNeeded() {
+        self._close(error: nil, promise: nil)
+    }
+
     /// Called when the stream handler receives a disconnected event.
     ///
     /// Runs the close cascade synchronously
@@ -683,9 +691,8 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
         case .skipAlreadyDetached:
             break
         }
-        if self.isActive {
-            self._close(error: error, promise: nil)
-        }
+
+        self._close(error: error, promise: nil)
     }
 
     @inline(__always)
@@ -1345,20 +1352,31 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
 
     private func _close(error: (any Error)?, promise: EventLoopPromise<Void>?) {
         self.eventLoop.preconditionInEventLoop()
-        guard self.isActive else {
+        if self.isClosed {
             promise?.succeed()
             return
         }
         self.log("_close error: \(String(describing: error))")
-        self._isActive.store(false, ordering: .sequentiallyConsistent)
+        self.isClosed = true
+
+        // A stream can be closed before it ever became active, e.g. its flow was attached in the
+        // same read batch in which the connection tore down.
+        //
+        // If that happens it must not see 'channelInactive' (it didn't see 'channelActive') but
+        // its close promise must still be completed.
+        let wasActive = self._isActive.exchange(false, ordering: .sequentiallyConsistent)
+
         // Put calls to _close on the next runloop tick because it calls fireChannelInactive
         self.eventLoop.assumeIsolated().execute {
             if let error {
                 self.pipeline.fireErrorCaught(error)
             }
 
-            self.pipeline.fireChannelInactive()
-            self.pipeline.fireChannelUnregistered()
+            if wasActive {
+                self.pipeline.fireChannelInactive()
+                self.pipeline.fireChannelUnregistered()
+            }
+
             self.removeHandlers(pipeline: self.pipeline)
             self._closePromise.succeed(())
             promise?.succeed()

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -828,6 +828,7 @@ final class SwiftNetworkQUICConnection {
         let futures = streamInputHandlers.values.map { $0.closeFuture }
         for stream in streamInputHandlers.values {
             stream.stop(detachFromLowerProtocol: true)
+            stream.closeIfNeeded()
         }
         return futures
     }

--- a/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
@@ -19,6 +19,7 @@ import NIOCore
 import NIOEmbedded
 import NIOQUICHelpers
 @_spi(ProtocolProvider) import SwiftNetwork
+import Synchronization
 import Testing
 
 @testable import NIOQUIC
@@ -398,6 +399,37 @@ struct QUICChannelStreamHandlerTests {
         }
     }
 
+    @available(anyAppleOS 26, *)
+    @Test("closeAllStreams resolves the close future of a stream", arguments: [true, false])
+    func closeAllStreamsResolvesCloseFuture(active: Bool) throws {
+        try Self.withServerConnectionAndStream { connection, streamChannel in
+            streamChannel._isActive.store(active, ordering: .sequentiallyConsistent)
+
+            let recorder = RecordingHandler()
+            try streamChannel.pipeline.syncOperations.addHandler(recorder)
+
+            let closeFutureCompleted = Mutex(false)
+            streamChannel.closeFuture.whenComplete { _ in
+                closeFutureCompleted.withLock { $0 = true }
+            }
+
+            let futures = connection.closeAllStreams()
+            #expect(futures.count == 1)
+
+            // `_close` defers completing the promise to the next event-loop tick; flush.
+            (streamChannel.eventLoop as! EmbeddedEventLoop).run()
+
+            #expect(closeFutureCompleted.withLock { $0 })
+            #expect(!streamChannel.isActive)
+
+            if active {
+                #expect(recorder.events == [.channelInactive, .channelUnregistered])
+            } else {
+                #expect(recorder.events == [])
+            }
+        }
+    }
+
     /// `invoke*` wrappers must release their borrow on `swiftNetworkStreamHandle` before the linkage call;
     /// SwiftNetwork's synchronous drain otherwise re-enters `invokeDetach` on a live read borrow and traps.
     @available(anyAppleOS 26, *)
@@ -439,6 +471,21 @@ extension QUICChannelStreamHandlerTests {
         direction: QUICStreamDirection = .bidirectional,
         autoRead: Bool = true,
         body: (QUICChannelStreamHandler) throws -> Void
+    ) throws {
+        try Self.withServerConnectionAndStream(
+            streamID: streamID,
+            direction: direction,
+            autoRead: autoRead
+        ) { _, streamChannel in
+            try body(streamChannel)
+        }
+    }
+
+    static func withServerConnectionAndStream(
+        streamID: UInt64 = 0,
+        direction: QUICStreamDirection = .bidirectional,
+        autoRead: Bool = true,
+        body: (SwiftNetworkQUICConnection, QUICChannelStreamHandler) throws -> Void
     ) throws {
         let testPrivateKeyPath = Bundle.module.url(forResource: "privateKey", withExtension: "der")!.path
         let testPublicKeyPath = Bundle.module.url(forResource: "publicKey", withExtension: "der")!.path
@@ -483,7 +530,7 @@ extension QUICChannelStreamHandlerTests {
 
         try streamChannel.syncOptions!.setOption(.autoRead, value: autoRead)
 
-        try body(streamChannel)
+        try body(connection, streamChannel)
 
         try udpChannel.close().wait()
     }
@@ -511,6 +558,8 @@ extension QUICChannelStreamHandlerTests {
             case channelRead(ByteBuffer)
             case channelReadComplete
             case inputClosedEvent
+            case channelInactive
+            case channelUnregistered
         }
 
         var events: [Event] = []
@@ -548,6 +597,16 @@ extension QUICChannelStreamHandlerTests {
         func channelReadComplete(context: ChannelHandlerContext) {
             self.events.append(.channelReadComplete)
             context.fireChannelReadComplete()
+        }
+
+        func channelInactive(context: ChannelHandlerContext) {
+            self.events.append(.channelInactive)
+            context.fireChannelInactive()
+        }
+
+        func channelUnregistered(context: ChannelHandlerContext) {
+            self.events.append(.channelUnregistered)
+            context.fireChannelUnregistered()
         }
 
         func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {


### PR DESCRIPTION
Motivation:

If a stream is openend in the same read batch that closes the connection, the stream will be created but never complete its close promise. Note that the stream channel won't have been configured.

The connection channel waits for all streams to close before it fires inactive so this results in the connection wedging open.

Modifications:

- Making closing a stream idempotent
- When closing, check whether to the stream was active first and conditionally fire inactive

Result:

Fewer wedges