### PR TITLE
Only propagate read complete to connections which read

### DIFF
--- a/Sources/NIOQUIC/ConnectionRegistry.swift
+++ b/Sources/NIOQUIC/ConnectionRegistry.swift
@@ -190,12 +190,6 @@ extension ConnectionRegistry where Value == QUICConnectionChannel.TransportView 
         }
     }
 
-    func notifyParentChannelReadComplete() {
-        for view in self.values {
-            view.parentChannelReadComplete()
-        }
-    }
-
     func notifyParentChannelWritabilityChanged(_ writable: Bool) {
         for view in self.values {
             view.parentChannelWritabilityChanged(to: writable)

--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -84,6 +84,9 @@ final class QUICConnectionChannel: @unchecked Sendable {
     /// Whether the channel is allowed to drain the output from the connection.
     private var _isAllowedToDrain: Bool
 
+    /// Whether the channel is currently in a read loop.
+    private var _inReadLoop: Bool
+
     /// A queue of streams pushed to the channel by the underlying connection. These are dequeued
     /// at the end of the parent channel's read loop (in `_parentChannelReadComplete`).
     private var _pendingStreams: Deque<(QUICStreamID, QUICChannelStreamHandler)>
@@ -140,6 +143,7 @@ final class QUICConnectionChannel: @unchecked Sendable {
         self._streamInitializer = nil
         self._readyPromise = nil
         self._isAllowedToDrain = true
+        self._inReadLoop = false
         self._pendingStreams = []
         self._datagramNegotiation = .waitingForPeerAdvertisement(earlyWrites: TinyArray())
 
@@ -553,7 +557,9 @@ extension QUICConnectionChannel.TransportView {
         }
     }
 
-    func parentChannelRead(_ buffer: ByteBuffer) {
+    /// Returns whether the read caused the channel to enter a read loop.
+    @discardableResult
+    func parentChannelRead(_ buffer: ByteBuffer) -> Bool {
         self.channel._parentChannelRead(buffer)
     }
 
@@ -860,15 +866,20 @@ extension QUICConnectionChannel {
         self.pipeline.syncOperations.fireUserInboundEventTriggered(event)
     }
 
-    fileprivate func _parentChannelRead(_ buffer: ByteBuffer) {
+    fileprivate func _parentChannelRead(_ buffer: ByteBuffer) -> Bool {
         self.eventLoop.assertInEventLoop()
         // Feed packets in, '_parentChannelReadComplete' signals to the connection that
         // it should then consume those packets.
         self._connection.receivePacket(buffer)
+
+        let didEnterReadLoop = !self._inReadLoop
+        self._inReadLoop = true
+        return didEnterReadLoop
     }
 
     fileprivate func _parentChannelReadComplete() {
         self.eventLoop.assertInEventLoop()
+        self._inReadLoop = false
 
         // Avoid entering 'drainOutput'; wait for all events to be delivered and then
         // deal with them in 'drainAndReconcileLifecycle' below.

--- a/Sources/NIOQUIC/QUICHandler.swift
+++ b/Sources/NIOQUIC/QUICHandler.swift
@@ -62,6 +62,8 @@ public final class QUICHandler {
     private var didWrite = false
     /// Whether we're expecting a channelReadComplete. This is used to delay flushing the channel until the a read complete is received.
     private var expectingChannelReadComplete: Bool = false
+    /// Connections which read at least one datagram in the read loop.
+    private var connectionsAwaitingReadComplete: [QUICConnectionChannel.TransportView] = []
     /// The context of the channel handler.
     private var context: ChannelHandlerContext?
     /// The next connection handle to use. Don't use directly, use `nextConnectionHandle()` instead.
@@ -420,11 +422,32 @@ public final class QUICHandler {
         to view: QUICConnectionChannel.TransportView
     ) {
         self.eventLoop.assertInEventLoop()
-        view.parentChannelRead(packet)
+        self.deliverPacket(packet, to: view)
 
+        // First reads can be delivered outside of the read loop (i.e. after the connection init)
+        // so notify read complete out-of-band if necessary.
         if !self.expectingChannelReadComplete {
+            self.notifyPendingReadCompletions()
+        }
+    }
+
+    private func deliverPacket(
+        _ packet: ByteBuffer,
+        to view: QUICConnectionChannel.TransportView
+    ) {
+        let didEnterReadLoop = view.parentChannelRead(packet)
+
+        if didEnterReadLoop {
+            self.connectionsAwaitingReadComplete.append(view)
+        }
+    }
+
+    private func notifyPendingReadCompletions() {
+        for view in self.connectionsAwaitingReadComplete {
             view.parentChannelReadComplete()
         }
+
+        self.connectionsAwaitingReadComplete.removeAll(keepingCapacity: true)
     }
 
     private func connectionDidClose(_ handle: ConnectionHandle) {
@@ -524,7 +547,7 @@ extension QUICHandler: ChannelInboundHandler {
             switch self.state {
             case .accepting:
                 if let view = self.connectionRegistry[header.destinationConnectionID] {
-                    view.parentChannelRead(addressedEnvelope.data)
+                    self.deliverPacket(addressedEnvelope.data, to: view)
                 } else if self.quicConfiguration.role == .server {
                     // Only INITIAL packets can create new connections. However, we do need to
                     // pass packets with unknown versions to Swift QUIC to initiate version
@@ -584,7 +607,7 @@ extension QUICHandler: ChannelInboundHandler {
                     ]
                 )
 
-                view.parentChannelRead(addressedEnvelope.data)
+                self.deliverPacket(addressedEnvelope.data, to: view)
 
             case .shutdown:
                 self.logger.warning(
@@ -606,7 +629,7 @@ extension QUICHandler: ChannelInboundHandler {
     public func channelReadComplete(context: ChannelHandlerContext) {
         self.logger.trace("QUICHandler read complete")
 
-        self.connectionRegistry.notifyParentChannelReadComplete()
+        self.notifyPendingReadCompletions()
         self.expectingChannelReadComplete = false
 
         if self.didWrite {

--- a/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
+++ b/Tests/NIOQUICTests/QUICConnectionChannelTests.swift
@@ -454,11 +454,11 @@ struct QUICConnectionChannelTests {
             }
 
             let view = channel.transportView
-            view.parentChannelRead(ByteBuffer(string: "Hello,"))
+            #expect(view.parentChannelRead(ByteBuffer(string: "Hello,")))
             #expect(connection.events.popFirst() == .receivedPacket(ByteBuffer(string: "Hello,")))
             #expect(transport.events.isEmpty)
 
-            view.parentChannelRead(ByteBuffer(string: "QUIC!"))
+            #expect(!view.parentChannelRead(ByteBuffer(string: "QUIC!")))
             #expect(connection.events.popFirst() == .receivedPacket(ByteBuffer(string: "QUIC!")))
             #expect(transport.events.isEmpty)
 


### PR DESCRIPTION
Motivation:

At the moment the QUICHandler notifies all connections when the UDP channel receives a read complete event. This is wasteful for QUIC channels which handle many connections as only a handlful are likely to read anything.

It's also surprising (but likely inoccuous) behavior for connection channel's to receive: a read complete without a read is a little odd and wastes a pipeline traversal.

Modifications:

- parentChannelRead(_:) returns whether the read was the start of a read loop for a given connection: this allows the QUICHandler to cheaply track which connections are due a read-complete.
- Only notify channels which read at least one packet.

Result:

- Less work.
- ~10% uplift in perf for tests with 1000 concurrent connections