### PR TITLE
Various fixes

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel+Lifecycle.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel+Lifecycle.swift
@@ -129,7 +129,9 @@ extension QUICConnectionChannel {
         mutating func beginClosing(error: (any Error)?) -> OnBeginClosing {
             switch self.state {
             case .idle, .initializing, .initialized, .activated:
-                self.pending.close = error.map { .withError($0) } ?? .cleanly
+                if self.pending.close == nil {
+                    self.pending.close = error.map { .withError($0) } ?? .cleanly
+                }
                 self.state = .closing(inactiveFired: false)
                 return .beganClosing
             case .closing:
@@ -196,7 +198,9 @@ extension QUICConnectionChannel {
 
         /// The connection closed spontaneously. Call ``reconcile()`` to apply the state change.
         mutating func connectionClosed(error: (any Error)?) {
-            self.pending.close = error.map { .withError($0) } ?? .cleanly
+            if self.pending.close == nil {
+                self.pending.close = error.map { .withError($0) } ?? .cleanly
+            }
         }
 
         // MARK: Streams

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -718,7 +718,7 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     /// advancing its flow control window, defeating backpressure and letting unbounded bytes accumulate here.
     private func deliverInboundDataDownstreamIfDemand() {
         // Only continue if there is a pending read.
-        guard self.pendingRead && !self.isClosed else {
+        guard self.pendingRead else {
             return
         }
 

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -692,7 +692,8 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
             break
         }
 
-        self._close(error: error, promise: nil)
+        let quicError = error.flatMap { QUICConnectionError(networkError: $0) }
+        self._close(error: quicError ?? error, promise: nil)
     }
 
     @inline(__always)
@@ -1548,5 +1549,25 @@ extension QUICChannelStreamHandler {
     internal func _testOnly_appendToBufferedReadData(_ buffer: ByteBuffer) {
         self.eventLoop.preconditionInEventLoop()
         self.bufferedReadData.writeImmutableBuffer(buffer)
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICConnectionError {
+    init?(networkError error: NetworkError) {
+        let errorCode: UInt64
+        let isApplication: Bool
+
+        if let code = error.quicApplicationError {
+            errorCode = UInt64(code)
+            isApplication = true
+        } else if let code = error.quicTransportError {
+            errorCode = UInt64(code)
+            isApplication = false
+        } else {
+            return nil
+        }
+
+        self.init(reason: String(describing: error), isApplication: isApplication, code: errorCode)
     }
 }

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1098,7 +1098,7 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
                 self.closeStream(mode: .disconnectOnly, error: nil, promise: nil)
             }
 
-        case .closeRead(let streamFullyClosed):
+        case .closeRead(let streamFullyClosed, let deliverEndOfStream):
             // Send STOP_SENDING so no more data is received from the peer.
             // Per RFC 9000 §3.4, send and receive are independent state machines,
             // so we always use the graceful path regardless of the write side's state.
@@ -1106,12 +1106,18 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
                 "shutdownStream shutting down read, applicationErrorCode: \(String(describing: applicationErrorCode))"
             )
             self.abortInbound(error: NetworkError(quicApplicationError: applicationErrorCode?.rawValue ?? 0))
+            if deliverEndOfStream {
+                self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
+            }
             if streamFullyClosed {
                 self.closeStream(mode: .disconnectOnly, error: nil, promise: nil)
             }
 
-        case .readAlreadyClosed:
+        case .readAlreadyClosed(let deliverEndOfStream):
             self.log("shutdownStream read side already closed")
+            if deliverEndOfStream {
+                self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
+            }
 
         case .readPeerReset:
             self.log("shutdownStream read side already reset by peer")

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1425,19 +1425,17 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
                 return
             }
         case .input:
-            switch self.streamStateMachine.completeRead() {
-            case .nothingToReport:
-                // `shutdownStream` handles the QUIC-level signaling as needed,
-                // e.g. STOP_SENDING for `.read`, RESET_STREAM for `.write`.
-                self.shutdownStream(direction: .read, applicationErrorCode: nil)
-                if self.streamStateMachine.isWriteClosed {
-                    self.log("Input and output for stream are now closed, stream will be queued up for closure")
-                }
-                promise?.succeed()
-            default:
+            if self.streamStateMachine.isReceiveClosed {
                 promise?.fail(ChannelError.inputClosed)
                 return
             }
+            // `shutdownStream` handles the QUIC-level signaling as needed,
+            // e.g. STOP_SENDING for `.read`, RESET_STREAM for `.write`.
+            self.shutdownStream(direction: .read, applicationErrorCode: nil)
+            if self.streamStateMachine.isWriteClosed {
+                self.log("Input and output for stream are now closed, stream will be queued up for closure")
+            }
+            promise?.succeed()
         case .all:
             // Gracefully shutdown both sides.
             if self.streamID != nil {
@@ -1454,13 +1452,8 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
                     shutdownWrite = true
                 }
 
-                if shutdownRead {
-                    switch self.streamStateMachine.completeRead() {
-                    case .nothingToReport:
-                        self.shutdownStream(direction: .read, applicationErrorCode: nil)
-                    default:
-                        break
-                    }
+                if shutdownRead, !self.streamStateMachine.isReceiveClosed {
+                    self.shutdownStream(direction: .read, applicationErrorCode: nil)
                 }
 
                 if shutdownWrite, self.streamStateMachine.canWrite {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1366,6 +1366,8 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
         // its close promise must still be completed.
         let wasActive = self._isActive.exchange(false, ordering: .sequentiallyConsistent)
 
+        promise?.succeed()
+
         if let error {
             self.pipeline.fireErrorCaught(error)
         }
@@ -1379,7 +1381,6 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
         self.eventLoop.assumeIsolated().execute {
             self.removeHandlers(pipeline: self.pipeline)
             self._closePromise.succeed(())
-            promise?.succeed()
             // Fire disconnect if there is no error present
             if let disconnect = self.disconnectedEventHandler {
                 disconnect(nil)

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -717,7 +717,7 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     /// advancing its flow control window, defeating backpressure and letting unbounded bytes accumulate here.
     private func deliverInboundDataDownstreamIfDemand() {
         // Only continue if there is a pending read.
-        guard self.pendingRead else {
+        guard self.pendingRead && !self.isClosed else {
             return
         }
 

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -294,11 +294,9 @@ struct QUICStreamStateMachine: ~Copyable {
         self.isConnected && !self.isWriteClosed
     }
 
-    // MARK: - Private Queries
-
     /// Returns `true` if the receive side is closed (terminal, reset, stream closed,
     /// or send-only direction where there is no receive side).
-    private var isReceiveClosed: Bool {
+    var isReceiveClosed: Bool {
         switch self.state {
         case .connected(let connected):
             switch connected.streamState {
@@ -317,6 +315,8 @@ struct QUICStreamStateMachine: ~Copyable {
             return true
         }
     }
+
+    // MARK: - Private Queries
 
     /// Returns `true` if the stream is disconnected and fully closed, indicating it needs cleanup.
     private var needsCleanup: Bool {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -601,8 +601,8 @@ struct QUICStreamStateMachine: ~Copyable {
     // MARK: - Combined atomic transitions
 
     enum CloseReadSideAction: ~Copyable {
-        case markReadClosed(streamFullyClosed: Bool)
-        case ignoreAlreadyClosed
+        case markReadClosed(streamFullyClosed: Bool, deliverEndOfStream: Bool)
+        case ignoreAlreadyClosed(deliverEndOfStream: Bool)
         case deliverPeerResetError(applicationErrorCode: QUICApplicationErrorCode)
     }
 
@@ -651,10 +651,6 @@ struct QUICStreamStateMachine: ~Copyable {
     /// Called after draining read data. Checks whether the receive side has
     /// reached a terminal condition (FIN or reset) and atomically closes it.
     mutating func completeRead() -> CompleteReadAction {
-        if self.isFullyClosed {
-            // Stream was closed (e.g. connection teardown) — signal end-of-stream.
-            return .reportFin(streamFullyClosed: true)
-        }
         switch self.consumeFinOrReset() {
         case .reportFin(let streamFullyClosed):
             return .reportFin(streamFullyClosed: streamFullyClosed)
@@ -671,10 +667,12 @@ struct QUICStreamStateMachine: ~Copyable {
         /// Shut down both directions — caller should stop and remove handler.
         case shutdownBoth
         /// Read side closed. If `streamFullyClosed`, stop and remove handler;
-        /// otherwise send STOP_SENDING via `abortInbound`.
-        case closeRead(streamFullyClosed: Bool)
-        /// Read side was already closed — no action needed.
-        case readAlreadyClosed
+        /// otherwise send STOP\_SENDING via `abortInbound`. When `deliverEndOfStream`
+        /// is set the caller must surface `ChannelEvent.inputClosed` exactly once.
+        case closeRead(streamFullyClosed: Bool, deliverEndOfStream: Bool)
+        /// Read side was already closed. `deliverEndOfStream` is set if a FIN had been
+        /// captured but never surfaced, in which case the caller must surface it now.
+        case readAlreadyClosed(deliverEndOfStream: Bool)
         /// Peer reset the stream — stop and remove handler.
         case readPeerReset
         /// Write side reset. Send RESET_STREAM via `abortOutbound` with the given code.
@@ -708,10 +706,13 @@ struct QUICStreamStateMachine: ~Copyable {
             if self.canShutdownRead {
                 do {
                     switch try self.closeReadSide() {
-                    case .markReadClosed(let streamFullyClosed):
-                        return .closeRead(streamFullyClosed: streamFullyClosed)
-                    case .ignoreAlreadyClosed:
-                        return .readAlreadyClosed
+                    case .markReadClosed(let streamFullyClosed, let deliverEndOfStream):
+                        return .closeRead(
+                            streamFullyClosed: streamFullyClosed,
+                            deliverEndOfStream: deliverEndOfStream
+                        )
+                    case .ignoreAlreadyClosed(let deliverEndOfStream):
+                        return .readAlreadyClosed(deliverEndOfStream: deliverEndOfStream)
                     case .deliverPeerResetError:
                         return .readPeerReset
                     }
@@ -1146,18 +1147,24 @@ extension QUICStreamStateMachine.State {
             let finAction = connected.streamState.withReceiveState {
                 $0.receiveFin(finalSize: 0)
             }
-            // Transition receive SM to terminal state (dataRead or resetRead).
-            // The return value is intentionally not propagated — closeReadSide
-            // uses finAction (from receiveFin) to determine the outcome.
-            connected.streamState.withReceiveState { recv in
+            // Transition receive SM to terminal state (dataRead or resetRead). The result says
+            // whether a FIN was still waiting to be surfaced: consuming it here without telling
+            // the caller loses the one `inputClosed` the pipeline is owed.
+            let endOfStream = connected.streamState.withReceiveState { recv in
                 switch recv.applicationRead() {
-                case .deliverData: break
-                case .deliverEndOfStream: break
-                case .deliverResetError: break
-                case .ignore(.noDataAvailable): break
-                case .ignore(.alreadyDelivered): break
+                case .deliverEndOfStream:
+                    return true
+                case .deliverData:
+                    return false
+                case .deliverResetError:
+                    return false
+                case .ignore(.noDataAvailable):
+                    return false
+                case .ignore(.alreadyDelivered):
+                    return false
                 }
             }
+            let deliverEndOfStream = endOfStream ?? false
 
             let resetCode = connected.streamState.withReceiveState { $0.resetErrorCode }.flatMap { $0 }
             let streamFullyClosed = connected.streamState.isFullyClosed
@@ -1165,7 +1172,7 @@ extension QUICStreamStateMachine.State {
 
             switch finAction {
             case .ignore(.alreadyReceivedFin):
-                return .ignoreAlreadyClosed
+                return .ignoreAlreadyClosed(deliverEndOfStream: deliverEndOfStream)
 
             case .ignore(.streamReset):
                 // resetCode must be non-nil if the stream was reset
@@ -1177,7 +1184,10 @@ extension QUICStreamStateMachine.State {
                 }
 
             case .markAllDataReceived:
-                return .markReadClosed(streamFullyClosed: streamFullyClosed)
+                return .markReadClosed(
+                    streamFullyClosed: streamFullyClosed,
+                    deliverEndOfStream: deliverEndOfStream
+                )
 
             case nil:
                 throw .wrongDirection

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -1258,6 +1258,12 @@ extension SwiftNetworkQUICConnection {
             } else {
                 self.logger.trace("Beginning connection draining")
             }
+            // Record the close on the channel before tearing down. Stopping a stream fires
+            // `channelInactive` on its pipeline, and a handler may react by closing the connection
+            // channel: if that lands first the channel commits to a clean close and this error is
+            // never surfaced.
+            self.channelView?.connectionClosed(error: error)
+
             // Complete draining and tear down.
             // SwiftNetwork manages the draining timeout per RFC 9000 §10.2.2 internally.
             // By the time this handler is called, the draining period is complete and
@@ -1274,8 +1280,6 @@ extension SwiftNetworkQUICConnection {
             case .notDraining:
                 self.logger.warning("Unexpected state when completing draining")
             }
-
-            self.channelView?.connectionClosed(error: error)
 
         case .completeClosing:
             self.logger.trace("Completing connection closing")

--- a/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
+++ b/Tests/NIOQUICTests/QUICChannelStreamHandlerTests.swift
@@ -649,3 +649,34 @@ extension QUICChannelStreamHandlerTests {
         }
     }
 }
+
+@Suite("NetworkError to QUIC error conversion")
+struct NetworkErrorConversionTests {
+    @available(anyAppleOS 26, *)
+    @Test
+    func applicationErrorCodeConverts() throws {
+        let error = try #require(NetworkError(quicApplicationError: UInt64(261), reason: "no headers"))
+        let converted = try #require(QUICConnectionError(networkError: error))
+        #expect(converted.isApplication)
+        #expect(converted.code == 261)
+        #expect(converted.reason == error.description)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func transportErrorCodeConverts() throws {
+        let error = try #require(NetworkError(quicTransportError: UInt64(10), reason: "protocol violation"))
+        let converted = try #require(QUICConnectionError(networkError: error))
+        #expect(!converted.isApplication)
+        #expect(converted.code == 10)
+        #expect(converted.reason == error.description)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func errorWithoutQUICCodeDoesNotConvert() {
+        // The caller keeps such errors as-is; there is no QUIC-level equivalent to convert to.
+        let converted = QUICConnectionError(networkError: .posix(ETIMEDOUT))
+        #expect(converted == nil)
+    }
+}

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -887,6 +887,69 @@ struct QUICStreamStateMachineTests {
     }
 
     @available(anyAppleOS 26, *)
+    @Test("Closing the read side surfaces end-of-stream exactly once")
+    func closeReadSideSurfacesEndOfStreamOnce() throws {
+        var sm = QUICStreamStateMachine()
+        _ = sm.streamConnected(direction: .bidirectional)
+
+        // A local input close owes the pipeline one `inputClosed`.
+        switch try sm.closeReadSide() {
+        case .markReadClosed(_, let deliverEndOfStream):
+            #expect(deliverEndOfStream)
+        case .ignoreAlreadyClosed:
+            Issue.record("expected the read side to be newly closed")
+        case .deliverPeerResetError:
+            Issue.record("expected the read side to be newly closed")
+        }
+
+        // Closing again owes nothing, and neither does any later read.
+        switch try sm.closeReadSide() {
+        case .ignoreAlreadyClosed(let deliverEndOfStream):
+            #expect(!deliverEndOfStream)
+        case .markReadClosed:
+            Issue.record("expected the read side to already be closed")
+        case .deliverPeerResetError:
+            Issue.record("expected the read side to already be closed")
+        }
+
+        switch sm.completeRead() {
+        case .nothingToReport:
+            ()
+        case .reportFin:
+            Issue.record("end-of-stream was surfaced twice")
+        case .reportPeerReset:
+            Issue.record("end-of-stream was surfaced twice")
+        }
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("Closing the read side surfaces a captured FIN which was never read")
+    func closeReadSideSurfacesUnreadFIN() throws {
+        var sm = QUICStreamStateMachine()
+        _ = sm.streamConnected(direction: .bidirectional)
+        _ = try sm.receiveFin(finalSize: 0)
+
+        // The FIN arrived but was never surfaced, so the close still owes the event.
+        switch try sm.closeReadSide() {
+        case .ignoreAlreadyClosed(let deliverEndOfStream):
+            #expect(deliverEndOfStream)
+        case .markReadClosed:
+            Issue.record("expected the FIN to already have been received")
+        case .deliverPeerResetError:
+            Issue.record("expected the FIN to already have been received")
+        }
+
+        switch sm.completeRead() {
+        case .nothingToReport:
+            ()
+        case .reportFin:
+            Issue.record("end-of-stream was surfaced twice")
+        case .reportPeerReset:
+            Issue.record("end-of-stream was surfaced twice")
+        }
+    }
+
+    @available(anyAppleOS 26, *)
     @Test("Receive operations throw wrongDirection on send-only stream")
     func receiveOnSendOnlyThrows() {
         var sm = QUICStreamStateMachine()


### PR DESCRIPTION
### Motivation

The connection channel refactor surfaced a few regression in HTTP/3. These were mostly hidden because of the stream channel not behaving as a regular NIO channel should. One of these behaviors was corrected in #66 but surfaced even more issues. This change fixes a number of small issues.

### Modifications

- Complete a user supplied close promise before firing channel inactive
- Don't swallow pending end-of-stream 
- Only record the first pending close reason 
- Avoid surfacing input closed more than once

### Result

HTTP/3 tests pass