### PR TITLE
Add stateless reset token generator

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
@@ -51,7 +51,7 @@ struct QUICStatelessResetTokenGenerator: Sendable {
     /// The stateless reset token for `connectionID`.
     func token(for connectionID: QUICConnectionID) -> QUICStatelessResetToken {
         let code = connectionID.withUnsafeBufferPointer {
-            return HMAC<SHA256>.authenticationCode(for: $0, using: self.key)
+            HMAC<SHA256>.authenticationCode(for: $0, using: self.key)
         }
         let token = InlineArray<16, UInt8>(initializingWith: { outputSpan in
             for elem in code.prefix(Self.tokenLength) {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
@@ -50,17 +50,15 @@ struct QUICStatelessResetTokenGenerator: Sendable {
 
     /// The stateless reset token for `connectionID`.
     func token(for connectionID: QUICConnectionID) -> QUICStatelessResetToken {
-        // The initializer only rejects tokens which aren't `tokenLength` bytes long.
-        // Since the RFC defines the token length, we are safe here.
-        QUICStatelessResetToken(self.tokenBytes(for: connectionID))!
-    }
-
-    /// Generate the stateless reset token for `connectionID`.
-    func tokenBytes(for connectionID: QUICConnectionID) -> [UInt8] {
         let code = connectionID.withUnsafeBufferPointer {
             return HMAC<SHA256>.authenticationCode(for: $0, using: self.key)
         }
-        return Array(code.prefix(Self.tokenLength))
+        let token = InlineArray<16, UInt8>(initializingWith: { outputSpan in
+            for elem in code.prefix(Self.tokenLength) {
+                outputSpan.append(elem)
+            }
+        })
+        return QUICStatelessResetToken(token.span)!
     }
 
     /// Builds a stateless reset datagram for `connectionID`.

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
@@ -18,9 +18,8 @@ import NIOCore
 
 /// Derives the stateless reset tokens for the connection IDs this endpoint issues.
 ///
-/// A token is `HMAC-SHA256(key, connectionID)` truncated to 16 bytes, as suggested by
-/// RFC 9000 § 10.3.2. Since tokens can be derived from the key and the conection ID they can
-/// be regenerated after restarts.
+/// Tokens are be derived from the key and the connection ID, so they can be
+/// regenerated after restarts.
 @available(anyAppleOS 26, *)
 struct QUICStatelessResetTokenGenerator: Sendable {
     /// The length of a stateless reset token in bytes (RFC 9000 § 10.3).
@@ -56,7 +55,7 @@ struct QUICStatelessResetTokenGenerator: Sendable {
         QUICStatelessResetToken(self.tokenBytes(for: connectionID))!
     }
 
-    /// The bytes of the stateless reset token for `connectionID`.
+    /// Generate the stateless reset token for `connectionID`.
     func tokenBytes(for connectionID: QUICConnectionID) -> [UInt8] {
         let connectionIDBytes = connectionID.withUnsafeBufferPointer { Array($0) }
         let code = HMAC<SHA256>.authenticationCode(for: connectionIDBytes, using: self.key)

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import NIOCore
+@_spi(ProtocolProvider) import SwiftNetwork
+
+/// Derives the stateless reset tokens for the connection IDs this endpoint issues.
+///
+/// A token is `HMAC-SHA256(key, connectionID)` truncated to 16 bytes, as suggested by
+/// RFC 9000 § 10.3.2. Since tokens can be derived from the key and the conection ID they can
+/// be regenerated after restarts.
+@available(anyAppleOS 26, *)
+struct QUICStatelessResetTokenGenerator: Sendable {
+    /// The length of a stateless reset token in bytes (RFC 9000 § 10.3).
+    static var tokenLength: Int { 16 }
+
+    /// The shortest key accepted. HMAC keys shorter than the hash output weaken the derivation (RFC 2104).
+    static var minimumKeyLength: Int { 32 }
+
+    /// Our key input. To send valid stateless resets across restarts the same key must be configured.
+    private let key: SymmetricKey
+
+    /// Create a new stateless token generator.
+    ///
+    /// - Parameter key: The static key to derive tokens from, or `nil` to generate one. A generated
+    ///   key is private to this process, so tokens do not survive a restart.
+    /// - Precondition: A supplied key is at least ``minimumKeyLength`` bytes long.
+    init(key: [UInt8]?) {
+        if let key {
+            precondition(
+                key.count >= Self.minimumKeyLength,
+                "The stateless reset key must be at least \(Self.minimumKeyLength) bytes long"
+            )
+            self.key = SymmetricKey(data: key)
+        } else {
+            self.key = SymmetricKey(size: .bits256)
+        }
+    }
+
+    /// The stateless reset token for `connectionID`.
+    func token(for connectionID: QUICConnectionID) -> QUICStatelessResetToken {
+        // The initializer only rejects tokens which aren't `tokenLength` bytes long.
+        // Since the RFC defines the token length, we are safe here.
+        QUICStatelessResetToken(self.tokenBytes(for: connectionID))!
+    }
+
+    /// The bytes of the stateless reset token for `connectionID`.
+    func tokenBytes(for connectionID: QUICConnectionID) -> [UInt8] {
+        let connectionIDBytes = connectionID.withUnsafeBufferPointer { Array($0) }
+        let code = HMAC<SHA256>.authenticationCode(for: connectionIDBytes, using: self.key)
+        return Array(code.prefix(Self.tokenLength))
+    }
+
+    /// Builds a stateless reset datagram for `connectionID`.
+    ///
+    /// Given the same key and same connection ID this packet will always generate the same token.
+    ///
+    /// - Parameters:
+    ///   - connectionID: The related connection ID.
+    ///   - triggeringPacketLength: The size of that packet. The reset is always smaller to
+    ///     prohibit amplification.
+    ///   - allocator: The allocator for the returned buffer.
+    /// - Returns: The datagram, or `nil` if no valid reset fits below `triggeringPacketLength`.
+    func statelessResetPacket(
+        for connectionID: QUICConnectionID,
+        triggeringPacketLength: Int,
+        allocator: ByteBufferAllocator
+    ) -> ByteBuffer? {
+        let bytes = QUICConnectionUtilities.createStatelessResetPacket(
+            token: self.token(for: connectionID),
+            triggeringPacketLength: triggeringPacketLength
+        )
+        // No bytes means no reset could be built which is both a plausible QUIC packet (21 bytes
+        // at minimum) and smaller than the packet that triggered it.
+        guard !bytes.isEmpty else { return nil }
+
+        var buffer = allocator.buffer(capacity: bytes.count)
+        buffer.writeBytes(bytes)
+        return buffer
+    }
+}

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
@@ -53,11 +53,11 @@ struct QUICStatelessResetTokenGenerator: Sendable {
         let code = connectionID.withUnsafeBufferPointer {
             HMAC<SHA256>.authenticationCode(for: $0, using: self.key)
         }
-        let token = InlineArray<16, UInt8>(initializingWith: { outputSpan in
+        let token = InlineArray<16, UInt8> { outputSpan in
             for elem in code.prefix(Self.tokenLength) {
                 outputSpan.append(elem)
             }
-        })
+        }
         return QUICStatelessResetToken(token.span)!
     }
 

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStatelessResetTokenGenerator.swift
@@ -57,8 +57,9 @@ struct QUICStatelessResetTokenGenerator: Sendable {
 
     /// Generate the stateless reset token for `connectionID`.
     func tokenBytes(for connectionID: QUICConnectionID) -> [UInt8] {
-        let connectionIDBytes = connectionID.withUnsafeBufferPointer { Array($0) }
-        let code = HMAC<SHA256>.authenticationCode(for: connectionIDBytes, using: self.key)
+        let code = connectionID.withUnsafeBufferPointer {
+            return HMAC<SHA256>.authenticationCode(for: $0, using: self.key)
+        }
         return Array(code.prefix(Self.tokenLength))
     }
 
@@ -83,7 +84,7 @@ struct QUICStatelessResetTokenGenerator: Sendable {
         )
         // No bytes means no reset could be built which is both a plausible QUIC packet (21 bytes
         // at minimum) and smaller than the packet that triggered it.
-        guard !bytes.isEmpty else { return nil }
+        if bytes.isEmpty { return nil }
 
         var buffer = allocator.buffer(capacity: bytes.count)
         buffer.writeBytes(bytes)

--- a/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
+++ b/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import XCTest
+
+@testable import NIOQUIC
+
+@available(anyAppleOS 26, *)
+final class QUICStatelessResetTokenGeneratorTests: XCTestCase {
+    private static let key = [UInt8](repeating: 0xAB, count: 32)
+    private static let otherKey = [UInt8](repeating: 0xCD, count: 32)
+
+    private func makeConnectionID(_ byte: UInt8) -> QUICConnectionID {
+        QUICConnectionID(bytes: InlineArray<20, UInt8>(repeating: byte), length: 8)
+    }
+
+    func testTokenIsSixteenBytes() {
+        let generator = QUICStatelessResetTokenGenerator(key: Self.key)
+
+        XCTAssertEqual(generator.tokenBytes(for: self.makeConnectionID(1)).count, 16)
+    }
+
+    func testTokenIsStableForTheSameKeyAndConnectionID() {
+        let connectionID = self.makeConnectionID(1)
+        let generator = QUICStatelessResetTokenGenerator(key: Self.key)
+        let other = QUICStatelessResetTokenGenerator(key: Self.key)
+
+        // The whole point of deriving tokens: a second generator with the same key produces the
+        // same token, so a reset stays valid after the connection state is gone.
+        XCTAssertEqual(generator.tokenBytes(for: connectionID), other.tokenBytes(for: connectionID))
+    }
+
+    func testTokenDiffersPerConnectionID() {
+        let generator = QUICStatelessResetTokenGenerator(key: Self.key)
+
+        XCTAssertNotEqual(
+            generator.tokenBytes(for: self.makeConnectionID(1)),
+            generator.tokenBytes(for: self.makeConnectionID(2))
+        )
+    }
+
+    func testTokenDiffersPerKey() {
+        let connectionID = self.makeConnectionID(1)
+
+        XCTAssertNotEqual(
+            QUICStatelessResetTokenGenerator(key: Self.key).tokenBytes(for: connectionID),
+            QUICStatelessResetTokenGenerator(key: Self.otherKey).tokenBytes(for: connectionID)
+        )
+    }
+
+    func testKeyIsGeneratedWhenNoneIsConfigured() {
+        let connectionID = self.makeConnectionID(1)
+
+        XCTAssertNotEqual(
+            QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID),
+            QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID)
+        )
+    }
+}

--- a/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
+++ b/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
@@ -112,7 +112,7 @@ final class QUICStatelessResetTokenGeneratorTests: XCTestCase {
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
 
         // A reset needs 5 unpredictable bytes plus the 16-byte token, so nothing valid fits into
-        // fewer than 22 bytes.
+        // fewer than 21 bytes.
         for triggeringPacketLength in [0, 1, 21] {
             XCTAssertNil(
                 generator.statelessResetPacket(

--- a/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
+++ b/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
@@ -28,14 +28,6 @@ struct QUICStatelessResetTokenGeneratorTests {
 
     @Test
     @available(anyAppleOS 26, *)
-    func tokenIsSixteenBytes() {
-        let generator = QUICStatelessResetTokenGenerator(key: Self.key)
-
-        #expect(generator.tokenBytes(for: self.makeConnectionID(1)).count == 16)
-    }
-
-    @Test
-    @available(anyAppleOS 26, *)
     func tokenIsStableForTheSameKeyAndConnectionID() {
         let connectionID = self.makeConnectionID(1)
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
@@ -43,7 +35,7 @@ struct QUICStatelessResetTokenGeneratorTests {
 
         // The whole point of deriving tokens: a second generator with the same key produces the
         // same token, so a reset stays valid after the connection state is gone.
-        #expect(generator.tokenBytes(for: connectionID) == other.tokenBytes(for: connectionID))
+        #expect(generator.token(for: connectionID) == other.token(for: connectionID))
     }
 
     @Test
@@ -51,10 +43,7 @@ struct QUICStatelessResetTokenGeneratorTests {
     func tokenDiffersPerConnectionID() {
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
 
-        #expect(
-            generator.tokenBytes(for: self.makeConnectionID(1))
-            != generator.tokenBytes(for: self.makeConnectionID(2))
-        )
+        #expect(generator.token(for: self.makeConnectionID(1)) != generator.token(for: self.makeConnectionID(2)))
     }
 
     @Test
@@ -63,8 +52,8 @@ struct QUICStatelessResetTokenGeneratorTests {
         let connectionID = self.makeConnectionID(1)
 
         #expect(
-            QUICStatelessResetTokenGenerator(key: Self.key).tokenBytes(for: connectionID)
-            != QUICStatelessResetTokenGenerator(key: Self.otherKey).tokenBytes(for: connectionID)
+            QUICStatelessResetTokenGenerator(key: Self.key).token(for: connectionID)
+            != QUICStatelessResetTokenGenerator(key: Self.otherKey).token(for: connectionID)
         )
     }
 
@@ -74,8 +63,8 @@ struct QUICStatelessResetTokenGeneratorTests {
         let connectionID = self.makeConnectionID(1)
 
         #expect(
-            QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID)
-            != QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID)
+            QUICStatelessResetTokenGenerator(key: nil).token(for: connectionID)
+            != QUICStatelessResetTokenGenerator(key: nil).token(for: connectionID)
         )
     }
 
@@ -93,7 +82,6 @@ struct QUICStatelessResetTokenGeneratorTests {
             )
         )
 
-        #expect(Array(packet.readableBytesView.suffix(16)) == generator.tokenBytes(for: connectionID))
         // Form bit clear, fixed bit set: indistinguishable from a 1-RTT packet (RFC 9000 § 10.3).
         let firstByte = try #require(packet.getInteger(at: packet.readerIndex, as: UInt8.self))
         #expect(firstByte & 0b1100_0000 == 0b0100_0000)

--- a/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
+++ b/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
@@ -53,7 +53,7 @@ struct QUICStatelessResetTokenGeneratorTests {
 
         #expect(
             QUICStatelessResetTokenGenerator(key: Self.key).token(for: connectionID)
-            != QUICStatelessResetTokenGenerator(key: Self.otherKey).token(for: connectionID)
+                != QUICStatelessResetTokenGenerator(key: Self.otherKey).token(for: connectionID)
         )
     }
 
@@ -64,7 +64,7 @@ struct QUICStatelessResetTokenGeneratorTests {
 
         #expect(
             QUICStatelessResetTokenGenerator(key: nil).token(for: connectionID)
-            != QUICStatelessResetTokenGenerator(key: nil).token(for: connectionID)
+                != QUICStatelessResetTokenGenerator(key: nil).token(for: connectionID)
         )
     }
 
@@ -121,7 +121,7 @@ struct QUICStatelessResetTokenGeneratorTests {
                     triggeringPacketLength: triggeringPacketLength,
                     allocator: ByteBufferAllocator()
                 )
-                == nil
+                    == nil
             )
         }
     }

--- a/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
+++ b/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
@@ -13,67 +13,79 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import XCTest
+import Testing
 
 @testable import NIOQUIC
 
-@available(anyAppleOS 26, *)
-final class QUICStatelessResetTokenGeneratorTests: XCTestCase {
+struct QUICStatelessResetTokenGeneratorTests {
     private static let key = [UInt8](repeating: 0xAB, count: 32)
     private static let otherKey = [UInt8](repeating: 0xCD, count: 32)
 
+    @available(anyAppleOS 26, *)
     private func makeConnectionID(_ byte: UInt8) -> QUICConnectionID {
         QUICConnectionID(bytes: InlineArray<20, UInt8>(repeating: byte), length: 8)
     }
 
-    func testTokenIsSixteenBytes() {
+    @Test
+    @available(anyAppleOS 26, *)
+    func tokenIsSixteenBytes() {
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
 
-        XCTAssertEqual(generator.tokenBytes(for: self.makeConnectionID(1)).count, 16)
+        #expect(generator.tokenBytes(for: self.makeConnectionID(1)).count == 16)
     }
 
-    func testTokenIsStableForTheSameKeyAndConnectionID() {
+    @Test
+    @available(anyAppleOS 26, *)
+    func tokenIsStableForTheSameKeyAndConnectionID() {
         let connectionID = self.makeConnectionID(1)
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
         let other = QUICStatelessResetTokenGenerator(key: Self.key)
 
         // The whole point of deriving tokens: a second generator with the same key produces the
         // same token, so a reset stays valid after the connection state is gone.
-        XCTAssertEqual(generator.tokenBytes(for: connectionID), other.tokenBytes(for: connectionID))
+        #expect(generator.tokenBytes(for: connectionID) == other.tokenBytes(for: connectionID))
     }
 
-    func testTokenDiffersPerConnectionID() {
+    @Test
+    @available(anyAppleOS 26, *)
+    func tokenDiffersPerConnectionID() {
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
 
-        XCTAssertNotEqual(
-            generator.tokenBytes(for: self.makeConnectionID(1)),
-            generator.tokenBytes(for: self.makeConnectionID(2))
+        #expect(
+            generator.tokenBytes(for: self.makeConnectionID(1))
+            != generator.tokenBytes(for: self.makeConnectionID(2))
         )
     }
 
-    func testTokenDiffersPerKey() {
+    @Test
+    @available(anyAppleOS 26, *)
+    func tokenDiffersPerKey() {
         let connectionID = self.makeConnectionID(1)
 
-        XCTAssertNotEqual(
-            QUICStatelessResetTokenGenerator(key: Self.key).tokenBytes(for: connectionID),
-            QUICStatelessResetTokenGenerator(key: Self.otherKey).tokenBytes(for: connectionID)
+        #expect(
+            QUICStatelessResetTokenGenerator(key: Self.key).tokenBytes(for: connectionID)
+            != QUICStatelessResetTokenGenerator(key: Self.otherKey).tokenBytes(for: connectionID)
         )
     }
 
-    func testKeyIsGeneratedWhenNoneIsConfigured() {
+    @Test
+    @available(anyAppleOS 26, *)
+    func keyIsGeneratedWhenNoneIsConfigured() {
         let connectionID = self.makeConnectionID(1)
 
-        XCTAssertNotEqual(
-            QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID),
+        #expect(
             QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID)
+            != QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID)
         )
     }
 
-    func testResetPacketEndsWithTheTokenAndLooksLikeAShortHeader() throws {
+    @Test
+    @available(anyAppleOS 26, *)
+    func resetPacketEndsWithTheTokenAndLooksLikeAShortHeader() throws {
         let connectionID = self.makeConnectionID(1)
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
 
-        let packet = try XCTUnwrap(
+        let packet = try #require(
             generator.statelessResetPacket(
                 for: connectionID,
                 triggeringPacketLength: 1200,
@@ -81,45 +93,47 @@ final class QUICStatelessResetTokenGeneratorTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            Array(packet.readableBytesView.suffix(16)),
-            generator.tokenBytes(for: connectionID)
-        )
+        #expect(Array(packet.readableBytesView.suffix(16)) == generator.tokenBytes(for: connectionID))
         // Form bit clear, fixed bit set: indistinguishable from a 1-RTT packet (RFC 9000 § 10.3).
-        let firstByte = try XCTUnwrap(packet.getInteger(at: packet.readerIndex, as: UInt8.self))
-        XCTAssertEqual(firstByte & 0b1100_0000, 0b0100_0000)
-        XCTAssertGreaterThanOrEqual(packet.readableBytes, 21)
+        let firstByte = try #require(packet.getInteger(at: packet.readerIndex, as: UInt8.self))
+        #expect(firstByte & 0b1100_0000 == 0b0100_0000)
+        #expect(packet.readableBytes >= 21)
     }
 
-    func testResetPacketIsSmallerThanThePacketThatTriggeredIt() throws {
+    @Test
+    @available(anyAppleOS 26, *)
+    func resetPacketIsSmallerThanThePacketThatTriggeredIt() throws {
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
 
         // RFC 9000 § 10.3.3: every reset must be smaller than its trigger, so an exchange of
         // resets between two stateless endpoints dies out instead of looping.
         for triggeringPacketLength in [22, 30, 43, 1200] {
-            let packet = try XCTUnwrap(
+            let packet = try #require(
                 generator.statelessResetPacket(
                     for: self.makeConnectionID(1),
                     triggeringPacketLength: triggeringPacketLength,
                     allocator: ByteBufferAllocator()
                 )
             )
-            XCTAssertLessThan(packet.readableBytes, triggeringPacketLength)
+            #expect(packet.readableBytes < triggeringPacketLength)
         }
     }
 
-    func testNoResetPacketWhenTheTriggerIsTooSmall() {
+    @Test
+    @available(anyAppleOS 26, *)
+    func noResetPacketWhenTheTriggerIsTooSmall() {
         let generator = QUICStatelessResetTokenGenerator(key: Self.key)
 
         // A reset needs 5 unpredictable bytes plus the 16-byte token, so nothing valid fits into
         // fewer than 21 bytes.
         for triggeringPacketLength in [0, 1, 21] {
-            XCTAssertNil(
+            #expect(
                 generator.statelessResetPacket(
                     for: self.makeConnectionID(1),
                     triggeringPacketLength: triggeringPacketLength,
                     allocator: ByteBufferAllocator()
                 )
+                == nil
             )
         }
     }

--- a/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
+++ b/Tests/NIOQUICTests/QUICStatelessResetTokenGeneratorTests.swift
@@ -68,4 +68,59 @@ final class QUICStatelessResetTokenGeneratorTests: XCTestCase {
             QUICStatelessResetTokenGenerator(key: nil).tokenBytes(for: connectionID)
         )
     }
+
+    func testResetPacketEndsWithTheTokenAndLooksLikeAShortHeader() throws {
+        let connectionID = self.makeConnectionID(1)
+        let generator = QUICStatelessResetTokenGenerator(key: Self.key)
+
+        let packet = try XCTUnwrap(
+            generator.statelessResetPacket(
+                for: connectionID,
+                triggeringPacketLength: 1200,
+                allocator: ByteBufferAllocator()
+            )
+        )
+
+        XCTAssertEqual(
+            Array(packet.readableBytesView.suffix(16)),
+            generator.tokenBytes(for: connectionID)
+        )
+        // Form bit clear, fixed bit set: indistinguishable from a 1-RTT packet (RFC 9000 § 10.3).
+        let firstByte = try XCTUnwrap(packet.getInteger(at: packet.readerIndex, as: UInt8.self))
+        XCTAssertEqual(firstByte & 0b1100_0000, 0b0100_0000)
+        XCTAssertGreaterThanOrEqual(packet.readableBytes, 21)
+    }
+
+    func testResetPacketIsSmallerThanThePacketThatTriggeredIt() throws {
+        let generator = QUICStatelessResetTokenGenerator(key: Self.key)
+
+        // RFC 9000 § 10.3.3: every reset must be smaller than its trigger, so an exchange of
+        // resets between two stateless endpoints dies out instead of looping.
+        for triggeringPacketLength in [22, 30, 43, 1200] {
+            let packet = try XCTUnwrap(
+                generator.statelessResetPacket(
+                    for: self.makeConnectionID(1),
+                    triggeringPacketLength: triggeringPacketLength,
+                    allocator: ByteBufferAllocator()
+                )
+            )
+            XCTAssertLessThan(packet.readableBytes, triggeringPacketLength)
+        }
+    }
+
+    func testNoResetPacketWhenTheTriggerIsTooSmall() {
+        let generator = QUICStatelessResetTokenGenerator(key: Self.key)
+
+        // A reset needs 5 unpredictable bytes plus the 16-byte token, so nothing valid fits into
+        // fewer than 22 bytes.
+        for triggeringPacketLength in [0, 1, 21] {
+            XCTAssertNil(
+                generator.statelessResetPacket(
+                    for: self.makeConnectionID(1),
+                    triggeringPacketLength: triggeringPacketLength,
+                    allocator: ByteBufferAllocator()
+                )
+            )
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

QUIC stateless reset requires token generation based off a key and a QUIC connection ID. Given the same key and the same connection ID, the generated tokens should be equivalent. Changing either should produce different tokens.

### Modifications

Add a token generator and respective tests.

### Results

Nothing is wired up, this sets up a follow-up PR.
