### PR TITLE
Add per-stream storage for a consumer's state

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let swiftSettings: [SwiftSetting] =
         .enableUpcomingFeature("ExistentialAny"),
         .enableUpcomingFeature("StrictConcurrency"),
         .enableExperimentalFeature("AnyAppleOSAvailability"),
+        .enableExperimentalFeature("Lifetimes"),
     ]
 
 let package = Package(

--- a/Sources/NIOQUIC/Collections/PagedBuffer.swift
+++ b/Sources/NIOQUIC/Collections/PagedBuffer.swift
@@ -97,7 +97,7 @@ struct PagedBuffer<Value: ~Copyable>: ~Copyable {
     }
 }
 
-extension PagedBuffer where Value: ExpressibleByNilLiteral {
+extension PagedBuffer where Value: ExpressibleByNilLiteral & ~Copyable {
     /// Grows the buffer by one `nil`-initialized slot and returns it.
     ///
     /// The rest of any page this allocates is `nil`-initialized too: the whole-page operations
@@ -109,10 +109,10 @@ extension PagedBuffer where Value: ExpressibleByNilLiteral {
         let pointer = self.append()
 
         if self._pages.count > allocated {
-            self._pages[allocated].initialize(
-                repeating: nil,
-                count: Page.capacity(ofPage: allocated)
-            )
+            let page = self._pages[allocated]
+            for offset in 0..<Page.capacity(ofPage: allocated) {
+                page.advanced(by: offset).initialize(to: nil)
+            }
         }
 
         return pointer
@@ -121,8 +121,11 @@ extension PagedBuffer where Value: ExpressibleByNilLiteral {
     /// Sets every slot to `nil`.
     @inlinable
     func setAllToNil() {
-        for page in 0..<self._pages.count {
-            self._pages[page].update(repeating: nil, count: Page.capacity(ofPage: page))
+        for index in self._pages.indices {
+            let page = self._pages[index]
+            for offset in 0..<Page.capacity(ofPage: index) {
+                page.advanced(by: offset).pointee = nil
+            }
         }
     }
 

--- a/Sources/NIOQUIC/Streams/QUICStreamConsumer.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamConsumer.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Consumes streams for a single QUIC connection.
+@available(anyAppleOS 26, *)
+public protocol QUICStreamConsumer: SendableMetatype, ~Copyable {
+    /// Per-stream state stored by the connection.
+    associatedtype StreamState: ~Copyable
+}

--- a/Sources/NIOQUIC/Streams/QUICStreamConsumer.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamConsumer.swift
@@ -16,5 +16,9 @@
 @available(anyAppleOS 26, *)
 public protocol QUICStreamConsumer: SendableMetatype, ~Copyable {
     /// Per-stream state stored by the connection.
+    #if swift(>=6.4)
     associatedtype StreamState: ~Copyable
+    #else  // 6.3 doesn't support ~Copyable associatedtypes
+    associatedtype StreamState
+    #endif
 }

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamConsumerStates.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamConsumerStates.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Storage for the consumer's per-stream state.
+///
+/// The indexing space is shared with a ``QUICStreamSlots`` instance so state is addressed via a
+/// ``QUICStreamHandle/Index``. There is *no generation checking* here; this should be done via
+/// ``QUICStreamSlots`` prior to accessing state here.
+@usableFromInline
+struct QUICStreamConsumerStates<State: ~Copyable>: ~Copyable {
+    @usableFromInline
+    var _storage: PagedBuffer<State?>
+
+    @inlinable
+    init() {
+        self._storage = PagedBuffer()
+    }
+
+    deinit {
+        self._storage.deinitializeAll()
+    }
+
+    /// The pointer for the value at `index`, growing the storage by one slot if `index` is a slot
+    /// the slots have only just allocated.
+    @inlinable
+    mutating func reserve(at index: QUICStreamHandle.Index) -> UnsafeMutablePointer<State?> {
+        if index.rawValue < self._storage.count {
+            return self._storage.pointer(at: index.rawValue)
+        } else {
+            return self._storage.appendNil()
+        }
+    }
+
+    /// The pointer for `index`, which must have been reserved.
+    @inlinable
+    func pointer(at index: QUICStreamHandle.Index) -> UnsafeMutablePointer<State?> {
+        self._storage.pointer(at: index.rawValue)
+    }
+
+    /// Destroys the state at the given `index`, if it has any.
+    @inlinable
+    func removeValue(at index: QUICStreamHandle.Index) {
+        self.pointer(at: index).pointee = nil
+    }
+
+    /// Removes all values from the store, keeping capacity.
+    @inlinable
+    func removeAll() {
+        self._storage.setAllToNil()
+    }
+}


### PR DESCRIPTION
Motivation:

The connection table will need to store the per stream consumer state. This will be provided by the `QUICStreamConsumer` and stored in `QUICStreamConsumerStates`.

Modifications:

- Add `QUICStreamConsumer`, this will be the protocol that users implement. At the moment it only provides the `associatedtype` for the state it provdes and isn't actually used yet.
- Make the `nil`-handling extension on `PagedBuffer` handle `~Copyable` values (I missed doing that previously)
- Add "Lifetimes" to the manifest (not user here, but makes the next PR a little smaller)

Result:

Not much changes beyond making the next PR a little smaller