### PR TITLE
Add a custom key-value store for QUICStreamID keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 Package.resolved
+Benchmarks/.build

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 Package.resolved
-Benchmarks/.build
+.build

--- a/Benchmarks/Benchmarks/QUICStreamIDDictionaryBenchmarks/QUICStreamIDCache.swift
+++ b/Benchmarks/Benchmarks/QUICStreamIDDictionaryBenchmarks/QUICStreamIDCache.swift
@@ -1,0 +1,1 @@
+../../../Sources/NIOQUIC/QUICStreamIDCache.swift

--- a/Benchmarks/Benchmarks/QUICStreamIDDictionaryBenchmarks/QUICStreamIDDictionary.swift
+++ b/Benchmarks/Benchmarks/QUICStreamIDDictionaryBenchmarks/QUICStreamIDDictionary.swift
@@ -1,0 +1,1 @@
+../../../Sources/NIOQUIC/QUICStreamIDDictionary.swift

--- a/Benchmarks/Benchmarks/QUICStreamIDDictionaryBenchmarks/QUICStreamIDDictionaryBenchmarks.swift
+++ b/Benchmarks/Benchmarks/QUICStreamIDDictionaryBenchmarks/QUICStreamIDDictionaryBenchmarks.swift
@@ -1,0 +1,137 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import NIOQUICHelpers
+
+private struct StreamState {}
+private final class StreamStateObject: Sendable {}
+
+private let lookupsPerStream = 8
+
+private let concurrentStreams = 64
+private let filledStreams = 4096
+
+let benchmarks: @Sendable () -> Void = {
+    Benchmark.defaultConfiguration = Benchmark.Configuration(
+        metrics: [.cpuTotal, .instructions, .mallocCountTotal],
+        timeUnits: .nanoseconds,
+        units: [.instructions: .count, .mallocCountTotal: .count],
+        scalingFactor: .kilo
+    )
+
+    Benchmark("Stream churn (value)") { benchmark in
+        streamChurn(benchmark, StreamState())
+    }
+
+    Benchmark("Stream churn (reference)") { benchmark in
+        streamChurn(benchmark, StreamStateObject())
+    }
+
+    Benchmark("Stream lookup (value)") { benchmark in
+        streamLookup(benchmark, StreamState())
+    }
+
+    Benchmark("Stream lookup (reference)") { benchmark in
+        streamLookup(benchmark, StreamStateObject())
+    }
+
+    Benchmark("Steady state stream churn (value)") { benchmark in
+        steadyStateStreamChurn(benchmark, StreamState())
+    }
+
+    Benchmark("Steady state stream churn (reference)") { benchmark in
+        steadyStateStreamChurn(benchmark, StreamStateObject())
+    }
+
+    Benchmark("Fill (value)") { benchmark in
+        fill(benchmark, StreamState())
+    }
+
+    Benchmark("Fill (reference)") { benchmark in
+        fill(benchmark, StreamStateObject())
+    }
+}
+
+private func streamChurn<Value>(_ benchmark: Benchmark, _ value: Value) {
+    var dictionary = QUICStreamIDDictionary<Value>()
+    var id = QUICStreamID(rawValue: 0)
+
+    for _ in benchmark.scaledIterations {
+        dictionary[id] = value
+        for _ in 0..<lookupsPerStream {
+            blackHole(dictionary[id])
+        }
+        blackHole(dictionary.removeValue(forID: id))
+        id = QUICStreamID(rawValue: id.rawValue &+ 4)
+    }
+}
+
+private func streamLookup<Value>(_ benchmark: Benchmark, _ value: Value) {
+    var dictionary = QUICStreamIDDictionary<Value>()
+    let ids = openStreamIDs(count: concurrentStreams)
+    for id in ids {
+        dictionary[id] = value
+    }
+
+    benchmark.startMeasurement()
+
+    for _ in benchmark.scaledIterations {
+        for id in ids {
+            blackHole(dictionary[id])
+        }
+    }
+}
+
+private func steadyStateStreamChurn<Value>(_ benchmark: Benchmark, _ value: Value) {
+    var dictionary = QUICStreamIDDictionary<Value>()
+    var ids = openStreamIDs(count: concurrentStreams)
+    for id in ids {
+        dictionary[id] = value
+    }
+
+    benchmark.startMeasurement()
+
+    var next = QUICStreamID(rawValue: UInt64(concurrentStreams) * 4)
+    var index = 0
+    for _ in benchmark.scaledIterations {
+        blackHole(dictionary.removeValue(forID: ids[index]))
+        dictionary[next] = value
+        for _ in 0..<lookupsPerStream {
+            blackHole(dictionary[next])
+        }
+
+        ids[index] = next
+        index = (index &+ 1) & (concurrentStreams - 1)
+        next = QUICStreamID(rawValue: next.rawValue &+ 4)
+    }
+}
+
+private func fill<Value>(_ benchmark: Benchmark, _ value: Value) {
+    let ids = openStreamIDs(count: filledStreams)
+
+    benchmark.startMeasurement()
+
+    for _ in benchmark.scaledIterations {
+        var dictionary = QUICStreamIDDictionary<Value>()
+        for id in ids {
+            dictionary[id] = value
+        }
+        blackHole(dictionary.count)
+    }
+}
+
+private func openStreamIDs(count: Int) -> [QUICStreamID] {
+    (0..<count).map { QUICStreamID(rawValue: UInt64($0) << 2) }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:6.3
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-nio-quic-benchmarks",
+    platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(url: "https://github.com/ordo-one/benchmark", from: "1.36.2"),
+        .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
+    ],
+    targets: [
+        .executableTarget(
+            name: "QUICStreamIDDictionaryBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "benchmark"),
+                .product(name: "NIOQUICHelpers", package: "swift-nio-quic-helpers"),
+            ],
+            path: "Benchmarks/QUICStreamIDDictionaryBenchmarks",
+            plugins: [.plugin(name: "BenchmarkPlugin", package: "benchmark")]
+        )
+    ]
+)

--- a/Sources/NIOQUIC/QUICStreamIDCache.swift
+++ b/Sources/NIOQUIC/QUICStreamIDCache.swift
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+
+/// A cache of values keyed by `QUICStreamID`. See ``QUICStreamIDDictionary``.
+///
+/// Slots are indexed by the numeric part of a stream ID (i.e. `rawValue >> 2`) modulo the capacity
+/// of the cache, which is always a power of two so that the modulo can be done by masking.
+struct QUICStreamIDCache<Value> {
+    fileprivate struct Entry {
+        var id: QUICStreamID
+        var value: Value
+    }
+
+    /// The underlying slots in the cache, `nil` means the slot is free.
+    private var slots: [Entry?]
+
+    /// A mask applied to the numeric part of a stream ID (i.e. top 62 bits) to get its slot index.
+    /// Stored rather than recomputed to avoid the `Int` to `UInt64` conversion on every lookup.
+    private var mask: UInt64
+
+    /// The value of `count` at which the cache doubles in size.
+    private var nextGrowthCount: Int
+
+    /// The utilisation threshold above which the cache will double in size.
+    private let threshold: Double
+
+    /// The number of elements currently stored in the cache.
+    private(set) var count: Int
+
+    /// The number of elements that can be stored in the cache.
+    var capacity: Int { self.slots.count }
+
+    /// Whether the cache is empty.
+    var isEmpty: Bool { self.count == 0 }
+
+    init(capacity: Int, threshold: Double) {
+        let capacity = capacity.nextPowerOfTwo
+        self.slots = Array(repeating: nil, count: capacity)
+        self.mask = UInt64(capacity - 1)
+        self.threshold = threshold
+        self.nextGrowthCount = capacity.scaled(by: threshold)
+        self.count = 0
+    }
+
+    /// Index of the slot for the given stream ID.
+    func slotIndex(of id: QUICStreamID) -> Int {
+        // Drop the type bits and then mask. The mask can be used instead of '%' as the capacity is
+        // guaranteed to be a power of two (and the mask is just `capacity - 1`).
+        Int((id.rawValue >> 2) & self.mask)
+    }
+
+    /// Returns the value for the given stream ID, if it exists in the cache.
+    subscript(id: QUICStreamID) -> Value? {
+        if let entry = self.slots[self.slotIndex(of: id)], entry.id == id {
+            return entry.value
+        } else {
+            return nil
+        }
+    }
+
+    /// Returns whether the cache contains the given stream ID.
+    func contains(_ id: QUICStreamID) -> Bool {
+        self.slots[self.slotIndex(of: id)]?.id == id
+    }
+
+    enum UpdateResult {
+        /// The value was inserted into an empty slot.
+        case inserted
+        /// The value replaced a value for the same stream ID.
+        case replaced(Value)
+        /// The value was inserted but evicted a value for a different stream ID.
+        case evicted(id: QUICStreamID, value: Value)
+    }
+
+    /// Updates the value stored for the given stream ID.
+    ///
+    /// - Parameters:
+    ///   - value: The value to store.
+    ///   - id: The ID of the stream.
+    /// - Returns: Whether the value was inserted, replaced an existed value, or evicted a value
+    ///   for another stream.
+    @discardableResult
+    mutating func updateValue(_ value: Value, forID id: QUICStreamID) -> UpdateResult {
+        let index = self.slotIndex(of: id)
+
+        var entry: Entry? = Entry(id: id, value: value)
+        swap(&self.slots[index], &entry)
+
+        switch entry {
+        case .none:
+            self.count &+= 1
+            self.doubleCapacityIfNeeded()
+            return .inserted
+
+        case .some(let previous):
+            if previous.id == id {
+                return .replaced(previous.value)
+            } else {
+                return .evicted(id: previous.id, value: previous.value)
+            }
+        }
+    }
+
+    /// Removes the value associated with the given ID, if one exists.
+    @discardableResult
+    mutating func removeValue(forID id: QUICStreamID) -> Value? {
+        let index = self.slotIndex(of: id)
+
+        var entry: Entry? = nil
+        swap(&entry, &self.slots[index])
+
+        switch entry {
+        case .some(let entry) where entry.id == id:
+            self.count &-= 1
+            return entry.value
+
+        case .some:
+            // Different ID, put back the entry.
+            swap(&entry, &self.slots[index])
+            return nil
+
+        case .none:
+            return nil
+        }
+    }
+
+    /// Remove all values in the cache.
+    mutating func removeAll() {
+        if self.isEmpty { return }
+
+        self.count = 0
+        for index in self.slots.indices {
+            self.slots[index] = nil
+        }
+    }
+
+    private mutating func doubleCapacityIfNeeded() {
+        if self.count < self.nextGrowthCount { return }
+
+        // Compute the new capacity, mask and growth count.
+        let oldCapacity = self.capacity
+        let capacity = oldCapacity * 2
+        self.mask = UInt64(capacity - 1)
+        self.nextGrowthCount = capacity.scaled(by: self.threshold)
+
+        // Add the new empty slots.
+        self.slots.append(contentsOf: repeatElement(nil, count: oldCapacity))
+
+        // Doubling capacity effectively splits each slot into two. One slots maintains its place
+        // and the other entry either moves by `oldCapacity` slots. This is determined by the bit
+        // for the `oldCapacity` (only one bit, because it was a power of two). All of the new slots
+        // are vacant.
+        let bit = UInt64(oldCapacity)
+        for index in 0..<oldCapacity {
+            switch self.slots[index] {
+            case .some(let entry):
+                if (entry.id.rawValue >> 2) & bit != 0 {
+                    self.slots.swapAt(index, index | oldCapacity)
+                }
+            case .none:
+                ()
+            }
+        }
+    }
+}
+
+extension QUICStreamIDCache: Sequence {
+    typealias Element = (QUICStreamID, Value)
+
+    func makeIterator() -> Iterator {
+        Iterator(iterator: self.slots.makeIterator())
+    }
+
+    struct Iterator: IteratorProtocol {
+        private var iterator: [QUICStreamIDCache<Value>.Entry?].Iterator
+
+        fileprivate init(iterator: [QUICStreamIDCache<Value>.Entry?].Iterator) {
+            self.iterator = iterator
+        }
+
+        mutating func next() -> (QUICStreamID, Value)? {
+            while let entry = self.iterator.next() {
+                if let entry {
+                    return (entry.id, entry.value)
+                }
+            }
+            return nil
+        }
+    }
+}
+
+extension Int {
+    fileprivate var nextPowerOfTwo: Int {
+        precondition(self > 0)
+        if self.nonzeroBitCount == 1 {
+            return self
+        } else {
+            return 1 << (Int.bitWidth - self.leadingZeroBitCount)
+        }
+    }
+
+    fileprivate func scaled(by factor: Double) -> Int {
+        let scaled = (Double(self) * factor).rounded(.up)
+        return Swift.max(1, Int(scaled))
+    }
+}

--- a/Sources/NIOQUIC/QUICStreamIDCache.swift
+++ b/Sources/NIOQUIC/QUICStreamIDCache.swift
@@ -47,7 +47,7 @@ struct QUICStreamIDCache<Value> {
     var isEmpty: Bool { self.count == 0 }
 
     init(capacity: Int, threshold: Double) {
-        precondition((0.0 ... 1.0).contains(threshold))
+        precondition((0.0...1.0).contains(threshold))
         let capacity = capacity.nextPowerOfTwo
         self.slots = Array(repeating: nil, count: capacity)
         self.mask = UInt64(capacity - 1)

--- a/Sources/NIOQUIC/QUICStreamIDCache.swift
+++ b/Sources/NIOQUIC/QUICStreamIDCache.swift
@@ -47,6 +47,7 @@ struct QUICStreamIDCache<Value> {
     var isEmpty: Bool { self.count == 0 }
 
     init(capacity: Int, threshold: Double) {
+        precondition((0.0 ... 1.0).contains(threshold))
         let capacity = capacity.nextPowerOfTwo
         self.slots = Array(repeating: nil, count: capacity)
         self.mask = UInt64(capacity - 1)

--- a/Sources/NIOQUIC/QUICStreamIDDictionary.swift
+++ b/Sources/NIOQUIC/QUICStreamIDDictionary.swift
@@ -43,10 +43,10 @@ struct QUICStreamIDDictionary<Value> {
     /// Returns the number of elements in the dictionary.
     var count: Int {
         var total = self.overflow.count
-        total &+= self.caches[0].count
-        total &+= self.caches[1].count
-        total &+= self.caches[2].count
-        total &+= self.caches[3].count
+        total += self.caches[0].count
+        total += self.caches[1].count
+        total += self.caches[2].count
+        total += self.caches[3].count
         return total
     }
 

--- a/Sources/NIOQUIC/QUICStreamIDDictionary.swift
+++ b/Sources/NIOQUIC/QUICStreamIDDictionary.swift
@@ -1,0 +1,234 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+
+/// A specialized dictionary where QUIC stream IDs are used as keys.
+///
+/// The dictionary takes advantage of the layout of stream IDs and how they are used in a QUIC
+/// connection to provide significantly faster operations than a regular dictionary keyed by stream
+/// ID by avoiding hashing in the majority of cases.
+///
+/// It works by maintaining a cache per stream type which is indexed by the stream ID's numeric bytes
+/// (i.e. `rawStreamID >> 2`) modulo the capacity of the cache at the time. Any collisions (in other
+/// words, long-lived streams) get evicted and stored into an overflow dictionary (a regular
+/// dictionary). Each cache is separately sized and doubles in capacity when its load factor (ratio
+/// of occupied slots to capacity) exceeds a threshold. This is naturally bounded by the connections
+/// limit on concurrent streams.
+@available(anyAppleOS 26, *)
+struct QUICStreamIDDictionary<Value> {
+    /// An overflow dictionary for when a value is evicted from a cache.
+    private var overflow: [QUICStreamID: Value]
+
+    /// Caches keyed by the "type bits" of a QUIC stream ID (i.e. `rawValue & 0b11`).
+    private var caches: InlineArray<4, QUICStreamIDCache<Value>>
+
+    /// Returns the cache index to use for a given stream ID.
+    private func cacheIndex(of id: QUICStreamID) -> Int {
+        // Bottom two bits are the type bits.
+        Int(id.rawValue & 0b11)
+    }
+
+    /// Returns the number of elements in the dictionary.
+    var count: Int {
+        var total = self.overflow.count
+        total &+= self.caches[0].count
+        total &+= self.caches[1].count
+        total &+= self.caches[2].count
+        total &+= self.caches[3].count
+        return total
+    }
+
+    /// Returns whether the dictionary is empty.
+    var isEmpty: Bool {
+        self.count == 0
+    }
+
+    /// Create a new dictionary keyed by QUIC stream IDs.
+    ///
+    /// - Parameters:
+    ///   - initialCacheCapacity: The initial capacity of each cache, rounded up to the next power
+    ///     of two. Defaults to 16.
+    ///   - cacheGrowthThreshold: The utilisation threshold above which a cache will grow, defaults
+    ///     to 0.6.
+    init(initialCacheCapacity: Int = 16, cacheGrowthThreshold: Double = 0.6) {
+        self.caches = [
+            QUICStreamIDCache(capacity: initialCacheCapacity, threshold: cacheGrowthThreshold),
+            QUICStreamIDCache(capacity: initialCacheCapacity, threshold: cacheGrowthThreshold),
+            QUICStreamIDCache(capacity: initialCacheCapacity, threshold: cacheGrowthThreshold),
+            QUICStreamIDCache(capacity: initialCacheCapacity, threshold: cacheGrowthThreshold),
+        ]
+        self.overflow = [:]
+    }
+
+    /// Returns whether the dictionary contains a value for the given stream ID.
+    func contains(_ id: QUICStreamID) -> Bool {
+        if self.caches[self.cacheIndex(of: id)].contains(id) {
+            return true
+        } else {
+            return self.overflowIndex(of: id) != nil
+        }
+    }
+
+    /// Returns or updates the value associated with a given ID.
+    subscript(id: QUICStreamID) -> Value? {
+        get {
+            if let value = self.caches[self.cacheIndex(of: id)][id] {
+                return value
+            } else if let index = self.overflowIndex(of: id) {
+                return self.overflow.values[index]
+            } else {
+                return nil
+            }
+        }
+        set {
+            if let newValue {
+                self.updateValue(newValue, forID: id)
+            } else {
+                self.removeValue(forID: id)
+            }
+        }
+    }
+
+    /// Updates the value for a given ID, returning the previously set value.
+    ///
+    /// - Parameters:
+    ///   - value: The new value.
+    ///   - id: The stream ID to update.
+    /// - Returns: The value previously set for the given ID.
+    @discardableResult
+    mutating func updateValue(_ value: Value, forID id: QUICStreamID) -> Value? {
+        let previous: Value?
+
+        if self.overflow.isEmpty {
+            // Fast-path: no-overflow values.
+            previous = self.insert(value, forID: id)
+        } else if let index = self.overflow.index(forKey: id) {
+            // Value was in the overflow storage.
+            previous = self.overflow.values[index]
+            self.overflow.values[index] = value
+        } else {
+            // Value wasn't in overflow.
+            previous = self.insert(value, forID: id)
+        }
+
+        return previous
+    }
+
+    /// Removes the value associated with the given ID.
+    @discardableResult
+    mutating func removeValue(forID id: QUICStreamID) -> Value? {
+        if let removed = self.caches[self.cacheIndex(of: id)].removeValue(forID: id) {
+            return removed
+        } else if self.overflow.isEmpty {
+            return nil
+        } else {
+            return self.overflow.removeValue(forKey: id)
+        }
+    }
+
+    /// Insert a value to the cache, moving evicted values into the cachee
+    private mutating func insert(_ value: Value, forID id: QUICStreamID) -> Value? {
+        switch self.caches[self.cacheIndex(of: id)].updateValue(value, forID: id) {
+        case .replaced(let previous):
+            return previous
+        case .inserted:
+            return nil
+        case .evicted(let evictedID, let evictedValue):
+            self.overflow[evictedID] = evictedValue
+            return nil
+        }
+    }
+
+    /// Returns whether the given ID is held in a cache rather than the overflow dictionary.
+    func _testOnly_isCached(_ id: QUICStreamID) -> Bool {
+        self.caches[self.cacheIndex(of: id)].contains(id)
+    }
+
+    /// Removes all values.
+    mutating func removeAll() {
+        for index in self.caches.indices {
+            self.caches[index].removeAll()
+        }
+        self.overflow.removeAll()
+    }
+
+    private func overflowIndex(of id: QUICStreamID) -> Dictionary<QUICStreamID, Value>.Index? {
+        self.overflow.isEmpty ? nil : self.overflow.index(forKey: id)
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICStreamIDDictionary: Sequence {
+    typealias Element = (QUICStreamID, Value)
+
+    func makeIterator() -> Iterator {
+        Iterator(storage: self)
+    }
+
+    struct Iterator: IteratorProtocol {
+        private let storage: QUICStreamIDDictionary<Value>
+        private var state: State
+
+        private enum State {
+            case iteratingCache(Int, QUICStreamIDCache<Value>.Iterator)
+            case iteratingOverflow([QUICStreamID: Value].Iterator)
+            case finished
+        }
+
+        fileprivate init(storage: QUICStreamIDDictionary<Value>) {
+            let index = storage.caches.startIndex
+            self.state = .iteratingCache(index, storage.caches[index].makeIterator())
+            self.storage = storage
+        }
+
+        mutating func next() -> (QUICStreamID, Value)? {
+            while true {
+                switch self.state {
+                case .iteratingCache(let index, var iterator):
+                    self.state = .finished
+
+                    if let value = iterator.next() {
+                        self.state = .iteratingCache(index, iterator)
+                        return value
+                    } else {
+                        let nextIndex = self.storage.caches.index(after: index)
+
+                        if nextIndex == self.storage.caches.endIndex {
+                            // Move on the overflow dictionary.
+                            self.state = .iteratingOverflow(self.storage.overflow.makeIterator())
+                        } else {
+                            // Next cache.
+                            let nextIterator = self.storage.caches[nextIndex].makeIterator()
+                            self.state = .iteratingCache(nextIndex, nextIterator)
+                        }
+                    }
+
+                case .iteratingOverflow(var iterator):
+                    self.state = .finished
+
+                    if let value = iterator.next() {
+                        self.state = .iteratingOverflow(iterator)
+                        return value
+                    } else {
+                        self.state = .finished
+                    }
+
+                case .finished:
+                    return nil
+                }
+            }
+        }
+    }
+}

--- a/Sources/NIOQUIC/QUICStreamIDDictionary.swift
+++ b/Sources/NIOQUIC/QUICStreamIDDictionary.swift
@@ -22,17 +22,45 @@ import NIOQUICHelpers
 ///
 /// It works by maintaining a cache per stream type which is indexed by the stream ID's numeric bytes
 /// (i.e. `rawStreamID >> 2`) modulo the capacity of the cache at the time. Any collisions (in other
-/// words, long-lived streams) get evicted and stored into an overflow dictionary (a regular
-/// dictionary). Each cache is separately sized and doubles in capacity when its load factor (ratio
-/// of occupied slots to capacity) exceeds a threshold. This is naturally bounded by the connections
-/// limit on concurrent streams.
+/// words, long-lived streams) get evicted and stored into overflow storage.
+///
+/// Each cache is separately sized and doubles in capacity when its load factor (ratio of occupied
+/// slots to capacity) exceeds a threshold. This is naturally bounded by the connection's limit on
+/// concurrent streams.
+///
+/// Overflow storage has two tiers: when there are no more than 32 elements in overflow storage an
+/// array is used and a linear scan is used to find the appropriate element. For 33 elements and
+/// above a regular dictionary is used. Only one storage tier is used at any one time.
 @available(anyAppleOS 26, *)
 struct QUICStreamIDDictionary<Value> {
-    /// An overflow dictionary for when a value is evicted from a cache.
-    private var overflow: [QUICStreamID: Value]
-
     /// Caches keyed by the "type bits" of a QUIC stream ID (i.e. `rawValue & 0b11`).
     private var caches: InlineArray<4, QUICStreamIDCache<Value>>
+
+    private struct OverflowEntry {
+        var id: QUICStreamID
+        var value: Value
+    }
+
+    /// Array of overflow values. Used when the number of overflow values is low.
+    ///
+    /// Values are moved to the overflow dictionary when `overflowArrayCapacity` are stored. The
+    /// order of elements has no semantic meaning.
+    ///
+    /// Note: Empty when `overflowDictionary` is non-empty.
+    private var overflowArray: [OverflowEntry]
+
+    /// Dictionary of overflow values.
+    ///
+    /// Note: Empty when `overflowArray` is non-empty.
+    private var overflowDictionary: [QUICStreamID: Value]
+
+    /// Number of items in overflow storage.
+    ///
+    /// Avoids loading a value from the array/dictionary's heap storage on the hot-path.
+    private var overflowCount: Int
+
+    /// The number of values held in `overflowArray` before switching to `overflowDictionary`.
+    private static var overflowArrayCapacity: Int { 32 }
 
     /// Returns the cache index to use for a given stream ID.
     private func cacheIndex(of id: QUICStreamID) -> Int {
@@ -42,7 +70,7 @@ struct QUICStreamIDDictionary<Value> {
 
     /// Returns the number of elements in the dictionary.
     var count: Int {
-        var total = self.overflow.count
+        var total = self.overflowCount
         total += self.caches[0].count
         total += self.caches[1].count
         total += self.caches[2].count
@@ -69,7 +97,9 @@ struct QUICStreamIDDictionary<Value> {
             QUICStreamIDCache(capacity: initialCacheCapacity, threshold: cacheGrowthThreshold),
             QUICStreamIDCache(capacity: initialCacheCapacity, threshold: cacheGrowthThreshold),
         ]
-        self.overflow = [:]
+        self.overflowArray = []
+        self.overflowDictionary = [:]
+        self.overflowCount = 0
     }
 
     /// Returns whether the dictionary contains a value for the given stream ID.
@@ -86,8 +116,8 @@ struct QUICStreamIDDictionary<Value> {
         get {
             if let value = self.caches[self.cacheIndex(of: id)][id] {
                 return value
-            } else if let index = self.overflowIndex(of: id) {
-                return self.overflow.values[index]
+            } else if let position = self.overflowIndex(of: id) {
+                return self.overflowValue(at: position)
             } else {
                 return nil
             }
@@ -111,13 +141,13 @@ struct QUICStreamIDDictionary<Value> {
     mutating func updateValue(_ value: Value, forID id: QUICStreamID) -> Value? {
         let previous: Value?
 
-        if self.overflow.isEmpty {
+        if self.overflowCount == 0 {
             // Fast-path: no-overflow values.
             previous = self.insert(value, forID: id)
-        } else if let index = self.overflow.index(forKey: id) {
+        } else if let position = self.overflowIndex(of: id) {
             // Value was in the overflow storage.
-            previous = self.overflow.values[index]
-            self.overflow.values[index] = value
+            previous = self.overflowValue(at: position)
+            self.setOverflowValue(value, at: position)
         } else {
             // Value wasn't in overflow.
             previous = self.insert(value, forID: id)
@@ -131,14 +161,14 @@ struct QUICStreamIDDictionary<Value> {
     mutating func removeValue(forID id: QUICStreamID) -> Value? {
         if let removed = self.caches[self.cacheIndex(of: id)].removeValue(forID: id) {
             return removed
-        } else if self.overflow.isEmpty {
+        } else if self.overflowCount == 0 {
             return nil
         } else {
-            return self.overflow.removeValue(forKey: id)
+            return self.removeOverflowValue(forID: id)
         }
     }
 
-    /// Insert a value to the cache, moving evicted values into the cachee
+    /// Insert a value to the cache, moving evicted values into the overflow storage.
     private mutating func insert(_ value: Value, forID id: QUICStreamID) -> Value? {
         switch self.caches[self.cacheIndex(of: id)].updateValue(value, forID: id) {
         case .replaced(let previous):
@@ -146,14 +176,24 @@ struct QUICStreamIDDictionary<Value> {
         case .inserted:
             return nil
         case .evicted(let evictedID, let evictedValue):
-            self.overflow[evictedID] = evictedValue
+            self.insertOverflow(evictedValue, forID: evictedID)
             return nil
         }
     }
 
-    /// Returns whether the given ID is held in a cache rather than the overflow dictionary.
+    /// Returns whether the given ID is held in a cache rather than the overflow storage.
     func _testOnly_isCached(_ id: QUICStreamID) -> Bool {
         self.caches[self.cacheIndex(of: id)].contains(id)
+    }
+
+    /// Returns whether the given ID is held in the linearly scanned part of the overflow storage.
+    func _testOnly_isInOverflowArray(_ id: QUICStreamID) -> Bool {
+        switch self.overflowIndex(of: id) {
+        case .array:
+            return true
+        case .dictionary, .none:
+            return false
+        }
     }
 
     /// Removes all values.
@@ -161,11 +201,102 @@ struct QUICStreamIDDictionary<Value> {
         for index in self.caches.indices {
             self.caches[index].removeAll()
         }
-        self.overflow.removeAll()
+        self.overflowArray.removeAll(keepingCapacity: true)
+        self.overflowDictionary.removeAll()
+        self.overflowCount = 0
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICStreamIDDictionary {
+    fileprivate enum OverflowIndex {
+        case array(Int)
+        case dictionary(Dictionary<QUICStreamID, Value>.Index)
     }
 
-    private func overflowIndex(of id: QUICStreamID) -> Dictionary<QUICStreamID, Value>.Index? {
-        self.overflow.isEmpty ? nil : self.overflow.index(forKey: id)
+    @inline(__always)
+    private func overflowIndex(of id: QUICStreamID) -> OverflowIndex? {
+        if self.overflowDictionary.isEmpty {
+            for index in self.overflowArray.indices {
+                if self.overflowArray[index].id == id {
+                    return .array(index)
+                }
+            }
+            return nil
+        } else if let index = self.overflowDictionary.index(forKey: id) {
+            return .dictionary(index)
+        } else {
+            return nil
+        }
+    }
+
+    @inline(__always)
+    private func overflowValue(at position: OverflowIndex) -> Value {
+        switch position {
+        case .array(let index):
+            return self.overflowArray[index].value
+        case .dictionary(let index):
+            return self.overflowDictionary.values[index]
+        }
+    }
+
+    @inline(never)
+    private mutating func setOverflowValue(_ value: Value, at position: OverflowIndex) {
+        switch position {
+        case .array(let index):
+            self.overflowArray[index].value = value
+        case .dictionary(let index):
+            self.overflowDictionary.values[index] = value
+        }
+    }
+
+    @inline(never)
+    private mutating func insertOverflow(_ value: Value, forID id: QUICStreamID) {
+        if self.overflowDictionary.isEmpty {
+            if self.overflowArray.count < Self.overflowArrayCapacity {
+                if self.overflowArray.isEmpty {
+                    self.overflowArray.reserveCapacity(Self.overflowArrayCapacity)
+                }
+                self.overflowArray.append(OverflowEntry(id: id, value: value))
+            } else {
+                self.switchOverflowToDictionary(inserting: value, forID: id)
+            }
+        } else {
+            self.overflowDictionary[id] = value
+        }
+        self.overflowCount &+= 1
+    }
+
+    @inline(never)
+    private mutating func switchOverflowToDictionary(
+        inserting value: Value,
+        forID id: QUICStreamID
+    ) {
+        self.overflowDictionary.reserveCapacity(self.overflowArray.count + 1)
+        for entry in self.overflowArray {
+            self.overflowDictionary[entry.id] = entry.value
+        }
+        self.overflowDictionary[id] = value
+        self.overflowArray.removeAll(keepingCapacity: true)
+    }
+
+    @inline(never)
+    private mutating func removeOverflowValue(forID id: QUICStreamID) -> Value? {
+        switch self.overflowIndex(of: id) {
+        case .array(let index):
+            self.overflowCount &-= 1
+            // Order has no meaning: swap with the final element to make removal O(1).
+            let lastIndex = self.overflowArray.index(before: self.overflowArray.endIndex)
+            self.overflowArray.swapAt(index, lastIndex)
+            return self.overflowArray.removeLast().value
+
+        case .dictionary(let index):
+            self.overflowCount &-= 1
+            return self.overflowDictionary.remove(at: index).value
+
+        case .none:
+            return nil
+        }
     }
 }
 
@@ -183,7 +314,8 @@ extension QUICStreamIDDictionary: Sequence {
 
         private enum State {
             case iteratingCache(Int, QUICStreamIDCache<Value>.Iterator)
-            case iteratingOverflow([QUICStreamID: Value].Iterator)
+            case iteratingOverflowArray([OverflowEntry].Iterator)
+            case iteratingOverflowDictionary([QUICStreamID: Value].Iterator)
             case finished
         }
 
@@ -206,8 +338,8 @@ extension QUICStreamIDDictionary: Sequence {
                         let nextIndex = self.storage.caches.index(after: index)
 
                         if nextIndex == self.storage.caches.endIndex {
-                            // Move on the overflow dictionary.
-                            self.state = .iteratingOverflow(self.storage.overflow.makeIterator())
+                            let iterator = self.storage.overflowArray.makeIterator()
+                            self.state = .iteratingOverflowArray(iterator)
                         } else {
                             // Next cache.
                             let nextIterator = self.storage.caches[nextIndex].makeIterator()
@@ -215,11 +347,22 @@ extension QUICStreamIDDictionary: Sequence {
                         }
                     }
 
-                case .iteratingOverflow(var iterator):
+                case .iteratingOverflowArray(var iterator):
+                    self.state = .finished
+
+                    if let entry = iterator.next() {
+                        self.state = .iteratingOverflowArray(iterator)
+                        return (entry.id, entry.value)
+                    } else {
+                        let iterator = self.storage.overflowDictionary.makeIterator()
+                        self.state = .iteratingOverflowDictionary(iterator)
+                    }
+
+                case .iteratingOverflowDictionary(var iterator):
                     self.state = .finished
 
                     if let value = iterator.next() {
-                        self.state = .iteratingOverflow(iterator)
+                        self.state = .iteratingOverflowDictionary(iterator)
                         return value
                     } else {
                         self.state = .finished

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -65,7 +65,7 @@ final class SwiftNetworkQUICConnection {
     private var scidPendingDeletion: QUICConnectionID?
 
     private var connectionNewFlowHandler: QUICChannelNewFlowHandler?
-    private var streamInputHandlers: [QUICStreamID: QUICChannelStreamHandler] = [:]
+    private var streamInputHandlers = QUICStreamIDDictionary<QUICChannelStreamHandler>()
     private var pendingInitialClientStream: QUICChannelStreamHandler?
 
     /// The connection's datagram (RFC 9221) flow, attached once the handshake completes.
@@ -855,10 +855,7 @@ final class SwiftNetworkQUICConnection {
     }
 
     func removeStreamHandler(streamID: QUICStreamID) -> Bool {
-        if let _ = self.streamInputHandlers.removeValue(forKey: streamID) {
-            return true
-        }
-        return false
+        self.streamInputHandlers.removeValue(forID: streamID) != nil
     }
 
     func streamInputHandler(streamID: QUICStreamID) -> QUICChannelStreamHandler? {
@@ -869,8 +866,8 @@ final class SwiftNetworkQUICConnection {
         if streamInputHandlers.isEmpty {
             return []
         }
-        let futures = streamInputHandlers.values.map { $0.closeFuture }
-        for stream in streamInputHandlers.values {
+        let futures = streamInputHandlers.map { $0.1.closeFuture }
+        for (_, stream) in streamInputHandlers {
             stream.stop(detachFromLowerProtocol: true)
             stream.closeIfNeeded()
         }
@@ -1545,7 +1542,7 @@ extension SwiftNetworkQUICConnection: QUICConnectionProtocol {
     }
 
     func quiesceStreams() {
-        for stream in self.streamInputHandlers.values {
+        for (_, stream) in self.streamInputHandlers {
             stream.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         }
     }

--- a/Tests/NIOQUICTests/QUICStreamIDCacheTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamIDCacheTests.swift
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+import Testing
+
+@testable import NIOQUIC
+
+struct QUICStreamIDCacheTests {
+    @Test(arguments: [(1, 1), (5, 8), (16, 16), (17, 32)])
+    func capacityIsRoundedUpToPowerOfTwo(capacity: Int, rounded: Int) {
+        #expect(QUICStreamIDCache<Int>(capacity: capacity, threshold: 0.6).capacity == rounded)
+    }
+
+    @Test
+    func insertThenLookup() {
+        var cache = Self.cache(capacity: 8)
+
+        for (index, id) in Self.streamIDs(count: 8).enumerated() {
+            #expect(cache.updateValue(index, forID: id).isInserted)
+            #expect(cache.contains(id))
+            #expect(cache[id] == index)
+        }
+
+        #expect(cache.count == 8)
+    }
+
+    @Test
+    func lookupUnknownID() {
+        var cache = Self.cache(capacity: 8)
+        cache.updateValue(42, forID: QUICStreamID(rawValue: 0))
+
+        #expect(cache[QUICStreamID(rawValue: 4)] == nil)
+        #expect(!cache.contains(QUICStreamID(rawValue: 4)))
+    }
+
+    @Test
+    func insertReplacesValueForSameID() {
+        var cache = Self.cache(capacity: 8)
+        let id = QUICStreamID(rawValue: 4)
+        cache.updateValue(1, forID: id)
+
+        #expect(cache.updateValue(2, forID: id).replaced == 1)
+        #expect(cache[id] == 2)
+        #expect(cache.count == 1)
+    }
+
+    @Test
+    func insertEvictsSlotOccupant() {
+        var cache = Self.cache(capacity: 4)
+        let (first, second) = Self.collidingIDs
+        cache.updateValue(1, forID: first)
+
+        let evicted = cache.updateValue(2, forID: second).evicted
+        #expect(evicted?.id == first)
+        #expect(evicted?.value == 1)
+
+        #expect(cache[second] == 2)
+        #expect(cache[first] == nil)
+        #expect(cache.count == 1)
+    }
+
+    @Test
+    func removeValue() {
+        var cache = Self.cache(capacity: 8)
+        let id = QUICStreamID(rawValue: 8)
+        cache.updateValue(1, forID: id)
+
+        #expect(cache.removeValue(forID: id) == 1)
+        #expect(cache[id] == nil)
+        #expect(cache.isEmpty)
+        #expect(cache.removeValue(forID: id) == nil)
+    }
+
+    @Test
+    func removeValueForIDOccupyingNoSlot() {
+        var cache = Self.cache(capacity: 4)
+        let (first, second) = Self.collidingIDs
+        cache.updateValue(1, forID: first)
+
+        #expect(cache.removeValue(forID: second) == nil)
+        #expect(cache[first] == 1)
+    }
+
+    @Test
+    func growthPreservesValues() {
+        var cache = QUICStreamIDCache<Int>(capacity: 4, threshold: 0.6)
+        let ids = Self.streamIDs(count: 32)
+
+        for (index, id) in ids.enumerated() {
+            #expect(cache.updateValue(index, forID: id).isInserted, "unexpected eviction of \(id)")
+        }
+
+        #expect(cache.count == 32)
+        #expect(cache.capacity >= 32)
+
+        for (index, id) in ids.enumerated() {
+            #expect(cache[id] == index)
+        }
+    }
+
+    @Test
+    func removeAll() {
+        var cache = Self.cache(capacity: 8)
+        let ids = Self.streamIDs(count: 4)
+        for (index, id) in ids.enumerated() {
+            cache.updateValue(index, forID: id)
+        }
+
+        cache.removeAll()
+
+        #expect(cache.isEmpty)
+        for id in ids {
+            #expect(cache[id] == nil)
+        }
+    }
+
+    @Test
+    func iterator() throws {
+        var cache = Self.cache(capacity: 8)
+        let ids = Self.streamIDs(count: 4)
+        for (index, id) in ids.enumerated() {
+            cache.updateValue(index, forID: id)
+        }
+        let values = Array(cache)
+        try #require(values.count == 4)
+
+        #expect(values[0] == (ids[0], 0))
+        #expect(values[1] == (ids[1], 1))
+        #expect(values[2] == (ids[2], 2))
+        #expect(values[3] == (ids[3], 3))
+    }
+
+    /// Client-initiated bidirectional stream IDs which share a slot in a cache with four slots.
+    private static var collidingIDs: (QUICStreamID, QUICStreamID) {
+        (QUICStreamID(rawValue: 0), QUICStreamID(rawValue: 16))
+    }
+
+    private static func streamIDs(count: Int) -> [QUICStreamID] {
+        (0..<count).map { QUICStreamID(rawValue: UInt64($0) << 2) }
+    }
+
+    /// A cache which evicts on a collision rather than growing.
+    private static func cache(capacity: Int) -> QUICStreamIDCache<Int> {
+        QUICStreamIDCache(capacity: capacity, threshold: 1.0)
+    }
+}
+
+extension QUICStreamIDCache.UpdateResult {
+    fileprivate var isInserted: Bool {
+        switch self {
+        case .inserted:
+            return true
+        case .replaced, .evicted:
+            return false
+        }
+    }
+
+    fileprivate var replaced: Value? {
+        switch self {
+        case .replaced(let value):
+            return value
+        case .inserted, .evicted:
+            return nil
+        }
+    }
+
+    fileprivate var evicted: (id: QUICStreamID, value: Value)? {
+        switch self {
+        case .evicted(let id, let value):
+            return (id, value)
+        case .inserted, .replaced:
+            return nil
+        }
+    }
+}

--- a/Tests/NIOQUICTests/QUICStreamIDCacheTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamIDCacheTests.swift
@@ -23,8 +23,7 @@ struct QUICStreamIDCacheTests {
         #expect(QUICStreamIDCache<Int>(capacity: capacity, threshold: 0.6).capacity == rounded)
     }
 
-    @Test
-    func insertThenLookup() {
+    @Test func insertThenLookup() {
         var cache = Self.cache(capacity: 8)
 
         for (index, id) in Self.streamIDs(count: 8).enumerated() {
@@ -36,8 +35,7 @@ struct QUICStreamIDCacheTests {
         #expect(cache.count == 8)
     }
 
-    @Test
-    func lookupUnknownID() {
+    @Test func lookupUnknownID() {
         var cache = Self.cache(capacity: 8)
         cache.updateValue(42, forID: QUICStreamID(rawValue: 0))
 
@@ -45,8 +43,7 @@ struct QUICStreamIDCacheTests {
         #expect(!cache.contains(QUICStreamID(rawValue: 4)))
     }
 
-    @Test
-    func insertReplacesValueForSameID() {
+    @Test func insertReplacesValueForSameID() {
         var cache = Self.cache(capacity: 8)
         let id = QUICStreamID(rawValue: 4)
         cache.updateValue(1, forID: id)
@@ -56,8 +53,7 @@ struct QUICStreamIDCacheTests {
         #expect(cache.count == 1)
     }
 
-    @Test
-    func insertEvictsSlotOccupant() {
+    @Test func insertEvictsSlotOccupant() {
         var cache = Self.cache(capacity: 4)
         let (first, second) = Self.collidingIDs
         cache.updateValue(1, forID: first)
@@ -71,8 +67,7 @@ struct QUICStreamIDCacheTests {
         #expect(cache.count == 1)
     }
 
-    @Test
-    func removeValue() {
+    @Test func removeValue() {
         var cache = Self.cache(capacity: 8)
         let id = QUICStreamID(rawValue: 8)
         cache.updateValue(1, forID: id)
@@ -83,8 +78,7 @@ struct QUICStreamIDCacheTests {
         #expect(cache.removeValue(forID: id) == nil)
     }
 
-    @Test
-    func removeValueForIDOccupyingNoSlot() {
+    @Test func removeValueForIDOccupyingNoSlot() {
         var cache = Self.cache(capacity: 4)
         let (first, second) = Self.collidingIDs
         cache.updateValue(1, forID: first)
@@ -93,8 +87,7 @@ struct QUICStreamIDCacheTests {
         #expect(cache[first] == 1)
     }
 
-    @Test
-    func growthPreservesValues() {
+    @Test func growthPreservesValues() {
         var cache = QUICStreamIDCache<Int>(capacity: 4, threshold: 0.6)
         let ids = Self.streamIDs(count: 32)
 
@@ -110,8 +103,7 @@ struct QUICStreamIDCacheTests {
         }
     }
 
-    @Test
-    func removeAll() {
+    @Test func removeAll() {
         var cache = Self.cache(capacity: 8)
         let ids = Self.streamIDs(count: 4)
         for (index, id) in ids.enumerated() {
@@ -126,8 +118,7 @@ struct QUICStreamIDCacheTests {
         }
     }
 
-    @Test
-    func iterator() throws {
+    @Test func iterator() throws {
         var cache = Self.cache(capacity: 8)
         let ids = Self.streamIDs(count: 4)
         for (index, id) in ids.enumerated() {

--- a/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
@@ -219,19 +219,19 @@ struct QUICStreamIDDictionaryTests {
 
     @available(anyAppleOS 26, *)
     @Test func overflowSwitchesToDictionaryWhenArrayIsFull() {
-        var dictionary = Self.evictingDictionary(overflowArrayCapacity: 2)
-        let ids = Self.collidingIDs(4)
+        var dictionary = Self.evictingDictionary()
+        let ids = Self.collidingIDs(Self.overflowArrayCapacity + 2)
 
         for (index, id) in ids.enumerated() {
             dictionary[id] = index
         }
 
-        // Each ID evicts its predecessor: the last stays in the cache and the three before it
-        // overflow, which is one more than the array holds, so all three move to the dictionary.
-        #expect(dictionary._testOnly_isCached(ids[3]))
-        #expect(!dictionary._testOnly_isInOverflowArray(ids[2]))
-        #expect(!dictionary._testOnly_isInOverflowArray(ids[1]))
-        #expect(!dictionary._testOnly_isInOverflowArray(ids[0]))
+        // Each ID evicts its predecessor: the last stays in the cache and every other ID
+        // overflows, which is one more than the array holds, so all of them move to the dictionary.
+        #expect(dictionary._testOnly_isCached(ids.last!))
+        for id in ids.dropLast() {
+            #expect(!dictionary._testOnly_isInOverflowArray(id))
+        }
 
         for (index, id) in ids.enumerated() {
             #expect(dictionary[id] == index)
@@ -241,30 +241,36 @@ struct QUICStreamIDDictionaryTests {
 
     @available(anyAppleOS 26, *)
     @Test func overflowSwitchesBackToArrayWhenDictionaryIsEmptied() throws {
-        var dictionary = Self.evictingDictionary(overflowArrayCapacity: 2)
-        let ids = Self.collidingIDs(5)
+        var dictionary = Self.evictingDictionary()
+        // One more than is needed to spill into the overflow dictionary; the extra ID triggers a
+        // final eviction once the dictionary has been emptied.
+        let ids = Self.collidingIDs(Self.overflowArrayCapacity + 3)
+        let spilling = ids.dropLast()
 
-        for (index, id) in ids.prefix(4).enumerated() {
+        for (index, id) in spilling.enumerated() {
             dictionary[id] = index
         }
         try #require(!dictionary._testOnly_isInOverflowArray(ids[0]))
 
-        for id in ids.prefix(3) {
+        // Remove everything but the cached ID.
+        for id in spilling.dropLast() {
             #expect(dictionary.removeValue(forID: id) != nil)
         }
 
         // The dictionary is empty again, so the next evicted value goes back into the array.
-        dictionary[ids[4]] = 4
-        #expect(dictionary._testOnly_isInOverflowArray(ids[3]))
-        #expect(dictionary[ids[3]] == 3)
-        #expect(dictionary[ids[4]] == 4)
+        let cached = spilling.last!
+        let cachedValue = spilling.count - 1
+        dictionary[ids.last!] = ids.count - 1
+        #expect(dictionary._testOnly_isInOverflowArray(cached))
+        #expect(dictionary[cached] == cachedValue)
+        #expect(dictionary[ids.last!] == ids.count - 1)
         #expect(dictionary.count == 2)
     }
 
     @available(anyAppleOS 26, *)
     @Test func spilledOverflowValuesCanBeUpdatedAndRemoved() {
-        var dictionary = Self.evictingDictionary(overflowArrayCapacity: 2)
-        let ids = Self.collidingIDs(4)
+        var dictionary = Self.evictingDictionary()
+        let ids = Self.collidingIDs(Self.overflowArrayCapacity + 2)
 
         for (index, id) in ids.enumerated() {
             dictionary[id] = index
@@ -274,7 +280,7 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary[ids[2]] == 42)
         #expect(dictionary.removeValue(forID: ids[2]) == 42)
         #expect(dictionary[ids[2]] == nil)
-        #expect(dictionary.count == 3)
+        #expect(dictionary.count == ids.count - 1)
     }
 
     @available(anyAppleOS 26, *)
@@ -322,15 +328,12 @@ struct QUICStreamIDDictionaryTests {
         (0..<count).map { QUICStreamID(rawValue: UInt64($0) * 16) }
     }
 
+    /// Mirrors `QUICStreamIDDictionary.overflowArrayCapacity`, which is private.
+    private static let overflowArrayCapacity = 32
+
     /// A dictionary which evicts on a collision rather than growing its caches.
     @available(anyAppleOS 26, *)
-    private static func evictingDictionary(
-        overflowArrayCapacity: Int = 32,
-    ) -> QUICStreamIDDictionary<Int> {
-        QUICStreamIDDictionary(
-            initialCacheCapacity: 4,
-            cacheGrowthThreshold: 1.0,
-            overflowArrayCapacity: overflowArrayCapacity,
-        )
+    private static func evictingDictionary() -> QUICStreamIDDictionary<Int> {
+        QUICStreamIDDictionary(initialCacheCapacity: 4, cacheGrowthThreshold: 1.0)
     }
 }

--- a/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
@@ -218,6 +218,66 @@ struct QUICStreamIDDictionaryTests {
     }
 
     @available(anyAppleOS 26, *)
+    @Test func overflowSwitchesToDictionaryWhenArrayIsFull() {
+        var dictionary = Self.evictingDictionary(overflowArrayCapacity: 2)
+        let ids = Self.collidingIDs(4)
+
+        for (index, id) in ids.enumerated() {
+            dictionary[id] = index
+        }
+
+        // Each ID evicts its predecessor: the last stays in the cache and the three before it
+        // overflow, which is one more than the array holds, so all three move to the dictionary.
+        #expect(dictionary._testOnly_isCached(ids[3]))
+        #expect(!dictionary._testOnly_isInOverflowArray(ids[2]))
+        #expect(!dictionary._testOnly_isInOverflowArray(ids[1]))
+        #expect(!dictionary._testOnly_isInOverflowArray(ids[0]))
+
+        for (index, id) in ids.enumerated() {
+            #expect(dictionary[id] == index)
+        }
+        #expect(dictionary.count == ids.count)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test func overflowSwitchesBackToArrayWhenDictionaryIsEmptied() throws {
+        var dictionary = Self.evictingDictionary(overflowArrayCapacity: 2)
+        let ids = Self.collidingIDs(5)
+
+        for (index, id) in ids.prefix(4).enumerated() {
+            dictionary[id] = index
+        }
+        try #require(!dictionary._testOnly_isInOverflowArray(ids[0]))
+
+        for id in ids.prefix(3) {
+            #expect(dictionary.removeValue(forID: id) != nil)
+        }
+
+        // The dictionary is empty again, so the next evicted value goes back into the array.
+        dictionary[ids[4]] = 4
+        #expect(dictionary._testOnly_isInOverflowArray(ids[3]))
+        #expect(dictionary[ids[3]] == 3)
+        #expect(dictionary[ids[4]] == 4)
+        #expect(dictionary.count == 2)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test func spilledOverflowValuesCanBeUpdatedAndRemoved() {
+        var dictionary = Self.evictingDictionary(overflowArrayCapacity: 2)
+        let ids = Self.collidingIDs(4)
+
+        for (index, id) in ids.enumerated() {
+            dictionary[id] = index
+        }
+
+        #expect(dictionary.updateValue(42, forID: ids[2]) == 2)
+        #expect(dictionary[ids[2]] == 42)
+        #expect(dictionary.removeValue(forID: ids[2]) == 42)
+        #expect(dictionary[ids[2]] == nil)
+        #expect(dictionary.count == 3)
+    }
+
+    @available(anyAppleOS 26, *)
     @Test func iteratorEmpty() {
         let dictionary = QUICStreamIDDictionary<Int>()
         #expect(Array(dictionary).isEmpty)
@@ -253,12 +313,24 @@ struct QUICStreamIDDictionaryTests {
 
     /// Client-initiated bidirectional stream IDs which share a slot in a cache with four slots.
     private static var collidingIDs: (QUICStreamID, QUICStreamID) {
-        (QUICStreamID(rawValue: 0), QUICStreamID(rawValue: 16))
+        let ids = Self.collidingIDs(2)
+        return (ids[0], ids[1])
+    }
+
+    /// Client-initiated bidirectional stream IDs which share a slot in a cache with four slots.
+    private static func collidingIDs(_ count: Int) -> [QUICStreamID] {
+        (0..<count).map { QUICStreamID(rawValue: UInt64($0) * 16) }
     }
 
     /// A dictionary which evicts on a collision rather than growing its caches.
     @available(anyAppleOS 26, *)
-    private static func evictingDictionary() -> QUICStreamIDDictionary<Int> {
-        QUICStreamIDDictionary(initialCacheCapacity: 4, cacheGrowthThreshold: 1.0)
+    private static func evictingDictionary(
+        overflowArrayCapacity: Int = 32,
+    ) -> QUICStreamIDDictionary<Int> {
+        QUICStreamIDDictionary(
+            initialCacheCapacity: 4,
+            cacheGrowthThreshold: 1.0,
+            overflowArrayCapacity: overflowArrayCapacity,
+        )
     }
 }

--- a/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
@@ -1,0 +1,284 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+import Testing
+
+@testable import NIOQUIC
+
+struct QUICStreamIDDictionaryTests {
+    @Test
+    @available(anyAppleOS 26, *)
+    func empty() {
+        let dictionary = QUICStreamIDDictionary<Int>()
+        #expect(dictionary.count == 0)
+        #expect(dictionary.isEmpty)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func updateNewValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        let previous = dictionary.updateValue(42, forID: 1)
+        #expect(previous == nil)
+        #expect(dictionary.count == 1)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func updateExistingValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        dictionary.updateValue(42, forID: 1)
+        let previous = dictionary.updateValue(41, forID: 1)
+        #expect(previous == 42)
+        #expect(dictionary.count == 1)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func setNewValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        dictionary[1] = 42
+        #expect(dictionary.count == 1)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func setExistingValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        dictionary[1] = 42
+        #expect(dictionary.count == 1)
+        dictionary[1] = 41
+        #expect(dictionary.count == 1)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func setRemoveExistingValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        dictionary[1] = 42
+        #expect(dictionary.count == 1)
+        dictionary[1] = nil
+        #expect(dictionary.count == 0)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func getValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        dictionary[1] = 42
+        #expect(dictionary[1] == 42)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func removeValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        dictionary[1] = 42
+        #expect(dictionary.removeValue(forID: 0) == nil)
+        #expect(dictionary.removeValue(forID: 1) == 42)
+        #expect(dictionary.count == 0)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func removeUnknownValue() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+        #expect(dictionary.removeValue(forID: 0) == nil)
+        #expect(dictionary.count == 0)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func streamTypesHaveIndependentKeys() {
+        var dictionary = QUICStreamIDDictionary<Int>()
+
+        // The IDs share a numeric part and differ only in their type bits.
+        for typeBits in UInt64(0)..<4 {
+            dictionary[QUICStreamID(rawValue: typeBits)] = Int(typeBits)
+        }
+
+        for typeBits in UInt64(0)..<4 {
+            #expect(dictionary[QUICStreamID(rawValue: typeBits)] == Int(typeBits))
+        }
+
+        #expect(dictionary.count == 4)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func evictedValuesRemainReadable() {
+        var dictionary = Self.evictingDictionary()
+        let (evicted, evictor) = Self.collidingIDs
+
+        dictionary[evicted] = 1
+        dictionary[evictor] = 2
+
+        #expect(dictionary[evicted] == 1)
+        #expect(dictionary[evictor] == 2)
+        #expect(dictionary.contains(evicted))
+        #expect(dictionary.count == 2)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func evictedValuesAreUpdatedInPlace() {
+        var dictionary = Self.evictingDictionary()
+        let (evicted, evictor) = Self.collidingIDs
+
+        dictionary[evicted] = 1
+        dictionary[evictor] = 2
+
+        #expect(dictionary.updateValue(3, forID: evicted) == 1)
+        #expect(dictionary[evicted] == 3)
+        #expect(dictionary.count == 2)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func evictedValuesCanBeRemoved() {
+        var dictionary = Self.evictingDictionary()
+        let (evicted, evictor) = Self.collidingIDs
+
+        dictionary[evicted] = 1
+        dictionary[evictor] = 2
+
+        #expect(dictionary.removeValue(forID: evicted) == 1)
+        #expect(dictionary[evicted] == nil)
+        #expect(dictionary[evictor] == 2)
+        #expect(dictionary.count == 1)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func manyStreamsOfEachType() {
+        var dictionary = QUICStreamIDDictionary<Int>(initialCacheCapacity: 4)
+        let ids = (0..<256).map { QUICStreamID(rawValue: UInt64($0)) }
+
+        for (index, id) in ids.enumerated() {
+            dictionary[id] = index
+        }
+
+        #expect(dictionary.count == ids.count)
+        for (index, id) in ids.enumerated() {
+            #expect(dictionary[id] == index)
+        }
+
+        for id in ids {
+            dictionary.removeValue(forID: id)
+        }
+
+        #expect(dictionary.isEmpty)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func removeAll() {
+        var dictionary = Self.evictingDictionary()
+        let (evicted, evictor) = Self.collidingIDs
+        dictionary[evicted] = 1
+        dictionary[evictor] = 2
+
+        dictionary.removeAll()
+
+        #expect(dictionary.isEmpty)
+        #expect(dictionary[evicted] == nil)
+        #expect(dictionary[evictor] == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func updatingCollidingStreamsDoesNotSwapThemInAndOutOfTheCache() {
+        var dictionary = Self.evictingDictionary()
+        let (evicted, evictor) = Self.collidingIDs
+        dictionary[evicted] = 1
+        dictionary[evictor] = 2
+        #expect(dictionary._testOnly_isCached(evictor))
+        #expect(!dictionary._testOnly_isCached(evicted))
+
+        for value in 3...6 {
+            dictionary[evicted] = value
+
+            #expect(dictionary._testOnly_isCached(evictor))
+            #expect(!dictionary._testOnly_isCached(evicted))
+            #expect(dictionary[evicted] == value)
+            #expect(dictionary[evictor] == 2)
+            #expect(dictionary.count == 2)
+        }
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func evictedStreamStaysInTheOverflowDictionary() {
+        var dictionary = Self.evictingDictionary()
+        let (evicted, evictor) = Self.collidingIDs
+        dictionary[evicted] = 1
+        dictionary[evictor] = 2
+
+        dictionary.removeValue(forID: evictor)
+        #expect(dictionary.updateValue(3, forID: evicted) == 1)
+
+        #expect(!dictionary._testOnly_isCached(evicted))
+        #expect(dictionary[evicted] == 3)
+        #expect(dictionary.count == 1)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func iteratorEmpty() {
+        let dictionary = QUICStreamIDDictionary<Int>()
+        #expect(Array(dictionary).isEmpty)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func iteratorVisitsEachCache() throws {
+        var dictionary = QUICStreamIDDictionary<Int>(initialCacheCapacity: 8)
+        // Cover all stream ID types
+        let ids = (0..<16).map { QUICStreamID(rawValue: UInt64($0)) }
+        for (index, id) in ids.enumerated() {
+            dictionary[id] = index
+        }
+
+        let elements = Array(dictionary)
+        try #require(elements.count == ids.count)
+        let expected = Dictionary(uniqueKeysWithValues: zip(ids, ids.indices))
+        #expect(Dictionary(uniqueKeysWithValues: elements) == expected)
+    }
+
+    @Test
+    @available(anyAppleOS 26, *)
+    func iteratorIncludesOverflowValues() throws {
+        var dictionary = Self.evictingDictionary()
+        let (evicted, evictor) = Self.collidingIDs
+        dictionary[evicted] = 1
+        dictionary[evictor] = 2
+        try #require(!dictionary._testOnly_isCached(evicted))
+
+        let elements = Array(dictionary)
+        try #require(elements.count == 2)
+        #expect(Dictionary(uniqueKeysWithValues: elements) == [evicted: 1, evictor: 2])
+    }
+
+    /// Client-initiated bidirectional stream IDs which share a slot in a cache with four slots.
+    private static var collidingIDs: (QUICStreamID, QUICStreamID) {
+        (QUICStreamID(rawValue: 0), QUICStreamID(rawValue: 16))
+    }
+
+    /// A dictionary which evicts on a collision rather than growing its caches.
+    @available(anyAppleOS 26, *)
+    private static func evictingDictionary() -> QUICStreamIDDictionary<Int> {
+        QUICStreamIDDictionary(initialCacheCapacity: 4, cacheGrowthThreshold: 1.0)
+    }
+}

--- a/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamIDDictionaryTests.swift
@@ -18,26 +18,23 @@ import Testing
 @testable import NIOQUIC
 
 struct QUICStreamIDDictionaryTests {
-    @Test
     @available(anyAppleOS 26, *)
-    func empty() {
+    @Test func empty() {
         let dictionary = QUICStreamIDDictionary<Int>()
         #expect(dictionary.count == 0)
         #expect(dictionary.isEmpty)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func updateNewValue() {
+    @Test func updateNewValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         let previous = dictionary.updateValue(42, forID: 1)
         #expect(previous == nil)
         #expect(dictionary.count == 1)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func updateExistingValue() {
+    @Test func updateExistingValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         dictionary.updateValue(42, forID: 1)
         let previous = dictionary.updateValue(41, forID: 1)
@@ -45,17 +42,15 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 1)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func setNewValue() {
+    @Test func setNewValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         dictionary[1] = 42
         #expect(dictionary.count == 1)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func setExistingValue() {
+    @Test func setExistingValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         dictionary[1] = 42
         #expect(dictionary.count == 1)
@@ -63,9 +58,8 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 1)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func setRemoveExistingValue() {
+    @Test func setRemoveExistingValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         dictionary[1] = 42
         #expect(dictionary.count == 1)
@@ -73,17 +67,15 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 0)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func getValue() {
+    @Test func getValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         dictionary[1] = 42
         #expect(dictionary[1] == 42)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func removeValue() {
+    @Test func removeValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         dictionary[1] = 42
         #expect(dictionary.removeValue(forID: 0) == nil)
@@ -91,17 +83,15 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 0)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func removeUnknownValue() {
+    @Test func removeUnknownValue() {
         var dictionary = QUICStreamIDDictionary<Int>()
         #expect(dictionary.removeValue(forID: 0) == nil)
         #expect(dictionary.count == 0)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func streamTypesHaveIndependentKeys() {
+    @Test func streamTypesHaveIndependentKeys() {
         var dictionary = QUICStreamIDDictionary<Int>()
 
         // The IDs share a numeric part and differ only in their type bits.
@@ -116,9 +106,8 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 4)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func evictedValuesRemainReadable() {
+    @Test func evictedValuesRemainReadable() {
         var dictionary = Self.evictingDictionary()
         let (evicted, evictor) = Self.collidingIDs
 
@@ -131,9 +120,8 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 2)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func evictedValuesAreUpdatedInPlace() {
+    @Test func evictedValuesAreUpdatedInPlace() {
         var dictionary = Self.evictingDictionary()
         let (evicted, evictor) = Self.collidingIDs
 
@@ -145,9 +133,8 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 2)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func evictedValuesCanBeRemoved() {
+    @Test func evictedValuesCanBeRemoved() {
         var dictionary = Self.evictingDictionary()
         let (evicted, evictor) = Self.collidingIDs
 
@@ -160,9 +147,8 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 1)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func manyStreamsOfEachType() {
+    @Test func manyStreamsOfEachType() {
         var dictionary = QUICStreamIDDictionary<Int>(initialCacheCapacity: 4)
         let ids = (0..<256).map { QUICStreamID(rawValue: UInt64($0)) }
 
@@ -182,9 +168,8 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.isEmpty)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func removeAll() {
+    @Test func removeAll() {
         var dictionary = Self.evictingDictionary()
         let (evicted, evictor) = Self.collidingIDs
         dictionary[evicted] = 1
@@ -198,8 +183,7 @@ struct QUICStreamIDDictionaryTests {
     }
 
     @available(anyAppleOS 26, *)
-    @Test
-    func updatingCollidingStreamsDoesNotSwapThemInAndOutOfTheCache() {
+    @Test func updatingCollidingStreamsDoesNotSwapThemInAndOutOfTheCache() {
         var dictionary = Self.evictingDictionary()
         let (evicted, evictor) = Self.collidingIDs
         dictionary[evicted] = 1
@@ -218,9 +202,8 @@ struct QUICStreamIDDictionaryTests {
         }
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func evictedStreamStaysInTheOverflowDictionary() {
+    @Test func evictedStreamStaysInTheOverflowDictionary() {
         var dictionary = Self.evictingDictionary()
         let (evicted, evictor) = Self.collidingIDs
         dictionary[evicted] = 1
@@ -234,16 +217,14 @@ struct QUICStreamIDDictionaryTests {
         #expect(dictionary.count == 1)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func iteratorEmpty() {
+    @Test func iteratorEmpty() {
         let dictionary = QUICStreamIDDictionary<Int>()
         #expect(Array(dictionary).isEmpty)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func iteratorVisitsEachCache() throws {
+    @Test func iteratorVisitsEachCache() throws {
         var dictionary = QUICStreamIDDictionary<Int>(initialCacheCapacity: 8)
         // Cover all stream ID types
         let ids = (0..<16).map { QUICStreamID(rawValue: UInt64($0)) }
@@ -257,9 +238,8 @@ struct QUICStreamIDDictionaryTests {
         #expect(Dictionary(uniqueKeysWithValues: elements) == expected)
     }
 
-    @Test
     @available(anyAppleOS 26, *)
-    func iteratorIncludesOverflowValues() throws {
+    @Test func iteratorIncludesOverflowValues() throws {
         var dictionary = Self.evictingDictionary()
         let (evicted, evictor) = Self.collidingIDs
         dictionary[evicted] = 1


### PR DESCRIPTION
Motivation:

The cost of hashing stream IDs is non-trivial on the hot path. We can use our knowledge of how stream IDs are structured and used to build a faster, custom data structure.

Modifications:

Add QUICStreamIDDictionary: a key-value store which only allows QUICStreamID to be useds as a key type.

This is built on top of QUICStreamIDCache which is a dynamically resizing array of optional stream ID and value pairs. The slot index is derived from the numeric bits of the stream ID modulo the capacity of the cache. The dictionary holds four of these caches (one per stream type) and an overflow dictionary. When a collison occurs in the cache (i.e. because a stream is long lived) then the older value is evicted and moved to the overflow dictionary.

This works quite nicely because the cache tends towards the number of open streams of that type and they effectively round-robin. Checking the cache for a value is cheap: a mask to lookup which cache, and then a bit shift and mask to lookup the slot within the cache.

Result:

Better perf.