### PR TITLE
Add a frame pool

### DIFF
--- a/Sources/NIOQUIC/FramePool.swift
+++ b/Sources/NIOQUIC/FramePool.swift
@@ -1,0 +1,188 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BasicContainers
+@_spi(ProtocolProvider) import SwiftNetwork
+
+/// A pool of `Frame`s.
+///
+/// The pool stores two category sizes of frame: small and large. To be pooled, small and large
+/// frames must have exactly the capacity as required by their size class. The pool limits also how
+/// many of each category size can be stored at a given time. This avoids situations where bursty
+/// traffic results in the pool overcomitting memory indefinitely.
+@available(anyAppleOS 26, *)
+final class FramePool {
+    private var smallStorage: BufferPool
+    private var largeStorage: BufferPool
+
+    private let smallFrameSize: Int
+    private let largeFrameSize: Int
+
+    init(
+        smallFrameSize: Int,
+        maxSmallFrames: Int,
+        largeFrameSize: Int,
+        maxLargeFrames: Int,
+    ) {
+        precondition(maxLargeFrames >= 0 && maxSmallFrames >= 0)
+        precondition(largeFrameSize >= 0 && smallFrameSize >= 0)
+        precondition(largeFrameSize > smallFrameSize || largeFrameSize == 0)
+
+        self.smallStorage = BufferPool(capacity: maxSmallFrames)
+        self.smallFrameSize = smallFrameSize
+
+        self.largeStorage = BufferPool(capacity: maxLargeFrames)
+        self.largeFrameSize = largeFrameSize
+    }
+
+    /// The number of small frames in the pool.
+    var smallFrameCount: Int {
+        self.smallStorage.count
+    }
+
+    /// The number of large frames in the pool.
+    var largeFrameCount: Int {
+        self.largeStorage.count
+    }
+
+    static func makePool(forGSO gso: Bool) -> Self {
+        Self(
+            // Small frames are approx MSS sized.
+            smallFrameSize: 1500,
+            // GSO expects fewer small frames.
+            maxSmallFrames: gso ? 8 : 64,
+            // 64KB is the upper limit on what can be sent with GSO.
+            largeFrameSize: gso ? 64 * 1024 : 0,
+            // 4 * 64KB is 256KB: the maximum amount retained per connection for GSO.
+            maxLargeFrames: gso ? 4 : 0
+        )
+    }
+
+    private func storeBufferPointer(_ buffer: consuming UnsafeMutableRawBufferPointer) -> Bool {
+        let stored: Bool
+
+        switch buffer.count {
+        case self.smallFrameSize:
+            stored = self.smallStorage.storeBuffer(buffer)
+        case self.largeFrameSize:
+            stored = self.largeStorage.storeBuffer(buffer)
+        default:
+            // Not a pooled size.
+            buffer.deallocate()
+            stored = false
+        }
+
+        return stored
+    }
+
+    /// Stores the backing storage from the frame.
+    ///
+    /// - Parameter frame: The frame to store.
+    /// - Returns: Whether the frame was stored or not.
+    @discardableResult
+    func storeFrame(_ frame: consuming Frame) -> Bool {
+        let stored: Bool
+
+        if let customFinalizer = frame.takeOwnershipOfCustomFinalizerBuffer() {
+            stored = self.storeBufferPointer(customFinalizer.bufferPointer)
+        } else {
+            stored = false
+        }
+
+        if !stored {
+            frame.finalize(success: false)
+        }
+
+        return stored
+    }
+
+    /// Take a frame from the pool if one is available.
+    ///
+    /// - Parameter minimumSize: The minimum size of the frame to take.
+    /// - Returns: A pooled frame, if one was available.
+    func takeFrame(minimumSize: Int) -> Frame? {
+        let buffer: UnsafeMutableRawBufferPointer?
+
+        if minimumSize <= self.smallFrameSize {
+            buffer = self.smallStorage.takeBuffer()
+        } else if minimumSize <= self.largeFrameSize {
+            buffer = self.largeStorage.takeBuffer()
+        } else {
+            buffer = nil
+        }
+
+        if let buffer {
+            return Frame(buffer: buffer) { $0.baseAddress?.deallocate() }
+        } else {
+            return nil
+        }
+    }
+
+    /// Takes a frame from the pool or creates one if none were available.
+    ///
+    /// - Parameter minimumSize: The minimum size of the frame to take or create.
+    /// - Returns: A frame.
+    func takeOrCreateFrame(minimumSize: Int) -> Frame {
+        if let frame = self.takeFrame(minimumSize: minimumSize) {
+            return frame
+        }
+
+        // Create a frame sized for one of the buckets.
+        let size: Int
+        if minimumSize <= self.smallFrameSize {
+            size = self.smallFrameSize
+        } else if minimumSize <= self.largeFrameSize {
+            size = self.largeFrameSize
+        } else {
+            size = minimumSize
+        }
+
+        return Frame(allocatingCustomFinalizerBufferOfSize: size)
+    }
+
+    private struct BufferPool: ~Copyable {
+        private var storage: UniqueArray<UnsafeMutableRawBufferPointer>
+        let capacity: Int
+
+        var count: Int {
+            self.storage.count
+        }
+
+        init(capacity: Int) {
+            self.storage = UniqueArray()
+            self.storage.reserveCapacity(capacity)
+            self.capacity = capacity
+        }
+
+        deinit {
+            for index in self.storage.indices {
+                self.storage[index].deallocate()
+            }
+        }
+
+        mutating func storeBuffer(_ buffer: consuming UnsafeMutableRawBufferPointer) -> Bool {
+            if self.storage.count < self.capacity {
+                self.storage.append(buffer)
+                return true
+            } else {
+                buffer.deallocate()
+                return false
+            }
+        }
+
+        mutating func takeBuffer() -> UnsafeMutableRawBufferPointer? {
+            self.storage.popLast()
+        }
+    }
+}

--- a/Tests/NIOQUICTests/FramePoolTests.swift
+++ b/Tests/NIOQUICTests/FramePoolTests.swift
@@ -1,0 +1,183 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BasicContainers
+@_spi(ProtocolProvider) import SwiftNetwork
+import Testing
+
+@testable import NIOQUIC
+
+struct FramePoolTests {
+    @available(anyAppleOS 26, *)
+    func makeFramePool(
+        smallFrameSize: Int = 100,
+        maxSmallFrames: Int = 16,
+        largeFrameSize: Int = 200,
+        maxLargeFrames: Int = 16
+    ) -> FramePool {
+        FramePool(
+            smallFrameSize: smallFrameSize,
+            maxSmallFrames: maxSmallFrames,
+            largeFrameSize: largeFrameSize,
+            maxLargeFrames: maxLargeFrames
+        )
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func empty() {
+        let pool = self.makeFramePool(smallFrameSize: 100, largeFrameSize: 200)
+        #expect(pool.smallFrameCount == 0)
+        #expect(pool.largeFrameCount == 0)
+
+        expectNil(pool.takeFrame(minimumSize: 0))
+        expectNil(pool.takeFrame(minimumSize: 100))
+        expectNil(pool.takeFrame(minimumSize: 200))
+        expectNil(pool.takeFrame(minimumSize: 300))
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func initPreconditions() async {
+        // Sizes must be >= 0
+        await #expect(processExitsWith: .failure) {
+            _ = FramePool(smallFrameSize: -1, maxSmallFrames: 1, largeFrameSize: 1, maxLargeFrames: 1)
+        }
+        await #expect(processExitsWith: .failure) {
+            _ = FramePool(smallFrameSize: 1, maxSmallFrames: 1, largeFrameSize: -1, maxLargeFrames: 1)
+        }
+
+        // max frame counts must be >= 0
+        await #expect(processExitsWith: .failure) {
+            _ = FramePool(smallFrameSize: 1, maxSmallFrames: -1, largeFrameSize: 2, maxLargeFrames: 1)
+        }
+        await #expect(processExitsWith: .failure) {
+            _ = FramePool(smallFrameSize: 1, maxSmallFrames: 1, largeFrameSize: 2, maxLargeFrames: -1)
+        }
+
+        // large frame size must be > small frame size
+        await #expect(processExitsWith: .failure) {
+            _ = FramePool(smallFrameSize: 10, maxSmallFrames: 1, largeFrameSize: 9, maxLargeFrames: 1)
+        }
+    }
+
+    @Test(
+        arguments: [
+            // Small
+            (0, 100),
+            (100, 100),
+            // Large
+            (101, 200),
+            (200, 200),
+            // Unpooled
+            (201, 201),
+            (202, 202),
+        ]
+    )
+    @available(anyAppleOS 26, *)
+    func appropriateSizeFrameIsCreated(requestedSize: Int, expectedSize: Int) {
+        let pool = self.makeFramePool(smallFrameSize: 100, largeFrameSize: 200)
+
+        var frame = pool.takeOrCreateFrame(minimumSize: requestedSize)
+        #expect(frame.unclaimedLength == expectedSize)
+        frame.finalize(success: true)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func returnedFrameGoesInRightBucket() {
+        let pool = self.makeFramePool(smallFrameSize: 100, largeFrameSize: 200)
+
+        let small = pool.takeOrCreateFrame(minimumSize: 100)
+        let storedSmall = pool.storeFrame(small)
+        #expect(storedSmall)
+        #expect(pool.smallFrameCount == 1)
+
+        let large = pool.takeOrCreateFrame(minimumSize: 200)
+        let storedLarge = pool.storeFrame(large)
+        #expect(storedLarge)
+        #expect(pool.largeFrameCount == 1)
+
+        let tooLarge = pool.takeOrCreateFrame(minimumSize: 201)
+        let storedTooLarge = pool.storeFrame(tooLarge)
+        #expect(!storedTooLarge)
+        // Still 1 each.
+        #expect(pool.smallFrameCount == 1)
+        #expect(pool.largeFrameCount == 1)
+    }
+
+    @Test(arguments: [true, false])
+    @available(anyAppleOS 26, *)
+    func capacityIsRespected(small: Bool) {
+        let size = small ? 100 : 200
+        let pool = self.makeFramePool(
+            smallFrameSize: 100,
+            maxSmallFrames: 4,
+            largeFrameSize: 200,
+            maxLargeFrames: 4
+        )
+
+        // Create 5 frames.
+        var frames = UniqueArray<Frame>()
+        for _ in 1...5 {
+            let frame = pool.takeOrCreateFrame(minimumSize: size)
+            frames.append(frame)
+        }
+
+        for expectedCount in 1...4 {
+            let frame = frames.removeLast()
+            let stored = pool.storeFrame(frame)
+            #expect(stored)
+
+            if small {
+                #expect(pool.smallFrameCount == expectedCount)
+                #expect(pool.largeFrameCount == 0)
+            } else {
+                #expect(pool.smallFrameCount == 0)
+                #expect(pool.largeFrameCount == expectedCount)
+            }
+        }
+
+        let frame = frames.removeLast()
+        let stored = pool.storeFrame(frame)
+        #expect(!stored)
+        if small {
+            #expect(pool.smallFrameCount == 4)
+            #expect(pool.largeFrameCount == 0)
+        } else {
+            #expect(pool.smallFrameCount == 0)
+            #expect(pool.largeFrameCount == 4)
+        }
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func foreignFrameIsNotStored() {
+        let pool = self.makeFramePool(smallFrameSize: 100, largeFrameSize: 200)
+        // Right size, wrong backing type.
+        let frame = Frame(count: 100)
+        let stored = pool.storeFrame(frame)
+        #expect(!stored)
+    }
+}
+
+private func expectNil<T: ~Copyable>(_ expression: @autoclosure () -> T?) {
+    let value = expression()
+    switch value {
+    case .some:
+        Issue.record("Expected nil but found a value")
+    case .none:
+        ()
+    }
+}


### PR DESCRIPTION
Motivation:

Before creating Frames, SwiftNetwork asks us for a batch of Frames to write outbound data into. It then populates them and hands them back to us. At that point we then copy their contents into out pooled ByteBuffer's. We can do the same for Frames: pool them.

Modifiactions:

Add a frame pool which stores two size classes of Frame: small and large. When GSO is used the large frames will be sized at 64KB, the largest size possible for a GSO write. When GSO isn't used the large frames won't be used at all. In both cases small frames will be sized at ~1500 bytes, i.e. larger than the MSS.

The pool has capacity limits on the number of each size class that can be stored to avoid holding memory for too long (e.g. if a burst of traffic results in many frames being created and then stored indefinitely).

Result:

Nothing yet, it isn't used. However, when used it will reduce allocs on the outbound path.