### PR TITLE
Avoid channel lifecycle changes during oob writes

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -431,14 +431,14 @@ extension QUICConnectionChannel.ConnectionView {
     }
 
     /// Notifies the connection that it should call back into the connection and drain its output
-    /// buffer.
-    func drainOutbound() {
+    /// buffer. This is used for tests.
+    func drainOutboundAndReconcileLifecycle() {
         self._channel.drainAndReconcileLifecycle()
     }
 
     /// Notifies the connection that it should call back into the connection and drain its output
     /// buffer. This is used for out-of-band writes.
-    func drainOutboundOnly() {
+    func drainOutbound() {
         self._channel.drainOutput()
     }
 

--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -437,9 +437,12 @@ extension QUICConnectionChannel.ConnectionView {
     }
 
     /// Notifies the connection that it should call back into the connection and drain its output
-    /// buffer. This is used for out-of-band writes.
+    /// buffer. Runs on the next event loop tick to avoid reentrancy. This is used for out-of-band
+    /// writes.
     func drainOutbound() {
-        self._channel.drainOutput()
+        self._channel.eventLoop.assumeIsolated().execute {
+            self._channel.drainAndReconcileLifecycle()
+        }
     }
 
     /// Notifies the connection that the handshake completed.

--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -433,7 +433,9 @@ extension QUICConnectionChannel.ConnectionView {
     /// Notifies the connection that it should call back into the connection and drain its output
     /// buffer. This is used for out-of-band writes.
     func drainOutbound() {
-        self._channel.drainAndReconcileLifecycle()
+        // When handling out-of-band write, we should only drain and not avoid
+        // firing events that might enter SwiftNetwork.
+        self._channel.drainOutput()
     }
 
     /// Notifies the connection that the handshake completed.
@@ -707,7 +709,7 @@ extension QUICConnectionChannel {
         return body()
     }
 
-    private func drainOutput() {
+    fileprivate func drainOutput() {
         self.eventLoop.assertInEventLoop()
 
         guard self._isAllowedToDrain else { return }

--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -431,10 +431,14 @@ extension QUICConnectionChannel.ConnectionView {
     }
 
     /// Notifies the connection that it should call back into the connection and drain its output
-    /// buffer. This is used for out-of-band writes.
+    /// buffer.
     func drainOutbound() {
-        // When handling out-of-band write, we should only drain and not avoid
-        // firing events that might enter SwiftNetwork.
+        self._channel.drainAndReconcileLifecycle()
+    }
+
+    /// Notifies the connection that it should call back into the connection and drain its output
+    /// buffer. This is used for out-of-band writes.
+    func drainOutboundOnly() {
         self._channel.drainOutput()
     }
 

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -1414,6 +1414,8 @@ extension SwiftNetworkQUICConnection {
             log("Dropping unexpected request to trigger write")
         case .triggerEvent(let channelView):
             log("Triggering out-of-band outbound write event")
+            // When handling out-of-band write, we should only drain and not avoid
+            // firing events that might enter SwiftNetwork.
             channelView.drainOutbound()
         }
     }

--- a/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
@@ -46,7 +46,7 @@ private func makeChannel(
 
         // Activate the connection.
         channel.connectionView.handshakeCompleted(peerMaxDatagramFrameSize: 0)
-        channel.connectionView.drainOutbound()
+        channel.connectionView.drainOutboundAndReconcileLifecycle()
 
         try promise.futureResult.wait()
 
@@ -292,14 +292,14 @@ struct QUICConnectionChannelTests {
             let channel = try makeChannel(connection: connection, transport: transport)
 
             // No buffers, so just a flush.
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
             #expect(transport.events.popFirst() == .flushed)
             #expect(transport.events.isEmpty)
 
             // Try again with a packet.
             let buffer = ByteBuffer(string: "Hello!")
             connection.outboundPackets.append(buffer)
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
 
             let expected = AddressedEnvelope(remoteAddress: .ipv4Loopback8081, data: buffer)
             #expect(transport.events.popFirst() == .wrote(expected))
@@ -320,7 +320,7 @@ struct QUICConnectionChannelTests {
             // applied on the next drain.
             struct Boom: Error {}
             channel.connectionView.connectionClosed(error: Boom())
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
 
             #expect(recorder.errors.last is Boom)
             #expect(recorder.inactiveCount == 1)
@@ -350,7 +350,7 @@ struct QUICConnectionChannelTests {
 
             struct Boom: Error {}
             channel.connectionView.connectionClosed(error: Boom())
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
 
             // The error is fired while the streams are still closing: a handler may rely on the
             // connection level error to fail its streams.
@@ -385,7 +385,7 @@ struct QUICConnectionChannelTests {
 
             // Complete handshake to activate.
             channel.connectionView.handshakeCompleted(peerMaxDatagramFrameSize: 0)
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
             #expect(channel.isActive)
         }
 
@@ -399,7 +399,7 @@ struct QUICConnectionChannelTests {
 
             // Only completes when the handshake completes.
             channel.connectionView.handshakeCompleted(peerMaxDatagramFrameSize: 0)
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
 
             try promise.futureResult.wait()
 
@@ -417,7 +417,7 @@ struct QUICConnectionChannelTests {
 
             struct Boom: Error {}
             channel.connectionView.connectionClosed(error: Boom())
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
 
             #expect(throws: Boom.self) {
                 try promise.futureResult.wait()
@@ -692,11 +692,11 @@ struct QUICConnectionChannelTests {
 
             // We can drain without triggering the lifecycle.
             channel.connectionView.handshakeCompleted(peerMaxDatagramFrameSize: 0)
-            channel.connectionView.drainOutboundOnly()
+            channel.connectionView.drainOutbound()
             #expect(!channel.isActive)
 
             // When draining with events, the channel will become active.
-            channel.connectionView.drainOutbound()
+            channel.connectionView.drainOutboundAndReconcileLifecycle()
             #expect(channel.isActive)
         }
     }

--- a/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
@@ -677,28 +677,6 @@ struct QUICConnectionChannelTests {
             channel.embeddedEventLoop.run()
             try channel.closeFuture.wait()
         }
-
-        @available(anyAppleOS 26, *)
-        @Test
-        func drainWithoutTriggeringLifecycle() throws {
-            let channel = try makeChannel()
-            let view = channel.transportView
-            let promise = channel.eventLoop.makePromise(of: Void.self)
-            view.initialize(promise: promise) { $0.eventLoop.makeSucceededVoidFuture() }
-            try promise.futureResult.wait()
-
-            // Channel isn't active yet.
-            #expect(!channel.isActive)
-
-            // We can drain without triggering the lifecycle.
-            channel.connectionView.handshakeCompleted(peerMaxDatagramFrameSize: 0)
-            channel.connectionView.drainOutbound()
-            #expect(!channel.isActive)
-
-            // When draining with events, the channel will become active.
-            channel.connectionView.drainOutboundAndReconcileLifecycle()
-            #expect(channel.isActive)
-        }
     }
 }
 

--- a/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
@@ -677,6 +677,28 @@ struct QUICConnectionChannelTests {
             channel.embeddedEventLoop.run()
             try channel.closeFuture.wait()
         }
+
+        @available(anyAppleOS 26, *)
+        @Test
+        func drainWithoutTriggeringLifecycle() throws {
+            let channel = try makeChannel()
+            let view = channel.transportView
+            let promise = channel.eventLoop.makePromise(of: Void.self)
+            view.initialize(promise: promise) { $0.eventLoop.makeSucceededVoidFuture() }
+            try promise.futureResult.wait()
+
+            // Channel isn't active yet.
+            #expect(!channel.isActive)
+
+            // We can drain without triggering the lifecycle.
+            channel.connectionView.handshakeCompleted(peerMaxDatagramFrameSize: 0)
+            channel.connectionView.drainOutboundOnly()
+            #expect(!channel.isActive)
+
+            // When draining with events, the channel will become active.
+            channel.connectionView.drainOutbound()
+            #expect(channel.isActive)
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

Out-of-band writes should not trigger channel lifecycle changes to avoid reentrancy. As an example a channel that turns active might open streams, which calls back into SwiftNetwork.

### Modifications

Restrict `drainOutbound` to draining the output.

### Results

Avoid potential crashes.