### PR TITLE
Fire channelReadComplete after reading datagrams

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -91,7 +91,10 @@ final class QUICConnectionChannel: @unchecked Sendable {
     /// at the end of the parent channel's read loop (in `_parentChannelReadComplete`).
     private var _pendingStreams: Deque<(QUICStreamID, QUICChannelStreamHandler)>
 
-    /// After a datagram was read during a read loop the channel should fire read complete.
+    /// This flag tracks if QUIC datagrams were forwarded inbound on the connection channel during
+    /// this tick. Part of the responsibility of the `QUICConnectionChannel` is accepting datagrams
+    /// from SwiftNetwork and sending them on the connection channel. At the end of a tick, it should
+    /// only fire `channelReadComplete` after sending datagrams.
     private var _readDatagramsInThisTick: Bool
 
     /// The negotiation state of the QUIC datagram extension (RFC 9221) for the connection.
@@ -913,7 +916,7 @@ extension QUICConnectionChannel {
         self.drainAndReconcileLifecycle()
         self.processPendingInboundStreams()
 
-        // If we read a datagram, we should fire channelReadComplete on the connection channel.
+        // Only fire channelReadComplete after reading a datagram.
         if self._readDatagramsInThisTick {
             self._readDatagramsInThisTick = false
             self.pipeline.syncOperations.fireChannelReadComplete()

--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -91,6 +91,9 @@ final class QUICConnectionChannel: @unchecked Sendable {
     /// at the end of the parent channel's read loop (in `_parentChannelReadComplete`).
     private var _pendingStreams: Deque<(QUICStreamID, QUICChannelStreamHandler)>
 
+    /// After a datagram was read during a read loop the channel should fire read complete.
+    private var _readDatagramsInThisTick: Bool
+
     /// The negotiation state of the QUIC datagram extension (RFC 9221) for the connection.
     enum DatagramNegotiation {
         /// The peer's `max_datagram_frame_size` transport parameter is not yet known.
@@ -146,6 +149,7 @@ final class QUICConnectionChannel: @unchecked Sendable {
         self._inReadLoop = false
         self._pendingStreams = []
         self._datagramNegotiation = .waitingForPeerAdvertisement(earlyWrites: TinyArray())
+        self._readDatagramsInThisTick = false
 
         self._pipeline = ChannelPipeline(channel: self)
 
@@ -459,6 +463,7 @@ extension QUICConnectionChannel.ConnectionView {
 
     /// A datagram was received from the peer; fire it as a `channelRead`.
     func datagramRead(_ datagram: ByteBuffer) {
+        self._channel._readDatagramsInThisTick = true
         self._channel.pipeline.syncOperations.fireChannelRead(NIOAny(datagram))
     }
 
@@ -907,6 +912,12 @@ extension QUICConnectionChannel {
 
         self.drainAndReconcileLifecycle()
         self.processPendingInboundStreams()
+
+        // If we read a datagram, we should fire channelReadComplete on the connection channel.
+        if self._readDatagramsInThisTick {
+            self._readDatagramsInThisTick = false
+            self.pipeline.syncOperations.fireChannelReadComplete()
+        }
 
         // Done producing data: exit read loop (which also flushes outbound data.)
         self._connection.withLiveOnly { $0.exitReadLoop() }

--- a/Tests/IntegrationTests/DatagramTests.swift
+++ b/Tests/IntegrationTests/DatagramTests.swift
@@ -45,6 +45,9 @@ struct DatagramTests {
         let serverReceivedPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
         let clientReceivedEchoPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
 
+        let serverReceivedReadComplete = NIOLockedValueBox<Int>(0)
+        let clientReceivedReadComplete = NIOLockedValueBox<Int>(0)
+
         let serverChannel = try await createServerChannel(
             eventLoopGroup: eventLoopGroup,
             host: host,
@@ -53,10 +56,13 @@ struct DatagramTests {
             inboundConnectionInitializer: { connectionChannel, streamCreator in
                 connectionChannel.eventLoop.makeCompletedFuture {
                     try connectionChannel.pipeline.syncOperations.addHandler(
-                        DatagramCapture(onDatagram: { buffer in
-                            serverReceivedPromise.succeed(buffer)
-                            connectionChannel.writeAndFlush(buffer, promise: nil)
-                        })
+                        DatagramCapture(
+                            onDatagram: { buffer in
+                                serverReceivedPromise.succeed(buffer)
+                                connectionChannel.writeAndFlush(buffer, promise: nil)
+                            },
+                            receivedReadComplete: serverReceivedReadComplete
+                        )
                     )
                 }
             },
@@ -87,7 +93,10 @@ struct DatagramTests {
         ) { connectionChannel, _ in
             connectionChannel.eventLoop.makeCompletedFuture {
                 try connectionChannel.pipeline.syncOperations.addHandler(
-                    DatagramCapture(onDatagram: { clientReceivedEchoPromise.succeed($0) })
+                    DatagramCapture(
+                        onDatagram: { clientReceivedEchoPromise.succeed($0) },
+                        receivedReadComplete: clientReceivedReadComplete
+                    )
                 )
             }
         }
@@ -102,6 +111,10 @@ struct DatagramTests {
 
         let clientReceived = try await clientReceivedEchoPromise.futureResult.get()
         #expect(clientReceived == payload)
+
+        // Verify that channelReadComplete was propagated as expected.
+        #expect(clientReceivedReadComplete.withLockedValue { $0 } == 1)
+        #expect(serverReceivedReadComplete.withLockedValue { $0 } == 1)
 
         try await serverChannel.close()
         try await noMoreConnectionsPromise.futureResult.get()
@@ -518,14 +531,22 @@ final class DatagramCapture: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
 
     let onDatagram: @Sendable (ByteBuffer) -> Void
+    let receivedReadComplete: NIOLockedValueBox<Int>?
 
-    init(onDatagram: @escaping @Sendable (ByteBuffer) -> Void) {
+    init(onDatagram: @escaping @Sendable (ByteBuffer) -> Void, receivedReadComplete: NIOLockedValueBox<Int>? = nil) {
         self.onDatagram = onDatagram
+        self.receivedReadComplete = receivedReadComplete
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = self.unwrapInboundIn(data)
         self.onDatagram(buffer)
+    }
+
+    func channelReadComplete(context: ChannelHandlerContext) {
+        self.receivedReadComplete?.withLockedValue {
+            $0 += 1
+        }
     }
 }
 

--- a/Tests/IntegrationTests/DatagramTests.swift
+++ b/Tests/IntegrationTests/DatagramTests.swift
@@ -45,9 +45,6 @@ struct DatagramTests {
         let serverReceivedPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
         let clientReceivedEchoPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
 
-        let serverReceivedReadComplete = NIOLockedValueBox<Int>(0)
-        let clientReceivedReadComplete = NIOLockedValueBox<Int>(0)
-
         let serverChannel = try await createServerChannel(
             eventLoopGroup: eventLoopGroup,
             host: host,
@@ -60,8 +57,7 @@ struct DatagramTests {
                             onDatagram: { buffer in
                                 serverReceivedPromise.succeed(buffer)
                                 connectionChannel.writeAndFlush(buffer, promise: nil)
-                            },
-                            receivedReadComplete: serverReceivedReadComplete
+                            }
                         )
                     )
                 }
@@ -94,8 +90,7 @@ struct DatagramTests {
             connectionChannel.eventLoop.makeCompletedFuture {
                 try connectionChannel.pipeline.syncOperations.addHandler(
                     DatagramCapture(
-                        onDatagram: { clientReceivedEchoPromise.succeed($0) },
-                        receivedReadComplete: clientReceivedReadComplete
+                        onDatagram: { clientReceivedEchoPromise.succeed($0) }
                     )
                 )
             }
@@ -112,9 +107,85 @@ struct DatagramTests {
         let clientReceived = try await clientReceivedEchoPromise.futureResult.get()
         #expect(clientReceived == payload)
 
-        // Verify that channelReadComplete was propagated as expected.
-        #expect(clientReceivedReadComplete.withLockedValue { $0 } == 1)
-        #expect(serverReceivedReadComplete.withLockedValue { $0 } == 1)
+        try await serverChannel.close()
+        try await noMoreConnectionsPromise.futureResult.get()
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func datagramRoundTripWaitingForReadComplete() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        let loggers = getChannelLoggers()
+        let host = "127.0.0.1"
+        let payload = ByteBuffer(string: "hello datagram")
+        let syncSignal = ByteBuffer(string: "ready")
+
+        let noMoreConnectionsPromise = eventLoopGroup.any().makePromise(of: Void.self)
+        let serverReceivedSyncPromise = eventLoopGroup.any().makePromise(of: Void.self)
+        let serverReceivedPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
+        let clientReceivedEchoPromise = eventLoopGroup.any().makePromise(of: ByteBuffer.self)
+
+        let serverChannel = try await createServerChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.serverLogger,
+            inboundConnectionInitializer: { connectionChannel, streamCreator in
+                connectionChannel.eventLoop.makeCompletedFuture {
+                    try connectionChannel.pipeline.syncOperations.addHandler(
+                        DatagramCaptureOnReadComplete(
+                            onDatagram: { buffer in
+                                serverReceivedPromise.succeed(buffer)
+                                connectionChannel.writeAndFlush(buffer, promise: nil)
+                            }
+                        )
+                    )
+                }
+            },
+            inboundStreamInitializer: { streamChannel in
+                streamChannel.pipeline.eventLoop.makeCompletedFuture {
+                    try streamChannel.pipeline.syncOperations.addHandler(
+                        SyncSignalHandler(receivedPromise: serverReceivedSyncPromise)
+                    )
+                }
+            },
+            noMoreConnections: {
+                noMoreConnectionsPromise.succeed()
+            }
+        ).get()
+        let serverPort = serverChannel.localAddress!.port!
+
+        let clientChannel = try await createClientChannel(
+            eventLoopGroup: eventLoopGroup,
+            host: host,
+            port: 0,
+            logger: loggers.clientLogger
+        ).get()
+
+        let (clientConnectionChannel, streamCreator) = try await connectOutbound(
+            clientChannel,
+            host: host,
+            port: serverPort
+        ) { connectionChannel, _ in
+            connectionChannel.eventLoop.makeCompletedFuture {
+                try connectionChannel.pipeline.syncOperations.addHandler(
+                    DatagramCaptureOnReadComplete(
+                        onDatagram: { clientReceivedEchoPromise.succeed($0) }
+                    )
+                )
+            }
+        }
+
+        // Open a tiny synchronization stream first. Once the server reads it, the connection was established.
+        try await performSyncHandshake(streamCreator, signal: syncSignal, serverReceived: serverReceivedSyncPromise)
+
+        clientConnectionChannel.writeAndFlush(payload, promise: nil)
+
+        let serverReceived = try await serverReceivedPromise.futureResult.get()
+        #expect(serverReceived == payload)
+
+        let clientReceived = try await clientReceivedEchoPromise.futureResult.get()
+        #expect(clientReceived == payload)
 
         try await serverChannel.close()
         try await noMoreConnectionsPromise.futureResult.get()
@@ -531,21 +602,36 @@ final class DatagramCapture: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
 
     let onDatagram: @Sendable (ByteBuffer) -> Void
-    let receivedReadComplete: NIOLockedValueBox<Int>?
 
-    init(onDatagram: @escaping @Sendable (ByteBuffer) -> Void, receivedReadComplete: NIOLockedValueBox<Int>? = nil) {
+    init(onDatagram: @escaping @Sendable (ByteBuffer) -> Void) {
         self.onDatagram = onDatagram
-        self.receivedReadComplete = receivedReadComplete
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = self.unwrapInboundIn(data)
         self.onDatagram(buffer)
     }
+}
+
+/// Captures inbound QUIC datagrams delivered on the connection channel.
+@available(anyAppleOS 26, *)
+final class DatagramCaptureOnReadComplete: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    let onDatagram: @Sendable (ByteBuffer) -> Void
+    var buffer: ByteBuffer? = nil
+
+    init(onDatagram: @escaping @Sendable (ByteBuffer) -> Void) {
+        self.onDatagram = onDatagram
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.buffer = self.unwrapInboundIn(data)
+    }
 
     func channelReadComplete(context: ChannelHandlerContext) {
-        self.receivedReadComplete?.withLockedValue {
-            $0 += 1
+        if let buffer = self.buffer {
+            self.onDatagram(buffer)
         }
     }
 }


### PR DESCRIPTION
### Motivation

After reading the available data in a tick channel handleres might expect a read complete call to notify that all data has been read. QUIC datagrams did not respect this and only ever read the datagrams.

### Modifications

If at least one datagrams was read, fire channelReadComplete on the connection channel.

### Results

Better behavior.