### PR TITLE
Avoid crash on undersized datagrams

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
@@ -257,6 +257,10 @@ extension NIOCore.ByteBuffer {
             packetType = .short
             let dcidLength = shortHeaderDCIDLength
 
+            guard localBuffer.readableBytes >= dcidLength else {
+                return nil
+            }
+
             let dcidWrittenBytes = destinationConnectionID.withUnsafeMutableBufferPointer {
                 destinationConnectionIDBytes in
                 localBuffer.readSlice(length: dcidLength)!.withUnsafeReadableBytes { pointer in
@@ -286,6 +290,9 @@ extension NIOCore.ByteBuffer {
             if longHeaderDCIDLength > QUICConnectionID.maxLength {
                 throw QUICError.invalidConnectionIDLength(Int(longHeaderDCIDLength))
             }
+            guard localBuffer.readableBytes >= dcidLength else {
+                return nil
+            }
             let dcidWrittenBytes = destinationConnectionID.withUnsafeMutableBufferPointer {
                 destinationConnectionIDBytes in
                 localBuffer.readSlice(length: dcidLength)!.withUnsafeReadableBytes { pointer in
@@ -304,6 +311,10 @@ extension NIOCore.ByteBuffer {
 
             if headerSCIDLength > QUICConnectionID.maxLength {
                 throw QUICError.invalidConnectionIDLength(scidLength)
+            }
+
+            guard localBuffer.readableBytes >= scidLength else {
+                return nil
             }
 
             var scid = QUICConnectionID.zero

--- a/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICPacketHeader.swift
@@ -257,13 +257,13 @@ extension NIOCore.ByteBuffer {
             packetType = .short
             let dcidLength = shortHeaderDCIDLength
 
-            guard localBuffer.readableBytes >= dcidLength else {
+            guard let dcidSlice = localBuffer.readSlice(length: dcidLength) else {
                 return nil
             }
 
             let dcidWrittenBytes = destinationConnectionID.withUnsafeMutableBufferPointer {
                 destinationConnectionIDBytes in
-                localBuffer.readSlice(length: dcidLength)!.withUnsafeReadableBytes { pointer in
+                dcidSlice.withUnsafeReadableBytes { pointer in
                     pointer.copyBytes(to: destinationConnectionIDBytes)
                 }
             }
@@ -290,12 +290,12 @@ extension NIOCore.ByteBuffer {
             if longHeaderDCIDLength > QUICConnectionID.maxLength {
                 throw QUICError.invalidConnectionIDLength(Int(longHeaderDCIDLength))
             }
-            guard localBuffer.readableBytes >= dcidLength else {
+            guard let dcidSlice = localBuffer.readSlice(length: dcidLength) else {
                 return nil
             }
             let dcidWrittenBytes = destinationConnectionID.withUnsafeMutableBufferPointer {
                 destinationConnectionIDBytes in
-                localBuffer.readSlice(length: dcidLength)!.withUnsafeReadableBytes { pointer in
+                dcidSlice.withUnsafeReadableBytes { pointer in
                     pointer.copyBytes(to: destinationConnectionIDBytes)
                 }
             }
@@ -313,14 +313,14 @@ extension NIOCore.ByteBuffer {
                 throw QUICError.invalidConnectionIDLength(scidLength)
             }
 
-            guard localBuffer.readableBytes >= scidLength else {
+            guard let scidSlice = localBuffer.readSlice(length: scidLength) else {
                 return nil
             }
 
             var scid = QUICConnectionID.zero
 
             let scidWrittenBytes = scid.withUnsafeMutableBufferPointer { sourceConnectionIDBytes in
-                localBuffer.readSlice(length: scidLength)!.withUnsafeReadableBytes { pointer in
+                scidSlice.withUnsafeReadableBytes { pointer in
                     pointer.copyBytes(to: sourceConnectionIDBytes)
                 }
             }

--- a/Tests/NIOQUICTests/QUICHeaderTests.swift
+++ b/Tests/NIOQUICTests/QUICHeaderTests.swift
@@ -293,4 +293,82 @@ final class HeaderIDTests {
         // Short headers have no SCID
         #expect(header.sourceConnectionID == nil)
     }
+
+    // MARK: - Undersized datagrams
+
+    @available(anyAppleOS 26, *)
+    @Test(
+        "short header too small to contain the destination connection ID"
+    )
+    func shortHeaderTooSmallForDCID() throws {
+        let connectionID = QUICConnectionID(
+            bytes: [
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+                1, 0, 0, 0, 0,
+            ],
+            length: 16
+        )
+        let packet = Array(QUICPackets.shortHeader(destinationID: connectionID).prefix(4))
+        let buffer = ByteBuffer(bytes: packet)
+
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
+
+        #expect(header == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test(
+        "long header too small to contain the destination connection ID"
+    )
+    func longHeaderTooSmallForDCID() throws {
+        let connectionID = QUICConnectionID(
+            bytes: [
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+            ],
+            length: 20
+        )
+        let packet = Array(
+            QUICPackets.initial(destinationID: connectionID, sourceID: connectionID, token: [], version: 1)
+                .prefix(6)
+        )
+        let buffer = ByteBuffer(bytes: packet)
+
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
+
+        #expect(header == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test(
+        "long header too small to contain the source connection ID"
+    )
+    func longHeaderTooSmallForSCID() throws {
+        let zeroLengthCID = QUICConnectionID(
+            bytes: InlineArray(repeating: 0),
+            length: 0
+        )
+        let sourceID = QUICConnectionID(
+            bytes: [
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1,
+            ],
+            length: 20
+        )
+        let packet = Array(
+            QUICPackets.initial(destinationID: zeroLengthCID, sourceID: sourceID, token: [], version: 1)
+                .prefix(7)
+        )
+        let buffer = ByteBuffer(bytes: packet)
+
+        let header = try buffer.getQUICPacketHeader(destinationIDLength: 16)
+
+        #expect(header == nil)
+    }
 }


### PR DESCRIPTION
### Motivation

Force unwrapping on uncontrolled input is dangerous.

### Modifications

Handle failures instead of force-unwrapping.

### Result

Robuster packet handling.
