### PR TITLE
Fix idle timeout test

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -599,6 +599,7 @@ extension QUICConnectionChannel {
     private func _connectionClosed(error: (any Error)?) {
         self.eventLoop.assertInEventLoop()
         self._lifecycle.connectionClosed(error: error)
+        self.drainAndReconcileLifecycle()
     }
 
     /// Ask the lifecycle whether to initiate a new close, cascade onto an existing close, or

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -1253,7 +1253,6 @@ extension SwiftNetworkQUICConnection {
             // channel: if that lands first the channel commits to a clean close and this error is
             // never surfaced.
             self.channelView?.connectionClosed(error: error)
-            self.channelView?.drainOutbound()
 
             // Complete draining and tear down.
             // SwiftNetwork manages the draining timeout per RFC 9000 §10.2.2 internally.

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -1253,6 +1253,7 @@ extension SwiftNetworkQUICConnection {
             // channel: if that lands first the channel commits to a clean close and this error is
             // never surfaced.
             self.channelView?.connectionClosed(error: error)
+            self.channelView?.drainOutbound()
 
             // Complete draining and tear down.
             // SwiftNetwork manages the draining timeout per RFC 9000 §10.2.2 internally.

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -527,8 +527,9 @@ final class IntegrationTests: XCTestCase {
     }
 
     func testIdleTimeout() async throws {
-        // Test that idle timeout closes the connection when there's no activity.
-        // SwiftNetwork handles idle timeout internally and delivers ETIMEDOUT via disconnected event.
+        // Once the connection goes idle for longer than the negotiated max_idle_timeout,
+        // SwiftNetwork times it out and reports ETIMEDOUT through the disconnected event. The
+        // connection channel must act on that: go inactive and complete its close future.
         let idleTimeout: Duration = .seconds(2)
 
         let (_, serverChannel, serverMultiplexer, clientMultiplexer) =
@@ -537,10 +538,11 @@ final class IntegrationTests: XCTestCase {
                 clientKeepAliveTime: nil  // No keepalives - we want idle timeout to fire
             )
 
-        let connectionClosed = Counter()
+        // The client's connection channel, captured from the stream channel's parent.
+        let connectionChannelBox = NIOLockedValueBox<(any Channel)?>(nil)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
-            // Server task - process one request then wait
+            // Server task - answer one request, then leave the connection alone.
             group.addTask {
                 for await serverConnection in serverMultiplexer.inboundConnections {
                     for await stream in serverConnection.inboundStreams {
@@ -551,9 +553,6 @@ final class IntegrationTests: XCTestCase {
                                 outbound.finish()
                             }
                         }
-                        // After first stream, wait for idle timeout then exit
-                        try await Task.sleep(for: .seconds(3))
-                        connectionClosed.increment()
                         return
                     }
                 }
@@ -570,7 +569,8 @@ final class IntegrationTests: XCTestCase {
 
             let stream = try await connection.createBidirectionalStream { streamInitializer in
                 streamInitializer.channel.eventLoop.makeCompletedFuture {
-                    try NIOAsyncChannel(
+                    connectionChannelBox.withLockedValue { $0 = streamInitializer.channel.parent! }
+                    return try NIOAsyncChannel(
                         wrappingChannelSynchronously: streamInitializer.channel,
                         configuration: .init(
                             isOutboundHalfClosureEnabled: true,
@@ -590,12 +590,16 @@ final class IntegrationTests: XCTestCase {
                 }
             }
 
-            // Wait for server task to complete (which waits for idle timeout)
             try await group.waitForAll()
         }
 
-        // After idle timeout, the connection should be closed
-        XCTAssertEqual(connectionClosed.load(), 1)
+        let connectionChannel = try XCTUnwrap(connectionChannelBox.withLockedValue { $0 })
+
+        // Only the idle timeout can close the client's connectionChannel now. Use a separate timeout
+        // to ensure the connection closes at all.
+        let closed = try await trackChannelClose(of: connectionChannel, within: idleTimeout + .seconds(2))
+        XCTAssertTrue(closed, "Connection channel did not close after the idle timeout elapsed")
+        XCTAssertFalse(connectionChannel.isActive, "Connection channel is still active after the idle timeout")
     }
 
     // MARK: - Zero-length connection ID tests (RFC 9000 Section 5.1)

--- a/Tests/IntegrationTests/TestHelpers.swift
+++ b/Tests/IntegrationTests/TestHelpers.swift
@@ -129,3 +129,22 @@ final class Counter: Sendable {
         self.value.load(ordering: .sequentiallyConsistent)
     }
 }
+
+/// Waits up to `timeout` for `channel` to close, reporting whether it did.
+///
+/// Basically just a loop to check regularaly to notice closure early instead of just waiting
+/// for the complete timeout.
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
+func trackChannelClose(of channel: any Channel, within timeout: Duration) async throws -> Bool {
+    let closed = Mutex(false)
+    channel.closeFuture.whenComplete { _ in closed.withLock { $0 = true } }
+
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if closed.withLock({ $0 }) {
+            return true
+        }
+        try await Task.sleep(for: .milliseconds(50))
+    }
+    return closed.withLock { $0 }
+}

--- a/Tests/NIOQUICTests/CertificateAuthTests.swift
+++ b/Tests/NIOQUICTests/CertificateAuthTests.swift
@@ -165,6 +165,7 @@ final class CertificateAuthTests: XCTestCase {
     func testClientIdleTimeout() async throws {
         let certs = try TestCertificates()
         let certificateFilePaths = try certs.writeToTemp(fileTag: "testClientIdleTimeout")
+        let idleTimeout: Duration = .milliseconds(800)
 
         let (serverChannel, serverMultiplexer) = try await buildServerChannel(
             name: certs.leafName,
@@ -172,7 +173,7 @@ final class CertificateAuthTests: XCTestCase {
             privateKeyFilePath: certificateFilePaths.serverPrivateKeyFilePath
         )
         let (_, clientMultiplexer) = try await buildClientChannel(
-            maxIdleTimeout: .milliseconds(2000),
+            maxIdleTimeout: idleTimeout,
             trustStoreFilePath: certificateFilePaths.trustStoreFilePath
         )
 
@@ -183,6 +184,9 @@ final class CertificateAuthTests: XCTestCase {
                 channel.eventLoop.makeCompletedFuture { fatalError() }
             }
         )
+
+        // The client's connection channel, captured from the stream channel's parent.
+        let connectionChannelBox = NIOLockedValueBox<(any Channel)?>(nil)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -198,7 +202,8 @@ final class CertificateAuthTests: XCTestCase {
             }
             let stream = try await clientConnection.createBidirectionalStream { streamInitializer in
                 streamInitializer.channel.eventLoop.makeCompletedFuture {
-                    try NIOAsyncChannel(
+                    connectionChannelBox.withLockedValue { $0 = streamInitializer.channel.parent! }
+                    return try NIOAsyncChannel(
                         wrappingChannelSynchronously: streamInitializer.channel,
                         configuration: .init(
                             isOutboundHalfClosureEnabled: true,
@@ -209,16 +214,19 @@ final class CertificateAuthTests: XCTestCase {
                 }
             }
             try await stream.executeThenClose { inbound, outbound in
-                try await Task.sleep(for: .seconds(4))
-                do {
-                    try await outbound.write(.init(string: "GET /foo"))
-                    outbound.finish()
-                } catch {
-                    XCTAssertNotNil(error, "Channel should be closed due to timeout")
-                }
+                // Idle for twice the timeout the client advertised, so the connection is gone.
+                try await Task.sleep(for: idleTimeout  + .seconds(2))
+                // Nothing to check here. Just testing that the bytes never reach the peer.
+                try? await outbound.write(.init(string: "GET /foo"))
+                outbound.finish()
             }
             group.cancelAll()
         }
+
+        let connectionChannel = try XCTUnwrap(connectionChannelBox.withLockedValue { $0 })
+        let closed = try await trackChannelClose(of: connectionChannel, within: idleTimeout + .seconds(3))
+        XCTAssertTrue(closed, "Connection channel did not close after the client's idle timeout elapsed")
+        XCTAssertFalse(connectionChannel.isActive, "Connection channel is still active after the idle timeout")
     }
 
     func testMultipleConnections() async throws {

--- a/Tests/NIOQUICTests/CertificateAuthTests.swift
+++ b/Tests/NIOQUICTests/CertificateAuthTests.swift
@@ -215,7 +215,7 @@ final class CertificateAuthTests: XCTestCase {
             }
             try await stream.executeThenClose { inbound, outbound in
                 // Idle for twice the timeout the client advertised, so the connection is gone.
-                try await Task.sleep(for: idleTimeout  + .seconds(2))
+                try await Task.sleep(for: idleTimeout * 2)
                 // Nothing to check here. Just testing that the bytes never reach the peer.
                 try? await outbound.write(.init(string: "GET /foo"))
                 outbound.finish()
@@ -224,7 +224,7 @@ final class CertificateAuthTests: XCTestCase {
         }
 
         let connectionChannel = try XCTUnwrap(connectionChannelBox.withLockedValue { $0 })
-        let closed = try await trackChannelClose(of: connectionChannel, within: idleTimeout + .seconds(3))
+        let closed = try await trackChannelClose(of: connectionChannel, within: idleTimeout + .seconds(2))
         XCTAssertTrue(closed, "Connection channel did not close after the client's idle timeout elapsed")
         XCTAssertFalse(connectionChannel.isActive, "Connection channel is still active after the idle timeout")
     }

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -71,7 +71,8 @@ final class QUICProtocolStackTests: XCTestCase {
         initialMaxUnidirectionalStreams: Int = 8,
         qlogConfiguration: QUICConfiguration.QLogConfiguration? = nil,
         sendRetry: Bool = false,
-        eventLoopGroup: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        eventLoopGroup: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
+        onConnectionChannel: (@Sendable (any Channel) -> Void)? = nil
     ) async throws -> (any Channel, QUICHandler.ConnectionMultiplexer<NIOAsyncChannel<ByteBuffer, ByteBuffer>>) {
         let (channel, multiplexer) = try await DatagramBootstrap(group: eventLoopGroup)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -96,6 +97,11 @@ final class QUICProtocolStackTests: XCTestCase {
                         logger: logger,
                         inboundStreamChannelInitializer: { streamChannel in
                             streamChannel.eventLoop.makeCompletedFuture {
+                                // Hands out the connection channel each time an inbound stream is
+                                // initialized, so a test can get at the server side of a connection.
+                                if let onConnectionChannel, let connectionChannel = streamChannel.parent {
+                                    onConnectionChannel(connectionChannel)
+                                }
                                 let asyncChannel = try NIOAsyncChannel(
                                     wrappingChannelSynchronously: streamChannel,
                                     configuration: .init(
@@ -324,12 +330,13 @@ final class QUICProtocolStackTests: XCTestCase {
     }
 
     func testClientIdleTimeout() async throws {
+        let idleTimeout: Duration = .milliseconds(400)
 
         let loggers = getChannelLoggers()
         let (serverChannel, serverMultiplexer) = try await buildServerChannel(logger: loggers.serverLogger)
         let (_, clientMultiplexer) = try await buildClientChannel(
             logger: loggers.clientLogger,
-            maxIdleTimeout: .milliseconds(400)
+            maxIdleTimeout: idleTimeout
         )
 
         let clientConnection = try await clientMultiplexer.createNewConnection(
@@ -339,6 +346,9 @@ final class QUICProtocolStackTests: XCTestCase {
                 channel.eventLoop.makeCompletedFuture { fatalError() }
             }
         )
+
+        // The client's connection channel, captured from the stream channel's parent.
+        let connectionChannelBox = NIOLockedValueBox<(any Channel)?>(nil)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -354,7 +364,8 @@ final class QUICProtocolStackTests: XCTestCase {
             }
             let stream = try await clientConnection.createBidirectionalStream { streamInitializer in
                 streamInitializer.channel.eventLoop.makeCompletedFuture {
-                    try NIOAsyncChannel(
+                    connectionChannelBox.withLockedValue { $0 = streamInitializer.channel.parent! }
+                    return try NIOAsyncChannel(
                         wrappingChannelSynchronously: streamInitializer.channel,
                         configuration: .init(
                             isOutboundHalfClosureEnabled: true,
@@ -366,24 +377,36 @@ final class QUICProtocolStackTests: XCTestCase {
             }
             try await stream.executeThenClose { inbound, outbound in
                 // The server should not get the client write here due to inactivity on the client and the connection going down.
-                try await Task.sleep(for: .milliseconds(800))
-                do {
-                    try await outbound.write(.init(string: "GET /foo"))
-                    outbound.finish()
-                } catch {
-                    XCTAssertNotNil(error, "Channel should be closed due to timeout")
-                }
+                try await Task.sleep(for: idleTimeout + .seconds(2))
+                // Nothing to check here. Just testing that the bytes never reach the peer.
+                try? await outbound.write(.init(string: "GET /foo"))
+                outbound.finish()
             }
             group.cancelAll()
         }
+
+        let connectionChannel = try XCTUnwrap(connectionChannelBox.withLockedValue { $0 })
+        let closed = try await trackChannelClose(of: connectionChannel, within: idleTimeout + .seconds(2))
+        XCTAssertTrue(closed, "Connection channel did not close after the client's idle timeout elapsed")
+        XCTAssertFalse(connectionChannel.isActive, "Connection channel is still active after the idle timeout")
     }
 
     func testServerIdleTimeout() async throws {
+        let idleTimout: Duration = .milliseconds(400)
+
+        // An idle timeout is a silent close (RFC 9000 § 10.1): no CONNECTION_CLOSE goes on the
+        // wire, so only the endpoint whose own timer fires learns about it. The short timeout
+        // here is the server's, so it is the server's connection channel that must close --
+        // hence capturing it from the server side rather than asserting on the client's.
+        let connectionChannelBox = NIOLockedValueBox<(any Channel)?>(nil)
 
         let loggers = getChannelLoggers()
         let (serverChannel, serverMultiplexer) = try await buildServerChannel(
             logger: loggers.serverLogger,
-            maxIdleTimeout: .milliseconds(400)
+            maxIdleTimeout: idleTimout,
+            onConnectionChannel: { connectionChannel in
+                connectionChannelBox.withLockedValue { $0 = connectionChannel }
+            }
         )
         let (_, clientMultiplexer) = try await buildClientChannel(
             logger: loggers.clientLogger
@@ -398,14 +421,20 @@ final class QUICProtocolStackTests: XCTestCase {
         )
 
         try await withThrowingTaskGroup(of: Void.self) { group in
+            // Answer one request, then leave the connection alone so it goes idle. The exchange
+            // is what gives the server an inbound stream, and with it a connection channel to
+            // capture.
             group.addTask {
                 for await connection in serverMultiplexer.inboundConnections {
                     for await stream in connection.inboundStreams {
                         try await stream.executeThenClose { inbound, outbound in
-                            for try await _ in inbound {
-                                XCTFail("Should not reach this path")
+                            for try await buffer in inbound {
+                                XCTAssertEqual(buffer, .init(string: "GET /foo"))
+                                try await outbound.write(.init(string: "<b>Success</b>"))
+                                outbound.finish()
                             }
                         }
+                        return
                     }
                 }
             }
@@ -422,17 +451,26 @@ final class QUICProtocolStackTests: XCTestCase {
                 }
             }
             try await stream.executeThenClose { inbound, outbound in
-                try await Task.sleep(for: .milliseconds(800))
-                do {
-                    // The server should not get the client write here due to inactivity on the server and the connection going down.
-                    try await outbound.write(.init(string: "GET /foo"))
-                    outbound.finish()
-                } catch {
-                    XCTAssertNotNil(error, "Channel should be closed due to timeout")
+                try await outbound.write(.init(string: "GET /foo"))
+                outbound.finish()
+
+                for try await buffer in inbound {
+                    XCTAssertEqual(buffer, .init(string: "<b>Success</b>"))
                 }
             }
-            group.cancelAll()
+
+            try await group.waitForAll()
         }
+
+        // Nothing touches the connection from here on, so only the idle timeout can close it.
+        let connectionChannel = try XCTUnwrap(connectionChannelBox.withLockedValue { $0 })
+        XCTAssertTrue(connectionChannel.isActive)
+        let closed = try await trackChannelClose(of: connectionChannel, within: idleTimout + .seconds(2))
+        XCTAssertTrue(closed, "Server connection channel did not close after its idle timeout elapsed")
+        XCTAssertFalse(
+            connectionChannel.isActive,
+            "Server connection channel is still active after the idle timeout"
+        )
     }
 
     func testMultipleConnections() async throws {

--- a/Tests/NIOQUICTests/QUICProtocolStackTests.swift
+++ b/Tests/NIOQUICTests/QUICProtocolStackTests.swift
@@ -377,7 +377,7 @@ final class QUICProtocolStackTests: XCTestCase {
             }
             try await stream.executeThenClose { inbound, outbound in
                 // The server should not get the client write here due to inactivity on the client and the connection going down.
-                try await Task.sleep(for: idleTimeout + .seconds(2))
+                try await Task.sleep(for: idleTimeout * 2)
                 // Nothing to check here. Just testing that the bytes never reach the peer.
                 try? await outbound.write(.init(string: "GET /foo"))
                 outbound.finish()

--- a/Tests/NIOQUICTests/TestHelpers.swift
+++ b/Tests/NIOQUICTests/TestHelpers.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import NIOCore
 import Synchronization
 import XCTest
 
@@ -41,4 +42,23 @@ final class Counter: Sendable {
     func load() -> Int {
         self.value.load(ordering: .sequentiallyConsistent)
     }
+}
+
+/// Waits up to `timeout` for `channel` to close, reporting whether it did.
+///
+/// Basically just a loop to check regularaly to notice closure early instead of just waiting
+/// for the complete timeout.
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
+func trackChannelClose(of channel: any Channel, within timeout: Duration) async throws -> Bool {
+    let closed = Mutex(false)
+    channel.closeFuture.whenComplete { _ in closed.withLock { $0 = true } }
+
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if closed.withLock({ $0 }) {
+            return true
+        }
+        try await Task.sleep(for: .milliseconds(50))
+    }
+    return closed.withLock { $0 }
 }


### PR DESCRIPTION
### Motivation

The idle timeout tests did not test the idle timeout and just waited for a while without checking the connection state after. Updating them exposed a bug in when closing the connection due to an idle timeout.

### Modifications

* Update tests that use an idle timeout to check that the channel was closed.
* Reconcile lifecycle on timeout, which otherwise doesn't happen in idle timeouts fired by SwiftNetwork.

### Results

Idle timeouts close the connection.