### PR TITLE
Rename isWriteClosed to isSendClosed

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -1439,7 +1439,7 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
             // `shutdownStream` handles the QUIC-level signaling as needed,
             // e.g. STOP_SENDING for `.read`, RESET_STREAM for `.write`.
             self.shutdownStream(direction: .read, applicationErrorCode: nil)
-            if self.streamStateMachine.isWriteClosed {
+            if self.streamStateMachine.isSendClosed {
                 self.log("Input and output for stream are now closed, stream will be queued up for closure")
             }
             promise?.succeed()
@@ -1491,7 +1491,7 @@ extension QUICChannelStreamHandler: Channel, ChannelCore {
                 direction: .read,
                 applicationErrorCode: event.code
             )
-            if self.streamStateMachine.isWriteClosed {
+            if self.streamStateMachine.isSendClosed {
                 // Both sides now closed
                 self.closeStream(mode: .closeOnly, error: nil, promise: promise)
             } else {

--- a/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICStreamStateMachine.swift
@@ -205,7 +205,7 @@ struct QUICStreamStateMachine: ~Copyable {
     }
 
     /// Returns `true` if the write side is closed (terminal, including both clean finish and reset).
-    var isWriteClosed: Bool {
+    var isSendClosed: Bool {
         switch self.state {
         case .connected(let connected):
             switch connected.streamState {
@@ -291,7 +291,7 @@ struct QUICStreamStateMachine: ~Copyable {
 
     /// Returns `true` if the stream is connected and the write side is open.
     var canWrite: Bool {
-        self.isConnected && !self.isWriteClosed
+        self.isConnected && !self.isSendClosed
     }
 
     /// Returns `true` if the receive side is closed (terminal, reset, stream closed,

--- a/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
+++ b/Tests/NIOQUICTests/QUICStreamStateMachineTests.swift
@@ -624,11 +624,11 @@ struct QUICStreamStateMachineTests {
         let sm = QUICStreamStateMachine()
         let isConnected = sm.isConnected
         let isFullyClosed = sm.isFullyClosed
-        let isWriteClosed = sm.isWriteClosed
+        let isSendClosed = sm.isSendClosed
         let hasReceivedFin = sm.hasReceivedFin
         #expect(!isConnected)
         #expect(!isFullyClosed)
-        #expect(!isWriteClosed)
+        #expect(!isSendClosed)
         #expect(!hasReceivedFin)
     }
 
@@ -728,16 +728,16 @@ struct QUICStreamStateMachineTests {
         _ = try sm.receiveData()
 
         _ = try sm.sendFin()
-        var isWriteClosed = sm.isWriteClosed
-        #expect(!isWriteClosed)
+        var isSendClosed = sm.isSendClosed
+        #expect(!isSendClosed)
 
         _ = try sm.receiveFin(finalSize: 100)
         let hasReceivedFin = sm.hasReceivedFin
         #expect(hasReceivedFin)
 
         _ = try sm.acknowledgeAllData()
-        isWriteClosed = sm.isWriteClosed
-        #expect(isWriteClosed)
+        isSendClosed = sm.isSendClosed
+        #expect(isSendClosed)
 
         _ = try sm.applicationRead()
 
@@ -857,8 +857,8 @@ struct QUICStreamStateMachineTests {
         var sm = QUICStreamStateMachine()
         _ = sm.streamConnected(direction: .receiveOnly)
 
-        let isWriteClosed = sm.isWriteClosed
-        #expect(isWriteClosed)
+        let isSendClosed = sm.isSendClosed
+        #expect(isSendClosed)
     }
 
     // MARK: - Direction Errors


### PR DESCRIPTION
Motivation:

The state machine tracks send state, so this is a little more consistent. Discussed in #89.

Modifications:

Rename

Result:

More consistency