### PR TITLE
Wire up frame pool

### DIFF
--- a/Sources/NIOQUIC/GSOCoalescer.swift
+++ b/Sources/NIOQUIC/GSOCoalescer.swift
@@ -35,8 +35,12 @@ struct GSOCoalescer: ~Copyable {
     /// A pool of byte buffers.
     private var pool: BufferPool
 
+    /// A pool of `Frame`s.
+    private let framePool: FramePool
+
     init(
         remoteAddress: SocketAddress,
+        framePool: FramePool,
         maxSegments: Int = 64,
         maxCoalescedSize: Int = 65535,
         bufferPoolCapacity: Int = 8
@@ -49,6 +53,7 @@ struct GSOCoalescer: ~Copyable {
         self.frames.reserveCapacity(16)
 
         self.pool = BufferPool(capacity: bufferPoolCapacity, allocator: ByteBufferAllocator())
+        self.framePool = framePool
     }
 
     var isEmpty: Bool {
@@ -76,21 +81,11 @@ struct GSOCoalescer: ~Copyable {
     private mutating func datagram(from frame: consuming Frame) -> AddressedEnvelope<ByteBuffer> {
         let buffer: ByteBuffer
 
-        if let frameInternals = frame.takeOwnershipOfCustomFinalizerBuffer() {
-            frame.finalize(success: true)
-            buffer = ByteBuffer(
-                takingOwnershipOf: frameInternals.bufferPointer,
-                allocator: FrameMemory.allocator,
-                readerIndex: frameInternals.readerOffset,
-                writerIndex: frameInternals.writerOffset
-            )
-        } else {
-            var buf = ByteBuffer()
-            buf.reserveCapacity(frame.unclaimedLength)
-            frame.span?.withUnsafeBufferPointer { _ = buf.writeBytes($0) }
-            frame.finalize(success: true)
-            buffer = buf
-        }
+        var buf = ByteBuffer()
+        buf.reserveCapacity(frame.unclaimedLength)
+        frame.span?.withUnsafeBufferPointer { _ = buf.writeBytes($0) }
+        self.framePool.storeFrame(frame)
+        buffer = buf
 
         return AddressedEnvelope(remoteAddress: self.remoteAddress, data: buffer)
     }
@@ -144,10 +139,7 @@ struct GSOCoalescer: ~Copyable {
             let (buffer, ()) = self.pool.withBuffer(minimumCapacity: totalSize) { buffer in
                 while runLength > 0 {
                     runLength &-= 1
-
-                    var frame = frames.popFirst()!
-                    frame.span?.withUnsafeBufferPointer { _ = buffer.writeBytes($0) }
-                    frame.finalize(success: true)
+                    Self.write(self.frames.popFirst()!, to: &buffer, returningFrameTo: self.framePool)
                 }
             }
 
@@ -161,5 +153,14 @@ struct GSOCoalescer: ~Copyable {
                 )
             )
         }
+    }
+
+    private static func write(
+        _ frame: consuming Frame,
+        to buffer: inout ByteBuffer,
+        returningFrameTo pool: FramePool
+    ) {
+        frame.span?.withUnsafeBufferPointer { _ = buffer.writeBytes($0) }
+        pool.storeFrame(frame)
     }
 }

--- a/Sources/NIOQUIC/GSOCoalescer.swift
+++ b/Sources/NIOQUIC/GSOCoalescer.swift
@@ -139,7 +139,7 @@ struct GSOCoalescer: ~Copyable {
             let (buffer, ()) = self.pool.withBuffer(minimumCapacity: totalSize) { buffer in
                 while runLength > 0 {
                     runLength &-= 1
-                    Self.write(self.frames.popFirst()!, to: &buffer, returningFrameTo: self.framePool)
+                    Self.write(self.frames.removeFirst(), to: &buffer, returningFrameTo: self.framePool)
                 }
             }
 

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
@@ -48,14 +48,18 @@ final class QUICChannelOutputHandler: ProtocolInstanceContainer, OutboundDatagra
     private var inputFramesHandler: ((Int) -> FrameArray?)?
     private var finalizeOutputFramesHandler: ((consuming FrameArray) -> Void)?
 
+    private let framePool: FramePool
+
     init(
         role: Role,
         logger: Logger,
-        context: NetworkContext
+        context: NetworkContext,
+        framePool: FramePool
     ) {
         self.logPrefix = "[\(role.description)][OutputHandler]"
         self.logger = logger
         self.context = context
+        self.framePool = framePool
     }
 
     func setInputFramesHandler(inputFramesHandler: @escaping (Int) -> FrameArray?) {
@@ -177,12 +181,14 @@ extension QUICChannelOutputHandler: LowerProtocolHandler {
         maximumDatagramCount: Int,
         minimumDatagramSize: Int
     ) throws(SwiftNetwork.NetworkError) -> SwiftNetwork.FrameArray? {
-        let frameSize = min(minimumDatagramSize, self.defaultFrameSize)
-        var frameArray = FrameArray(capacity: maximumDatagramCount)
+        var array = FrameArray(capacity: maximumDatagramCount)
+
         for _ in 0..<maximumDatagramCount {
-            frameArray.add(frame: Frame(allocatingCustomFinalizerBufferOfSize: frameSize))
+            let frame = self.framePool.takeOrCreateFrame(minimumSize: minimumDatagramSize)
+            array.add(frame: frame)
         }
-        return frameArray
+
+        return array
     }
 
     // Sends the datagram frames out to the SwiftNetworkConnection object to be queued for writing in writeOutboundData

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -108,7 +108,8 @@ final class SwiftNetworkQUICConnection {
         self.batchingEnabled = enabled
         // Enabling batching stops the underlying connection from producing (most) datagrams until
         // batching is disabled again, at which point any queued outbound writes will be emitted.
-        // This allows outbound writes to be better packed into datagrams.
+        // This allows outbound writes to be better packed into datagrams. Any outbound writes are
+        // emitted into `outputHandlerFinalizeOutputFrames` soon after batching is disabled.
         newFlowHandler.outboundBatching(enabled)
     }
 
@@ -332,13 +333,16 @@ final class SwiftNetworkQUICConnection {
         self.swiftNetworkQUICConnection = swiftNetworkQUICConnection
 
         #if os(Linux)
+        let framePool = FramePool.makePool(forGSO: true)
         let maxSegments = 64
         #else
+        let framePool = FramePool.makePool(forGSO: false)
         let maxSegments = 1
         #endif
 
         self.coalescer = GSOCoalescer(
             remoteAddress: remoteAddress,
+            framePool: framePool,
             maxSegments: maxSegments
         )
 
@@ -406,7 +410,8 @@ final class SwiftNetworkQUICConnection {
         self.outputHandler = QUICChannelOutputHandler(
             role: self.role,
             logger: logger,
-            context: swiftNetworkParameters.context
+            context: swiftNetworkParameters.context,
+            framePool: framePool
         )
 
         self.inReadLoop = false

--- a/Tests/NIOQUICTests/GSOCoalescerTests.swift
+++ b/Tests/NIOQUICTests/GSOCoalescerTests.swift
@@ -28,6 +28,7 @@ struct GSOCoalescerTests {
     ) -> GSOCoalescer {
         GSOCoalescer(
             remoteAddress: Self.peer,
+            framePool: .makePool(forGSO: false),
             maxSegments: maxSegments,
             maxCoalescedSize: maxCoalescedSize
         )
@@ -200,7 +201,11 @@ struct GSOCoalescerTests {
     @available(anyAppleOS 26, *)
     @Test
     func maxSegmentsOfOneNeverCoalesces() {
-        var coalescer = GSOCoalescer(remoteAddress: Self.peer, maxSegments: 1)
+        var coalescer = GSOCoalescer(
+            remoteAddress: Self.peer,
+            framePool: .makePool(forGSO: false),
+            maxSegments: 1
+        )
         coalescer.append(frames: self.frames([1200, 1200, 1200]))
 
         let runs = self.drain(&coalescer)


### PR DESCRIPTION
Motivation:

The output handler creates frames to pass into SwiftNetwork, and the GSOCoalescer consumes those frames. Instead of throwing them on the floor we can pool them in a FramePool.

Modifications:

- Wire up the frame pool

Result:

Fewer allocations