### PR TITLE
Wire up gso

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -714,11 +714,7 @@ extension QUICConnectionChannel {
 
         // Avoid re-entering this function.
         self.withoutEnteringDrainOutput {
-            while let buffer = self._connection.nextPacketToSend() {
-                let envelope = AddressedEnvelope(
-                    remoteAddress: self._remoteAddress,
-                    data: buffer
-                )
+            while let envelope = self._connection.nextPacketToSend() {
                 self._transport.writeDatagram(envelope, promise: nil)
             }
 

--- a/Sources/NIOQUIC/QUICConnectionProtocol.swift
+++ b/Sources/NIOQUIC/QUICConnectionProtocol.swift
@@ -43,7 +43,7 @@ protocol QUICConnectionProtocol {
     /// Call repeatedly until it returns `nil` to drain all pending output.
     ///
     /// - Returns: The next datagram to send, or `nil` if none are queued.
-    func nextPacketToSend() -> ByteBuffer?
+    func nextPacketToSend() -> AddressedEnvelope<ByteBuffer>?
 
     /// Initiates a locally-requested close of the connection.
     ///
@@ -155,7 +155,7 @@ extension QUICConnectionChannel.Connection: QUICConnectionProtocol {
         }
     }
 
-    func nextPacketToSend() -> ByteBuffer? {
+    func nextPacketToSend() -> AddressedEnvelope<ByteBuffer>? {
         switch self {
         case .live(let connection):
             connection.nextPacketToSend()

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -153,6 +153,9 @@ final class SwiftNetworkQUICConnection {
         self.connectionStateMachine.isTerminating
     }
 
+    /// Groups outbound datagrams for GSO.
+    private var coalescer: GSOCoalescer
+
     /// Creates a new client-side connection.
     ///
     /// - Parameters:
@@ -302,6 +305,17 @@ final class SwiftNetworkQUICConnection {
         let swiftNetworkQUICConnection = SwiftNetwork.QUICConnection(context: swiftNetworkParameters.context)
         self.swiftNetworkParameters = swiftNetworkParameters
         self.swiftNetworkQUICConnection = swiftNetworkQUICConnection
+
+        #if os(Linux)
+        let maxSegments = 64
+        #else
+        let maxSegments = 1
+        #endif
+
+        self.coalescer = GSOCoalescer(
+            remoteAddress: remoteAddress,
+            maxSegments: maxSegments
+        )
 
         self.connectionQLogID = Self.nextClientConnectionQLogID()
         let prefix = role == .server ? "L" : "C"
@@ -891,8 +905,8 @@ final class SwiftNetworkQUICConnection {
     ///
     @discardableResult
     @inlinable
-    func nextPacketToSend() -> ByteBuffer? {
-        self.finalizedOutput.popFirst()
+    func nextPacketToSend() -> AddressedEnvelope<ByteBuffer>? {
+        self.coalescer.next()
     }
 
 }
@@ -1358,32 +1372,9 @@ extension SwiftNetworkQUICConnection {
     /// These are QUIC output frames that have already been built by the protocol stack.
     internal func outputHandlerFinalizeOutputFrames(frames: consuming FrameArray) {
         log("finalizeOutputFrames: \(frames.count)")
-        var didFinalizeFrames = false
-        frames.iterateMutableFrames { frame in
-            if frame.unclaimedLength == 0 {
-                frame.finalize(success: true)
-                return true
-            }
+        self.coalescer.append(frames: frames)
 
-            if let bufferConfig = frame.takeOwnershipOfCustomFinalizerBuffer() {
-                frame.finalize(success: true)
-                let outputBuffer = ByteBuffer(
-                    takingOwnershipOf: bufferConfig.bufferPointer,
-                    allocator: FrameMemory.allocator,
-                    readerIndex: bufferConfig.readerOffset,
-                    writerIndex: bufferConfig.writerOffset
-                )
-                self.finalizedOutput.append(outputBuffer)
-                didFinalizeFrames = true
-                return true
-            }
-
-            assertionFailure("Encountered frame with unexpected buffer type.")
-            frame.finalize(success: false)
-            return true
-        }
-
-        if !self.inReadLoop && didFinalizeFrames {
+        if !self.inReadLoop, !self.coalescer.isEmpty {
             self.triggerOutOfBandWriteEvent()
         }
     }

--- a/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
@@ -814,8 +814,12 @@ final class RecordingConnection: QUICConnectionProtocol {
         self.events.append(.receivedPacketsComplete)
     }
 
-    func nextPacketToSend() -> ByteBuffer? {
-        self.outboundPackets.popFirst()
+    func nextPacketToSend() -> AddressedEnvelope<ByteBuffer>? {
+        if let buffer = self.outboundPackets.popFirst() {
+            return AddressedEnvelope(remoteAddress: self.remoteAddress, data: buffer)
+        } else {
+            return nil
+        }
     }
 
     func close(isApplicationClose: Bool, errorCode: Int64, reason: String) -> Bool {
@@ -862,7 +866,7 @@ struct NoOpConnection: QUICConnectionProtocol {
     func receivePacketsComplete() {
     }
 
-    func nextPacketToSend() -> ByteBuffer? {
+    func nextPacketToSend() -> AddressedEnvelope<ByteBuffer>? {
         nil
     }
 


### PR DESCRIPTION
Motivation:

We've got a datagram coalescer in place, we just need to wire it up.

Modifications:

- Change the API between the connection channel and the QUIC connection so outbound packets are AddressedEnvelope, the output type of the coalescer
- Modify the connection so that it stores frames and then coalesces them when the channel asks for outbound frames

Results:

GSO hooked up