### PR TITLE
Propagate batching to SwiftNetwork

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
         .package(
             url: "https://github.com/apple/swift-network-evolution",
-            .upToNextMinor(from: "0.1.1"),
+            .upToNextMinor(from: "0.1.2"),
             traits: swiftNetworkTraits
         ),
         .package(url: "https://github.com/apple/swift-tls", .upToNextMinor(from: "0.1.0")),

--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -874,28 +874,28 @@ extension QUICConnectionChannel {
     fileprivate func _parentChannelReadComplete() {
         self.eventLoop.assertInEventLoop()
 
-        defer {
-            switch self._connection {
-            case .live(let connection):
-                connection.exitReadLoop()
-            case .test:
-                ()
-            }
-        }
-
         // Avoid entering 'drainOutput'; wait for all events to be delivered and then
         // deal with them in 'drainAndReconcileLifecycle' below.
         self.withoutEnteringDrainOutput {
             self._connection.receivePacketsComplete()
         }
 
-        self.drainAndReconcileLifecycle()
-        let initializedAnyStreams = self.processPendingInboundStreams()
-
-        // Stream initializers may produce output; reconcile any pending events again.
-        if initializedAnyStreams {
-            self.drainAndReconcileLifecycle()
+        // Disable outbound batching so that SwiftQUIC emits frames into the connection. They'll
+        // be picked up when draining starts a few lines below. Re-enable again (i.e. disable
+        // temporarily) if there are pending streams as they may also produce output during their
+        // init.
+        self._connection.withLiveOnly { connection in
+            let hasPendingStreams = !self._pendingStreams.isEmpty
+            connection.flushOutboundBatch(resumeBatching: hasPendingStreams)
         }
+
+        self.drainAndReconcileLifecycle()
+        self.processPendingInboundStreams()
+
+        // Done producing data: exit read loop (and implicitly disables outbound batching).
+        self._connection.withLiveOnly { $0.exitReadLoop() }
+        // Stream initializers may produce output; reconcile any pending events again.
+        self.drainAndReconcileLifecycle()
     }
 
     fileprivate func _parentChannelWritabilityChanged(to isWritable: Bool) {
@@ -1001,19 +1001,15 @@ extension QUICConnectionChannel {
     }
 
     /// Initialize inbound streams pushed during the current read batch, skipping any not yet
-    /// connected. Returns `true` if any stream was initialized.
-    private func processPendingInboundStreams() -> Bool {
+    /// connected.
+    private func processPendingInboundStreams() {
         self.eventLoop.assertInEventLoop()
-        var anyStreamInitialized = false
 
         while let (streamID, stream) = self._pendingStreams.popFirst() {
             if stream.streamStateMachine.isConnected {
                 self.runInboundStreamInitializer(streamID: streamID, stream: stream)
-                anyStreamInitialized = true
             }
         }
-
-        return anyStreamInitialized
     }
 
     private func runInboundStreamInitializer(

--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -888,7 +888,7 @@ extension QUICConnectionChannel {
         self.drainAndReconcileLifecycle()
         self.processPendingInboundStreams()
 
-        // Done producing data: exit read loop (and implicitly disables outbound batching).
+        // Done producing data: exit read loop (which also flushes outbound data.)
         self._connection.withLiveOnly { $0.exitReadLoop() }
         // Stream initializers may produce output; reconcile any pending events again.
         self.drainAndReconcileLifecycle()

--- a/Sources/NIOQUIC/QUICConnectionProtocol.swift
+++ b/Sources/NIOQUIC/QUICConnectionProtocol.swift
@@ -98,7 +98,7 @@ extension QUICConnectionChannel {
         case test(any QUICConnectionProtocol)
 
         func withLiveOnly(
-            promise: EventLoopPromise<Void>?,
+            promise: EventLoopPromise<Void>? = nil,
             execute body: (SwiftNetworkQUICConnection) throws -> Void
         ) {
             switch self {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
@@ -168,6 +168,13 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
         }
     }
 
+    func outboundBatching(_ isEnabled: Bool) {
+        let event: ApplicationEvent = isEnabled ? .outboundDataBatchStart : .outboundDataBatchEnd
+        self.fromExternal {
+            self.lowerProtocol.invokeApplicationEvent(self.reference, event: event)
+        }
+    }
+
     // Received connected event
     func handleConnectedEvent(_ from: SwiftNetwork.ProtocolInstanceReference) {
         log("connected received")

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -108,7 +108,7 @@ final class SwiftNetworkQUICConnection {
         self.batchingEnabled = enabled
         // Enabling batching stops the underlying connection from producing (most) datagrams until
         // batching is disabled again, at which point any queued outbound writes will be emitted.
-        // This allows outbound wrties to be better packed into datagrams.
+        // This allows outbound writes to be better packed into datagrams.
         newFlowHandler.outboundBatching(enabled)
     }
 

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -90,8 +90,30 @@ final class SwiftNetworkQUICConnection {
     /// `exitReadLoop()`.
     private var inReadLoop: Bool
 
+    /// Whether SwiftQUIC has been told to batch outbound writes.
+    private var batchingEnabled: Bool
+
     internal func exitReadLoop() {
+        // Emit first as it triggers frames to be written; the writes check whether we're in a read
+        // loop and if we're not they'll do an out-of-band write. The connection channel is about
+        // to do an explicit drain anyway so no need for an out-of-band write.
+        self.setOutboundBatching(false)
         self.inReadLoop = false
+    }
+
+    internal func setOutboundBatching(_ enabled: Bool) {
+        if self.batchingEnabled == enabled { return }
+        guard let newFlowHandler = self.connectionNewFlowHandler else { return }
+
+        self.batchingEnabled = enabled
+        newFlowHandler.outboundBatching(enabled)
+    }
+
+    internal func flushOutboundBatch(resumeBatching: Bool) {
+        self.setOutboundBatching(false)
+        if resumeBatching {
+            self.setOutboundBatching(true)
+        }
     }
 
     /// Sets the connection channel and propagates it as the parent channel for inbound streams
@@ -371,6 +393,7 @@ final class SwiftNetworkQUICConnection {
         )
 
         self.inReadLoop = false
+        self.batchingEnabled = false
         self.start(
             localEndpoint: localEndpoint,
             remoteEndpoint: remoteEndpoint,
@@ -860,7 +883,12 @@ final class SwiftNetworkQUICConnection {
     @discardableResult
     @inlinable
     func receivePacket(_ packet: NIOCore.ByteBuffer) -> Int {
-        self.inReadLoop = true
+        if !self.inReadLoop {
+            self.inReadLoop = true
+            self.batchingEnabled = true
+            self.connectionNewFlowHandler?.outboundBatching(true)
+        }
+
         var packet = packet
         log("receivePacket called with \(packet.readableBytes) bytes")
         packet.withUnsafeMutableReadableBytesWithStorageManagement2 { buffer, owner in

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -106,6 +106,9 @@ final class SwiftNetworkQUICConnection {
         guard let newFlowHandler = self.connectionNewFlowHandler else { return }
 
         self.batchingEnabled = enabled
+        // Enabling batching stops the underlying connection from producing (most) datagrams until
+        // batching is disabled again, at which point any queued outbound writes will be emitted.
+        // This allows outbound wrties to be better packed into datagrams.
         newFlowHandler.outboundBatching(enabled)
     }
 
@@ -899,8 +902,7 @@ final class SwiftNetworkQUICConnection {
     func receivePacket(_ packet: NIOCore.ByteBuffer) -> Int {
         if !self.inReadLoop {
             self.inReadLoop = true
-            self.batchingEnabled = true
-            self.connectionNewFlowHandler?.outboundBatching(true)
+            self.setOutboundBatching(true)
         }
 
         var packet = packet


### PR DESCRIPTION
Motivation:

Every flush on a stream channel flushes out all pending frames in the QUIC connection. This is suboptimal because in a read loop there may be N streams that want to write. It's significantly more efficient to write on the N frames and then flush out the connection.

SwiftNetwork just added a signal we can use to hint that outbound writes should be batched. We set this at the start of a read loop and unset it at the end which causes SwiftQUIC to flush out data.

Modifications:

- Bump version
- Wire through outbound batching events
- At the end of the read loop the connection channel now tells QUIC to consume the inbound packets, disables batching (so flushes out writes) and then reconciles state.
- If there are pending streams then batching switched back on again as the init of streams may lead to writes. These are flushed out afterwards.
- Simplification to the processing of inbound streams: it no longer returns a boolean we always flush afterwards.

Result:

Better perf