### PR TITLE
Avoid fabricating QUIC application error codes

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICApplicationAbortError.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICApplicationAbortError.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+@available(anyAppleOS 26, *)
+struct QUICApplicationAbort {
+    let networkError: NetworkError
+}
+
+@available(anyAppleOS 26, *)
+func makeQUICApplicationAbortError(_ applicationErrorCode: QUICApplicationErrorCode?) -> QUICApplicationAbort? {
+    guard let applicationErrorCode else {
+        return nil
+    }
+
+    return QUICApplicationAbort(
+        networkError: NetworkError(quicApplicationError: applicationErrorCode.rawValue)
+    )
+}
+
+@available(anyAppleOS 26, *)
+extension QUICChannelStreamHandler {
+    func abortInbound(error applicationAbort: QUICApplicationAbort?) {
+        guard let applicationAbort else {
+            return
+        }
+
+        self.abortInbound(error: applicationAbort.networkError)
+    }
+}

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -112,7 +112,7 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
     /// which this endpoint is consuming inbound data.
     private var pendingRead: Bool = false
 
-    /// Whether the `autoRead` channel option is enabled. This value is inherited from the parent connection channel.
+    /// Whether `autoRead` channel option is enabled. This value is inherited from the parent connection channel.
     /// When `true`, `self.pipeline.read()` is called after every `channelReadComplete` to keep data flowing.
     ///
     /// Defaults to `true`. This value can be updated by calling `setOption`.
@@ -1105,7 +1105,7 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
             self.log(
                 "shutdownStream shutting down read, applicationErrorCode: \(String(describing: applicationErrorCode))"
             )
-            self.abortInbound(error: NetworkError(quicApplicationError: applicationErrorCode?.rawValue ?? 0))
+            self.abortInbound(error: makeQUICApplicationAbortError(applicationErrorCode))
             if deliverEndOfStream {
                 self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
             }

--- a/Tests/NIOQUICTests/QUICApplicationAbortErrorTests.swift
+++ b/Tests/NIOQUICTests/QUICApplicationAbortErrorTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+import Testing
+
+@testable import NIOQUIC
+
+@Suite("QUIC application abort errors")
+struct QUICApplicationAbortErrorTests {
+    @available(anyAppleOS 26, *)
+    @Test("Missing application error code does not create an abort")
+    func missingApplicationErrorCodeDoesNotCreateAbort() {
+        #expect(makeQUICApplicationAbortError(nil) == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test("Application error code is preserved")
+    func applicationErrorCodeIsPreserved() throws {
+        let abort = try #require(makeQUICApplicationAbortError(QUICApplicationErrorCode(42)))
+        #expect(abort.networkError.quicApplicationError == 42)
+    }
+}


### PR DESCRIPTION
### Motivation

A NIO read-side close does not necessarily provide an application-defined QUIC error code. However, the current implementation sends `STOP_SENDING` even when no application error code is available, causing an error code of `0` to be fabricated.

Per RFC 9000, the error code carried by `STOP_SENDING` is an application protocol error code and therefore should come from the application rather than being synthesized by the transport.

This addresses #3.

### Modifications

* Skip sending `STOP_SENDING` when a NIO read-side close does not provide an application-defined error code.
* Continue sending `STOP_SENDING` when an explicit QUIC application error code is provided.
* Preserve explicitly supplied application error codes unchanged.
* Add regression coverage for both:

  * read-side closes without an application error code;
  * read-side closes with an explicit application error code.

### Result

NIOQUIC no longer fabricates application error code `0` for code-less read-side closes.

Applications that explicitly provide a QUIC application error code retain the existing behavior, with that code propagated unchanged.
