### PR TITLE
Add paged slot storage for QUIC stream state

### DIFF
--- a/Sources/NIOQUIC/Collections/PagedBuffer.swift
+++ b/Sources/NIOQUIC/Collections/PagedBuffer.swift
@@ -1,0 +1,201 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Discontiguous storage for values addressed by index.
+///
+/// The storage is made up of pages which begin at one slot and double in size up to 64. Pages are
+/// allocated once and never moved, so the address of each value is stable until the buffer is
+/// destroyed and can be accessed via a pointer. By itself this construct is _not_ safe; callers
+/// must take care to ensure that pointers do not outlive the buffer.
+///
+/// Slots are handed out densely from zero: the buffer grows by one slot at a time and never has a
+/// hole, so its ``count`` is the next index it will hand out.
+@usableFromInline
+struct PagedBuffer<Value: ~Copyable>: ~Copyable {
+    /// The allocated pages.
+    @usableFromInline
+    var _pages: [UnsafeMutablePointer<Value>]
+
+    /// The number of slots handed out.
+    @usableFromInline
+    var _count: Int
+
+    @inlinable
+    init() {
+        self._pages = []
+        self._count = 0
+    }
+
+    deinit {
+        for page in self._pages {
+            page.deallocate()
+        }
+    }
+
+    /// The number of slots handed out, which is also the index the next ``append()`` returns.
+    @inlinable
+    var count: Int {
+        self._count
+    }
+
+    /// The number of pages allocated so far.
+    @inlinable
+    var pageCount: Int {
+        self._pages.count
+    }
+
+    /// The base pointer for a given `page`.
+    ///
+    /// - Precondition: `page` must exist.
+    @inlinable
+    func basePointer(ofPage page: Int) -> UnsafeMutablePointer<Value> {
+        self._pages[page]
+    }
+
+    /// Grows the buffer by one slot and returns it, allocating a page if the last one is full.
+    ///
+    /// The slot's storage is allocated but not initialized. It is the caller's responsibility to
+    /// initialize it. If `Value` is an `Optional` (or expressible by `nil`) then you can grow the
+    /// buffer with `nil`-initialized storage using ``appendNil()``.
+    @inlinable
+    @discardableResult
+    mutating func append() -> UnsafeMutablePointer<Value> {
+        let position = Page.position(of: self._count)
+
+        // Slots are dense, so the new one lands either on the last page or on the very next one.
+        if position.pageIndex == self._pages.count {
+            let capacity = Page.capacity(ofPage: position.pageIndex)
+            self._pages.append(UnsafeMutablePointer<Value>.allocate(capacity: capacity))
+        }
+
+        self._count &+= 1
+        return self._pages[position.pageIndex].advanced(by: position.offset)
+    }
+
+    /// The slot for `index`, which must have already been handed out.
+    ///
+    /// - Precondition: `index` must be below ``count``.
+    @inlinable
+    func pointer(at index: Int) -> UnsafeMutablePointer<Value> {
+        assert(index < self._count, "slot \(index) was never handed out")
+        let position = Page.position(of: index)
+        return self._pages[position.pageIndex].advanced(by: position.offset)
+    }
+}
+
+extension PagedBuffer where Value: ExpressibleByNilLiteral {
+    /// Grows the buffer by one `nil`-initialized slot and returns it.
+    ///
+    /// The rest of any page this allocates is `nil`-initialized too: the whole-page operations
+    /// below rely on every slot of an allocated page holding a value.
+    @inlinable
+    @discardableResult
+    mutating func appendNil() -> UnsafeMutablePointer<Value> {
+        let allocated = self._pages.count
+        let pointer = self.append()
+
+        if self._pages.count > allocated {
+            self._pages[allocated].initialize(
+                repeating: nil,
+                count: Page.capacity(ofPage: allocated)
+            )
+        }
+
+        return pointer
+    }
+
+    /// Sets every slot to `nil`.
+    @inlinable
+    func setAllToNil() {
+        for page in 0..<self._pages.count {
+            self._pages[page].update(repeating: nil, count: Page.capacity(ofPage: page))
+        }
+    }
+
+    /// Deinitializes every slot of every page.
+    @inlinable
+    func deinitializeAll() {
+        for index in self._pages.indices {
+            self._pages[index].deinitialize(count: Page.capacity(ofPage: index))
+        }
+    }
+}
+
+@usableFromInline
+enum Page {
+    /// The capacity every page has once doubling stops.
+    @usableFromInline
+    static var maxPageCapacity: Int { 64 }
+
+    /// The first page which holds ``maxPageCapacity`` slots.
+    @inlinable
+    static var firstFixedCapacityPage: Int { 6 }
+
+    /// The first index of a fixed-capacity page.
+    ///
+    /// I.e. how many slots the doubling pages hold between them: `1 + 2 + 4 + ... + 32`.
+    @inlinable
+    static var firstFixedCapacityIndex: Int {
+        (1 << Page.firstFixedCapacityPage) - 1
+    }
+
+    /// The number of slots in the given `page`.
+    @inlinable
+    static func capacity(ofPage page: Int) -> Int {
+        if page < Self.firstFixedCapacityPage {
+            return 1 << page
+        } else {
+            return Self.maxPageCapacity
+        }
+    }
+
+    /// The page `index` lives on, and where on that page it is.
+    @inlinable
+    static func position(of index: Int) -> Position {
+        let page: Int
+        let offset: Int
+
+        if index < Self.firstFixedCapacityIndex {
+            // Page p holds 2^p slots and begins at index 2^p - 1, so:
+            //
+            //     2^p - 1 <= index < 2^(p+1) - 1  ==>  2^p <= index + 1 < 2^(p+1)
+            //
+            // i.e. index + 1 has its highest set bit at position p. The page number is that bit's
+            // position; clearing it leaves the distance into the page.
+            let oneBased = index + 1
+            page = oneBased.bitWidth - 1 - oneBased.leadingZeroBitCount
+            offset = oneBased - (1 << page)
+        } else {
+            let beyond = index - Self.firstFixedCapacityIndex
+            page = Self.firstFixedCapacityPage + beyond / Self.maxPageCapacity
+            offset = beyond % Self.maxPageCapacity
+        }
+
+        return Position(page: page, offset: offset)
+    }
+
+    @usableFromInline
+    struct Position {
+        @usableFromInline
+        var pageIndex: Int
+        @usableFromInline
+        var offset: Int
+
+        @inlinable
+        init(page: Int, offset: Int) {
+            self.pageIndex = page
+            self.offset = offset
+        }
+    }
+}

--- a/Sources/NIOQUIC/Collections/PagedBuffer.swift
+++ b/Sources/NIOQUIC/Collections/PagedBuffer.swift
@@ -141,7 +141,7 @@ enum Page {
     @usableFromInline
     static var maxPageCapacity: Int { 64 }
 
-    /// The first page which holds ``maxPageCapacity`` slots.
+    /// The index of the first page which holds ``maxPageCapacity`` slots.
     @inlinable
     static var firstFixedCapacityPage: Int { 6 }
 

--- a/Sources/NIOQUIC/Collections/PagedBuffer.swift
+++ b/Sources/NIOQUIC/Collections/PagedBuffer.swift
@@ -37,6 +37,7 @@ struct PagedBuffer<Value: ~Copyable>: ~Copyable {
         self._count = 0
     }
 
+    @inlinable
     deinit {
         for page in self._pages {
             page.deallocate()

--- a/Sources/NIOQUIC/Collections/PagedBuffer.swift
+++ b/Sources/NIOQUIC/Collections/PagedBuffer.swift
@@ -78,6 +78,8 @@ struct PagedBuffer<Value: ~Copyable>: ~Copyable {
         if position.pageIndex == self._pages.count {
             let capacity = Page.capacity(ofPage: position.pageIndex)
             self._pages.append(UnsafeMutablePointer<Value>.allocate(capacity: capacity))
+        } else {
+            assert(position.pageIndex == self._pages.count - 1)
         }
 
         self._count &+= 1

--- a/Sources/NIOQUIC/Streams/QUICStreamHandle.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamHandle.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// An opaque handle for a stream on a connection.
+public struct QUICStreamHandle: Hashable, Sendable {
+    @usableFromInline
+    var _index: Index
+    @usableFromInline
+    var _generation: UInt32
+
+    @inlinable
+    var rawValue: UInt64 {
+        // Index asserts it's no greater than a UInt32.
+        let indexBits = UInt64(UInt32(truncatingIfNeeded: self._index.rawValue))
+        return indexBits | UInt64(self._generation) << 32
+    }
+
+    /// The index of the slot the stream occupies in the connection's stream table.
+    @inlinable
+    var index: Index {
+        self._index
+    }
+
+    /// How many times that slot has been reused.
+    @inlinable
+    var generation: UInt32 {
+        self._generation
+    }
+
+    @inlinable
+    init(index: Index, generation: UInt32) {
+        self._index = index
+        self._generation = generation
+    }
+
+    /// Rebuilds a handle which was flattened to its raw bits.
+    @inlinable
+    init(rawValue: UInt64) {
+        self._index = Index(Int(UInt32(truncatingIfNeeded: rawValue)))
+        self._generation = UInt32(truncatingIfNeeded: rawValue >> 32)
+    }
+}
+
+extension QUICStreamHandle {
+    /// The index into ``QUICStreamSlots`` for the handle the stream occupies.
+    @usableFromInline
+    struct Index: Hashable, Comparable, Sendable {
+        /// The slot the stream occupies, as a subscript into storage which is addressed by `Int`.
+        @usableFromInline
+        var rawValue: Int
+
+        @inlinable
+        init(_ rawValue: Int) {
+            assert(rawValue <= Int(UInt32.max))
+            self.rawValue = rawValue
+        }
+
+        /// The first slot a store hands out.
+        @inlinable
+        static var first: Index {
+            Index(0)
+        }
+
+        @inlinable
+        mutating func formNext() {
+            self.rawValue &+= 1
+            assert(self.rawValue <= Int(UInt32.max))
+        }
+
+        @inlinable
+        static func < (lhs: Index, rhs: Index) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+}

--- a/Sources/NIOQUIC/Streams/QUICStreamHandle.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamHandle.swift
@@ -73,7 +73,7 @@ extension QUICStreamHandle {
         }
 
         @inlinable
-        mutating func formNext() {
+        mutating func advance() {
             self.rawValue &+= 1
             assert(self.rawValue <= Int(UInt32.max))
         }

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamSlotRecord.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamSlotRecord.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A bookkeeping record for a slot in ``QUICStreamSlots``.
+@usableFromInline
+struct QUICStreamSlotRecord {
+    @usableFromInline
+    var _generation: UInt32
+    @usableFromInline
+    var _isOccupied: Bool
+
+    /// How many times the slot has been reused.
+    @inlinable
+    var generation: UInt32 { self._generation }
+
+    /// Whether the slot is currently occupied.
+    @inlinable
+    var isOccupied: Bool { self._isOccupied }
+
+    @inlinable
+    init() {
+        self._generation = 0
+        self._isOccupied = false
+    }
+
+    @inlinable
+    func isOccupied(by generation: UInt32) -> Bool {
+        self._isOccupied && self._generation == generation
+    }
+
+    @inlinable
+    mutating func occupy() -> UInt32 {
+        assert(!self._isOccupied)
+        self._isOccupied = true
+        // Wrapping is fine: it takes ~4 billion reuses of one slot, by which point any handle old
+        // enough to alias is long gone.
+        self._generation &+= 1
+        return self._generation
+    }
+
+    @inlinable
+    mutating func vacate() {
+        assert(self._isOccupied)
+        self._isOccupied = false
+    }
+
+    @inlinable
+    mutating func vacateIfOccupied() -> Bool {
+        let wasOccupied = self._isOccupied
+        self._isOccupied = false
+        return wasOccupied
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamSlots.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamSlots.swift
@@ -1,0 +1,178 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Paged storage for stream state, keyed by a ``QUICStreamHandle``.
+///
+/// Values live in a ``PagedBuffer`` so a value's address is stable while its slot is occupied.
+/// When a slot is vacated and later reused its generation is bumped which invalidates any handle
+/// previously used for addressing the same slot.
+@usableFromInline
+struct QUICStreamSlots<Value: ~Copyable>: ~Copyable {
+    @usableFromInline
+    var _storage: PagedBuffer<Value>
+
+    /// A record of each allocated slot, indexed by the `Index` of a `QUICStreamHandle`.
+    @usableFromInline
+    var _slots: [QUICStreamSlotRecord]
+
+    /// The indexes of the vacant slots.
+    @usableFromInline
+    var _freeList: [QUICStreamHandle.Index]
+
+    @usableFromInline
+    var _count: Int
+
+    /// The number of occupied slots.
+    @inlinable
+    var count: Int {
+        self._count
+    }
+
+    /// The number of slots ever allocated.
+    @inlinable
+    var allocated: Int {
+        self._slots.count
+    }
+
+    @inlinable
+    init() {
+        self._storage = PagedBuffer()
+        self._slots = []
+        self._freeList = []
+        self._count = 0
+    }
+
+    deinit {
+        for index in self._slots.indices {
+            if self._slots[index].isOccupied {
+                self._storage.pointer(at: index).deinitialize(count: 1)
+            }
+        }
+    }
+
+    /// Stores `value` in a free slot, returning the handle which addresses it.
+    @inlinable
+    mutating func insert(_ value: consuming Value) -> QUICStreamHandle {
+        let index: QUICStreamHandle.Index
+        let pointer: UnsafeMutablePointer<Value>
+
+        if let reused = self._freeList.popLast() {
+            index = reused
+            pointer = self._storage.pointer(at: index.rawValue)
+        } else {
+            pointer = self._storage.append()
+            index = QUICStreamHandle.Index(self._slots.count)
+            self._slots.append(QUICStreamSlotRecord())
+            // Storage and slots share indexes, double check they align.
+            assert(self._slots.count == self._storage.count)
+        }
+
+        pointer.initialize(to: consume value)
+        let generation = self._slots[index.rawValue].occupy()
+        self._count &+= 1
+
+        return QUICStreamHandle(index: index, generation: generation)
+    }
+
+    /// Runs `body` on the value `handle` addresses, or returns `nil` if it addresses nothing.
+    @inlinable
+    mutating func withValue<Result: ~Copyable>(
+        for handle: QUICStreamHandle,
+        execute body: (_ value: inout Value) -> Result
+    ) -> Result? {
+        if let pointer = self.pointer(for: handle) {
+            return body(&pointer.pointee)
+        } else {
+            return nil
+        }
+    }
+
+    /// Vacates the slot `handle` addresses and returns what was in it.
+    @inlinable
+    @discardableResult
+    mutating func removeValue(for handle: QUICStreamHandle) -> Value? {
+        guard let pointer = self.pointer(for: handle) else { return nil }
+
+        self._slots[handle.index.rawValue].vacate()
+        self._freeList.append(handle.index)
+        self._count &-= 1
+        return pointer.move()
+    }
+
+    /// Vacates every slot, handing each value to `body`.
+    @inlinable
+    mutating func removeAll(_ body: (_ value: consuming Value) -> Void) {
+        for index in self._slots.indices {
+            let wasOccupied = self._slots[index].vacateIfOccupied()
+
+            if wasOccupied {
+                let slotIndex = QUICStreamHandle.Index(index)
+                self._freeList.append(slotIndex)
+                self._count &-= 1
+                body(self._storage.pointer(at: slotIndex.rawValue).move())
+            }
+        }
+    }
+
+    /// Whether `handle` addresses an occupied slot of a matching generation.
+    @inlinable
+    func containsValue(for handle: QUICStreamHandle) -> Bool {
+        if handle.index.rawValue < self._slots.count {
+            return self._slots[handle.index.rawValue].isOccupied(by: handle.generation)
+        } else {
+            return false
+        }
+    }
+
+    /// The handle addressing whatever occupies `index`, or `nil` if that slot is vacant or was
+    /// never allocated.
+    @inlinable
+    func handle(at index: QUICStreamHandle.Index) -> QUICStreamHandle? {
+        guard self._slots.indices.contains(index.rawValue) else { return nil }
+
+        let slot = self._slots[index.rawValue]
+
+        if slot.isOccupied {
+            return QUICStreamHandle(index: index, generation: slot.generation)
+        } else {
+            return nil
+        }
+    }
+
+    /// Resolves `handle` to the value it addresses, or `nil` if it addresses nothing.
+    ///
+    /// Resolving takes no lasting access to the store, so unlike `withValue` a caller may hold
+    /// pointers to several slots at once and work through them together. In exchange the caller
+    /// owns the lifetime: nothing detects a pointer used after its slot was vacated, and if the
+    /// slot has since been reused the pointer addresses its successor.
+    @inlinable
+    func pointer(for handle: QUICStreamHandle) -> UnsafeMutablePointer<Value>? {
+        if self.containsValue(for: handle) {
+            return self._storage.pointer(at: handle.index.rawValue)
+        } else {
+            return nil
+        }
+    }
+
+    /// Resolves `index` to the value it addresses, without a generation check, or `nil` if the slot
+    /// is vacant or out of range.
+    @inlinable
+    func pointer(at index: QUICStreamHandle.Index) -> UnsafeMutablePointer<Value>? {
+        if self._slots.indices.contains(index.rawValue) && self._slots[index.rawValue].isOccupied {
+            return self._storage.pointer(at: index.rawValue)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamSlots.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamSlots.swift
@@ -26,7 +26,7 @@ struct QUICStreamSlots<Value: ~Copyable>: ~Copyable {
     @usableFromInline
     var _slots: [QUICStreamSlotRecord]
 
-    /// The indexes of the vacant slots.
+    /// The indices of the vacant slots.
     @usableFromInline
     var _freeList: [QUICStreamHandle.Index]
 
@@ -75,7 +75,7 @@ struct QUICStreamSlots<Value: ~Copyable>: ~Copyable {
             pointer = self._storage.append()
             index = QUICStreamHandle.Index(self._slots.count)
             self._slots.append(QUICStreamSlotRecord())
-            // Storage and slots share indexes, double check they align.
+            // Storage and slots share indices, double check they align.
             assert(self._slots.count == self._storage.count)
         }
 

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamSlots.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamSlots.swift
@@ -53,6 +53,7 @@ struct QUICStreamSlots<Value: ~Copyable>: ~Copyable {
         self._count = 0
     }
 
+    @inlinable
     deinit {
         for index in self._slots.indices {
             if self._slots[index].isOccupied {

--- a/Tests/NIOQUICTests/Collections/PagedBufferTests.swift
+++ b/Tests/NIOQUICTests/Collections/PagedBufferTests.swift
@@ -1,0 +1,181 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import NIOQUIC
+
+@Suite
+struct PageLayoutTests {
+    @Test
+    func capacitiesDoubleAndThenLevelOff() {
+        #expect((0..<8).map { Page.capacity(ofPage: $0) } == [1, 2, 4, 8, 16, 32, 64, 64])
+        #expect(Page.capacity(ofPage: 100) == 64)
+    }
+
+    @Test
+    func doublingPagesCoverEveryIndexBelowTheFixedCapacityOnes() {
+        let doubling = (0..<Page.firstFixedCapacityPage).map {
+            Page.capacity(ofPage: $0)
+        }
+
+        #expect(doubling.reduce(0, +) == Page.firstFixedCapacityIndex)
+    }
+
+    @Test
+    func positionsAtThePageBoundaries() {
+        let expected: [(index: Int, page: Int, offset: Int)] = [
+            (0, 0, 0),
+            (1, 1, 0),
+            (2, 1, 1),
+            (3, 2, 0),
+            (6, 2, 3),
+            (7, 3, 0),
+            (62, 5, 31),
+            (63, 6, 0),
+            (126, 6, 63),
+            (127, 7, 0),
+            (190, 7, 63),
+            (191, 8, 0),
+        ]
+
+        for (index, page, offset) in expected {
+            let position = Page.position(of: index)
+            #expect(position.pageIndex == page)
+            #expect(position.offset == offset)
+        }
+    }
+
+    @Test
+    func indicesFillPagesInOrderWithoutGapsOrRepeats() {
+        var seen = Set<Int>()
+        var pageCount = 0
+        var filled: [Int: Int] = [:]
+
+        for index in 0..<1000 {
+            let position = Page.position(of: index)
+            #expect(position.offset < Page.capacity(ofPage: position.pageIndex))
+
+            if position.offset == 0 {
+                #expect(position.pageIndex == pageCount)
+                pageCount += 1
+            } else {
+                #expect(position.pageIndex == pageCount - 1)
+            }
+
+            #expect(seen.insert(position.pageIndex * Page.maxPageCapacity + position.offset).inserted)
+            filled[position.pageIndex, default: 0] &+= 1
+        }
+
+        // Every page but the last is full.
+        for page in 0..<(pageCount - 1) {
+            #expect(filled[page] == Page.capacity(ofPage: page))
+        }
+    }
+}
+
+@Suite
+struct PagedBufferTests {
+    @Test
+    func appendingAllocatesAPageOnlyWhenTheLastOneIsFull() {
+        var buffer = PagedBuffer<Int>()
+        #expect(buffer.count == 0)
+        #expect(buffer.pageCount == 0)
+
+        for index in 0..<200 {
+            buffer.append()
+            #expect(buffer.count == index + 1)
+            #expect(buffer.pageCount == Page.position(of: index).pageIndex + 1)
+        }
+    }
+
+    @Test
+    func slotsKeepTheirAddressAndValueAsTheBufferGrows() {
+        var buffer = PagedBuffer<Int>()
+        var pointers: [UnsafeMutablePointer<Int>] = []
+
+        for index in 0..<300 {
+            let slot = buffer.append()
+            slot.initialize(to: index)
+            pointers.append(slot)
+        }
+
+        for index in 0..<300 {
+            #expect(buffer.pointer(at: index) == pointers[index], "slot \(index) moved")
+            #expect(pointers[index].pointee == index)
+        }
+
+        for pointer in pointers {
+            pointer.deinitialize(count: 1)
+        }
+    }
+
+    @Test
+    func slotsOfOnePageAreContiguous() {
+        var buffer = PagedBuffer<Int>()
+        for _ in 0...300 {
+            buffer.append()
+        }
+
+        for index in 0..<300 {
+            let here = Page.position(of: index)
+            let next = Page.position(of: index + 1)
+            if here.pageIndex == next.pageIndex {
+                #expect(buffer.pointer(at: index + 1) == buffer.pointer(at: index) + 1)
+            } else {
+                #expect(buffer.pointer(at: index + 1) == buffer.basePointer(ofPage: next.pageIndex))
+                #expect(here.offset == Page.capacity(ofPage: here.pageIndex) - 1)
+            }
+        }
+    }
+
+    @Test
+    func appendingNilInitializesWholePages() {
+        var buffer = PagedBuffer<Int?>()
+        for _ in 0...200 {
+            buffer.appendNil()
+        }
+
+        // Whole-page operations rely on every slot of an allocated page holding a value, including
+        // the ones past the end which were never handed out.
+        for page in 0..<buffer.pageCount {
+            let base = buffer.basePointer(ofPage: page)
+            for offset in 0..<Page.capacity(ofPage: page) {
+                #expect(base[offset] == nil, "page \(page), slot \(offset)")
+            }
+        }
+
+        buffer.pointer(at: 200).pointee = 7
+        buffer.setAllToNil()
+        #expect(buffer.pointer(at: 200).pointee == nil)
+
+        buffer.deinitializeAll()
+    }
+
+    @Test
+    func appendingNilDoesNotClobberEarlierSlots() {
+        var buffer = PagedBuffer<Int?>()
+        for index in 0..<10 {
+            buffer.appendNil().pointee = index
+        }
+
+        // Slot 3 shares a page with slots the later appends nil-initialized around it.
+        for index in 0..<10 {
+            #expect(buffer.pointer(at: index).pointee == index)
+        }
+
+        #expect(buffer.count == 10)
+        buffer.deinitializeAll()
+    }
+}

--- a/Tests/NIOQUICTests/Streams/QUICStreamHandleTests.swift
+++ b/Tests/NIOQUICTests/Streams/QUICStreamHandleTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import NIOQUIC
+
+@Suite
+struct QUICStreamHandleTests {
+    @Test
+    func indexAndGenerationRoundTrip() {
+        let handle = QUICStreamHandle(index: QUICStreamHandle.Index(3), generation: 7)
+        #expect(handle.index == QUICStreamHandle.Index(3))
+        #expect(handle.generation == 7)
+    }
+
+    @Test
+    func handlesWithDifferentGenerationsDiffer() {
+        let index = QUICStreamHandle.Index(1)
+        let lhs = QUICStreamHandle(index: index, generation: 1)
+        let rhs = QUICStreamHandle(index: index, generation: 2)
+        #expect(lhs != rhs)
+    }
+}

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamSlotsTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamSlotsTests.swift
@@ -1,0 +1,243 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import NIOQUIC
+
+@Suite
+struct QUICStreamSlotsTests {
+    @Test
+    func insertThenAccess() {
+        var store = QUICStreamSlots<Int>()
+        let handle = store.insert(42)
+        #expect(store.count == 1)
+        let value = store.withValue(for: handle) { $0 }
+        #expect(value == 42)
+    }
+
+    @Test
+    func mutateInPlace() {
+        var store = QUICStreamSlots<Int>()
+        let handle = store.insert(1)
+        // Non-overlapping visits to one slot are the ordinary case: only nesting is forbidden.
+        store.withValue(for: handle) { $0 += 1 }
+        store.withValue(for: handle) { $0 += 1 }
+        #expect(store.withValue(for: handle) { $0 } == 3)
+    }
+
+    @Test
+    func removeReturnsValueAndEmptiesSlot() {
+        var store = QUICStreamSlots<Int>()
+        let handle = store.insert(7)
+        #expect(store.removeValue(for: handle) == 7)
+        #expect(store.count == 0)
+        #expect(store.withValue(for: handle) { $0 } == nil)
+    }
+
+    @Test
+    func staleHandleDoesNotResolve() {
+        var store = QUICStreamSlots<Int>()
+        let first = store.insert(1)
+        _ = store.removeValue(for: first)
+        _ = store.insert(2)
+        #expect(store.withValue(for: first) { $0 } == nil)
+        #expect(store.removeValue(for: first) == nil)
+    }
+
+    @Test
+    func growsBeyondOnePage() {
+        var store = QUICStreamSlots<Int>()
+        var handles: [QUICStreamHandle] = []
+        for value in 0..<10 {
+            handles.append(store.insert(value))
+        }
+        #expect(store.count == 10)
+        for (value, handle) in handles.enumerated() {
+            #expect(store.withValue(for: handle) { $0 } == value)
+        }
+    }
+
+    @Test
+    func removeTwiceReturnsNilTheSecondTime() {
+        var store = QUICStreamSlots<Int>()
+        let handle = store.insert(7)
+        #expect(store.removeValue(for: handle) == 7)
+        #expect(store.count == 0)
+
+        // The slot is vacant but its generation still matches, so the absent value is the only
+        // thing standing between a second remove and a double free-list push.
+        #expect(store.removeValue(for: handle) == nil)
+        #expect(store.count == 0)
+
+        // A double push would hand the same index out twice.
+        let first = store.insert(1)
+        let second = store.insert(2)
+        #expect(first.index != second.index)
+        #expect(store.count == 2)
+    }
+
+    @Test
+    func resolvedPointerReadsAndWritesTheValue() {
+        var store = QUICStreamSlots<Int>()
+        let handle = store.insert(1)
+        let pointer = store.pointer(for: handle)!
+        #expect(pointer.pointee == 1)
+
+        pointer.pointee += 41
+        #expect(store.withValue(for: handle) { $0 } == 42)
+    }
+
+    @Test
+    func resolvedPointerSurvivesAPageAllocatingInsert() {
+        var store = QUICStreamSlots<Int>()
+        let first = store.insert(1)
+        // Enough to spill onto later pages, so the inserts below must allocate more of them.
+        for value in 2...4 { _ = store.insert(value) }
+        let pointer = store.pointer(for: first)!
+
+        // Pages are never moved, so growing the store cannot invalidate a pointer into one.
+        for value in 5...12 { _ = store.insert(value) }
+        #expect(store.count == 12)
+        #expect(pointer.pointee == 1)
+
+        pointer.pointee = 99
+        #expect(store.withValue(for: first) { $0 } == 99)
+    }
+
+    @Test
+    func twoResolvedPointersCanBeHeldAndMutatedTogether() {
+        var store = QUICStreamSlots<Int>()
+        let first = store.insert(1)
+        for value in 2...3 { _ = store.insert(value) }
+        let second = store.insert(4)
+
+        // On different pages, so the two pointers are independent of each other's storage.
+        #expect(
+            Page.position(of: first.index.rawValue).pageIndex
+                != Page.position(of: second.index.rawValue).pageIndex
+        )
+
+        // Resolving takes no lasting access to the store, so both pointers can be live at once —
+        // which the closure form cannot express, since it holds the store for the whole visit.
+        let firstPointer = store.pointer(for: first)!
+        let secondPointer = store.pointer(for: second)!
+        firstPointer.pointee += 10
+        secondPointer.pointee += 20
+
+        #expect(firstPointer.pointee == 11)
+        #expect(secondPointer.pointee == 24)
+        #expect(store.withValue(for: first) { $0 } == 11)
+        #expect(store.withValue(for: second) { $0 } == 24)
+    }
+
+    @Test
+    func pointerForStaleHandleIsNil() {
+        var store = QUICStreamSlots<Int>()
+        let first = store.insert(1)
+        _ = store.removeValue(for: first)
+        let vacant = store.pointer(for: first)
+        #expect(vacant == nil)
+
+        _ = store.insert(2)
+        let stale = store.pointer(for: first)
+        #expect(stale == nil)
+    }
+
+    @Test
+    func pointerAtVacantOrOutOfRangeIndexIsNil() {
+        var store = QUICStreamSlots<Int>()
+        let handle = store.insert(1)
+        let occupied = store.pointer(at: handle.index)
+        #expect(occupied?.pointee == 1)
+
+        _ = store.removeValue(for: handle)
+        let vacant = store.pointer(at: handle.index)
+        #expect(vacant == nil)
+
+        let outOfRange = store.pointer(at: .init(999))
+        #expect(outOfRange == nil)
+    }
+
+    @Test
+    func removeAllVisitsEveryValue() {
+        var store = QUICStreamSlots<Int>()
+        for value in 0..<5 { _ = store.insert(value) }
+        var seen: [Int] = []
+        store.removeAll { seen.append($0) }
+        #expect(seen.sorted() == [0, 1, 2, 3, 4])
+        #expect(store.count == 0)
+    }
+
+    @Test
+    func containsValueOnlyForALiveHandle() {
+        var store = QUICStreamSlots<Int>()
+        let first = store.insert(1)
+        // The results are bound before being expected because #expect decomposes a bare call into
+        // a helper which takes the receiver by value, and the store is noncopyable.
+        let liveIsOccupied = store.containsValue(for: first)
+        #expect(liveIsOccupied)
+
+        _ = store.removeValue(for: first)
+        let removedIsOccupied = store.containsValue(for: first)
+        #expect(removedIsOccupied == false)
+
+        // Reusing the slot must not resurrect the handle which used to address it.
+        let second = store.insert(2)
+        let reusedIsOccupied = store.containsValue(for: second)
+        let staleIsOccupied = store.containsValue(for: first)
+        #expect(reusedIsOccupied)
+        #expect(staleIsOccupied == false)
+
+        let outOfRangeIsOccupied = store.containsValue(for: QUICStreamHandle(index: .init(999), generation: 1))
+        #expect(outOfRangeIsOccupied == false)
+    }
+
+    @Test
+    func handleAtIndexMatchesTheIssuedHandle() {
+        var store = QUICStreamSlots<Int>()
+        let handle = store.insert(1)
+        #expect(store.handle(at: handle.index) == handle)
+
+        _ = store.removeValue(for: handle)
+        #expect(store.handle(at: handle.index) == nil)
+
+        // The reused slot reports its own handle, not the one it displaced.
+        let second = store.insert(2)
+        #expect(store.handle(at: handle.index) == second)
+
+        #expect(store.handle(at: .init(999)) == nil)
+    }
+
+    /// The generation counts a slot's reuses rather than its occupants, which is what makes a
+    /// handle from an earlier occupant fail to resolve instead of addressing its successor.
+    @Test
+    func generationsCountSlotReuse() {
+        var store = QUICStreamSlots<Int>()
+        // Zero is never handed out, so an all-zero handle addresses nothing.
+        #expect(store.containsValue(for: QUICStreamHandle(index: .first, generation: 0)) == false)
+
+        let first = store.insert(1)
+        _ = store.removeValue(for: first)
+
+        let second = store.insert(2)
+        #expect(second.index == first.index)
+        #expect(second.generation == first.generation &+ 1)
+
+        _ = store.removeValue(for: second)
+        let third = store.insert(3)
+        #expect(third.index == first.index)
+        #expect(third.generation == first.generation &+ 2)
+    }
+}


### PR DESCRIPTION
Motivation:

Having a per-stream Channel is expensive unless the stream is long-lived. In order to get great performance we need an alternative API surface that is significantly cheaper.

The first phase of these changes will put together a table of per-stream state for a connection. The table has slots for transport state (i.e. the underlying QUIC stack) and application state (i.e. state stored on behalf of the consumer). Both states are `~Copyable`.

Each state store is backed by a `PagedBuffer` which allocates a buffer pointer for N values in pages. Pagres aren't deallocated until the buffer is destroyed, so the address of a value is stable throughout its lifetime.

Two stores sit on top of the buffer: `QUICStreamSlots` and another type for application state (not added in this PR). `QUICStreamSlots` provides a handle when a value is inserted which is invalidated when the value is removed (so a handle cannot access data it doesn't not own). The storage is dense: slots can be reused, and lookups are fast (as there is no hashing).

Modifications:

- Add `PagedBuffer`, discontiguous index-addressed storage whose pages are allocated once and never moved
- Add `Page` which describes how big a page is, and how an index into the paged buffer maps to a page and the position on that page.
- Add `QUICStreamHandle`, an index into the paged buffer, and a generation
- Add `QUICStreamSlotRecord`, recording the occupancy and generation of a slot
- Add `QUICStreamSlots`, which is the generation-checked slot storage backed by a `PagedBuffer`.

Result:

A few key pieces of infra are in place.