### PR TITLE
Add QUICStreamTable

### DIFF
--- a/Sources/NIOQUIC/Streams/QUICStream.swift
+++ b/Sources/NIOQUIC/Streams/QUICStream.swift
@@ -1,0 +1,192 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOQUICHelpers
+
+/// A view over a QUIC stream as presented to a ``QUICStreamConsumer``.
+@available(anyAppleOS 26, *)
+public struct QUICStream<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyable, ~Escapable {
+    /// The table this stream's slot belongs to.
+    @usableFromInline
+    let table: QUICStreamTable<Consumer>
+
+    /// The transport state for the stream.
+    @usableFromInline
+    let transport: UnsafeMutablePointer<QUICStreamTransportState>
+
+    /// An opaque handle identifying this stream.
+    ///
+    /// The handle is invalidated when the stream is closed.
+    public let handle: QUICStreamHandle
+
+    // 'immortal' because the lifetime really depends on the lifetime of the 'transport' pointer
+    // which isn't `~Escapable`. The lifetime of the 'table' is a superset of the lifetime of the
+    // stream so using it as the bound also isn't valid. Instead, the stream is immortal for the
+    // lifetime of its lexical scope. See also the note in 'QUICStreamTable.withStream' about
+    // "borrowing" the stream more than once.
+    @inlinable
+    @_lifetime(immortal)
+    init(
+        table: QUICStreamTable<Consumer>,
+        transport: UnsafeMutablePointer<QUICStreamTransportState>,
+        handle: QUICStreamHandle
+    ) {
+        self.table = table
+        self.transport = transport
+        self.handle = handle
+    }
+
+    /// The ID the stack assigned, or `nil` if it hasn't been assigned one yet.
+    @inlinable
+    public var id: QUICStreamID? {
+        self.transport.pointee.core.id
+    }
+
+    /// Whether more data can be written to the stream.
+    @inlinable
+    public var isSendOpen: Bool {
+        self.transport.pointee.core.isSendOpen
+    }
+
+    /// Whether more data can be read from the stream.
+    @inlinable
+    public var isReceiveOpen: Bool {
+        self.transport.pointee.core.isReceiveOpen
+    }
+}
+
+// MARK: - Reading
+
+@available(anyAppleOS 26, *)
+extension QUICStream where Consumer: ~Copyable {
+    /// Hands the stream's inbound bytes to `body`, one chunk of contiguous bytes at a time.
+    ///
+    /// `body` must return the number of bytes it consumed from the bytes it was shown. Bytes
+    /// it leaves behind are held for the stream and shown in the next read call.
+    ///
+    /// Once the peer has finished sending data, and all bytes have been consumed, then read
+    /// will return ``QUICStreamReadOutcome/endOfStream(_:)`` each time.
+    ///
+    /// - Parameters:
+    ///   - maxBytes: The maximum number of bytes to read from the network stack in this call. Note
+    ///     that this isn't a limit on the total number of bytes passed to the span passed to
+    ///     `body`; the actual byte count may differ so you should consider this a hint.
+    ///   - minContiguousBytes: The shortest run of contiguous bytes to hand to `body`. Data is
+    ///     coalesced to reach it (which may incur additional copies and allocations); `1` never
+    ///     coalesces (and therefore does not incur additional copies and allocations).
+    ///   - body: Called with a chunk of contiguous bytes, returning how many of them it consumed.
+    ///     May be called multiple times.
+    /// - Returns: What was handed over, and whether the peer's data is now exhausted.
+    @inlinable
+    public mutating func read(
+        maxBytes: Int,
+        minContiguousBytes: Int = 1,
+        _ body: (_ span: borrowing RawSpan) -> Int
+    ) -> QUICStreamReadOutcome {
+        self.transport.pointee.core.read(maxBytes: maxBytes, minContiguous: minContiguousBytes, body)
+    }
+
+    /// Appends the stream's inbound bytes to `buffer`.
+    ///
+    /// - Parameters:
+    ///   - maxBytes: The most bytes to take out of the stack.
+    ///   - buffer: The buffer to append to.
+    /// - Returns: What was appended, and whether the peer's data is now exhausted.
+    @inlinable
+    public mutating func read(
+        maxBytes: Int,
+        into buffer: inout ByteBuffer
+    ) -> QUICStreamReadOutcome {
+        self.transport.pointee.core.read(maxBytes: maxBytes, minContiguous: 1) { bytes in
+            buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: bytes.byteCount) { target in
+                bytes.withUnsafeBytes { target.copyMemory(from: $0) }
+                return bytes.byteCount
+            }
+        }
+    }
+}
+
+// MARK: - Writing
+
+@available(anyAppleOS 26, *)
+extension QUICStream where Consumer: ~Copyable {
+    /// How many bytes the stream will accept right now.
+    ///
+    /// This is advisory: a write past this is queued in the stack. Writing more than this delays
+    /// the next ``QUICStreamEvents/writable`` event.
+    @inlinable
+    public var writableBytes: Int {
+        self.transport.pointee.core.writableBytes
+    }
+
+    /// Enqueue data to send at the next ``flush(fin:)``.
+    ///
+    /// - Parameters:
+    ///   - count: The number of writable bytes to hand to `body`.
+    ///   - body: Handed `count` writable bytes, returning how many it wrote.
+    @inlinable
+    public mutating func withWritableSpan(
+        count: Int,
+        _ body: (_ span: inout MutableRawSpan) -> Int
+    ) {
+        self.transport.pointee.core.withWritableSpan(count: count, body)
+    }
+
+    /// Enqueue data to send at the next ``flush(fin:)``.
+    ///
+    /// - Parameter buffer: The bytes to write.
+    @inlinable
+    public mutating func write(_ buffer: ByteBuffer) {
+        self.transport.pointee.core.write(buffer)
+    }
+
+    /// Write any queued data to the network.
+    ///
+    /// - Parameter fin: Whether to finish the send side.
+    /// - Throws: If the send side can't write the queued data. For example, the stream is already
+    ///   closed, or FIN has already been sent.
+    @inlinable
+    public mutating func flush(fin: Bool = false) throws {
+        self.table.markOutputPending()
+        try self.transport.pointee.core.flush(fin: fin)
+    }
+}
+
+// MARK: - Closing
+
+@available(anyAppleOS 26, *)
+extension QUICStream where Consumer: ~Copyable {
+    /// Resets the send side, telling the peer to discard what it has of this stream.
+    ///
+    /// - Parameter code: The application error code to send in RESET\_STREAM.
+    @inlinable
+    public mutating func sendResetStream(code: QUICApplicationErrorCode) {
+        self.table.markOutputPending()
+        self.transport.pointee.core.sendResetStream(code: code)
+    }
+
+    /// Closes the receive side, telling the peer to stop sending on this stream.
+    ///
+    /// - Parameter code: The application error code to send in STOP\_SENDING.
+    @inlinable
+    public mutating func sendStopSending(code: QUICApplicationErrorCode) {
+        self.table.markOutputPending()
+        self.transport.pointee.core.sendStopSending(code: code)
+    }
+}
+
+@available(anyAppleOS 26, *)
+@available(*, unavailable)
+extension QUICStream: Sendable where Consumer: ~Copyable {}

--- a/Sources/NIOQUIC/Streams/QUICStream.swift
+++ b/Sources/NIOQUIC/Streams/QUICStream.swift
@@ -80,9 +80,6 @@ extension QUICStream where Consumer: ~Copyable {
     /// will return ``QUICStreamReadOutcome/endOfStream(_:)`` each time.
     ///
     /// - Parameters:
-    ///   - maxBytes: The maximum number of bytes to read from the network stack in this call. Note
-    ///     that this isn't a limit on the total number of bytes passed to the span passed to
-    ///     `body`; the actual byte count may differ so you should consider this a hint.
     ///   - minContiguousBytes: The shortest run of contiguous bytes to hand to `body`. Data is
     ///     coalesced to reach it (which may incur additional copies and allocations); `1` never
     ///     coalesces (and therefore does not incur additional copies and allocations).
@@ -91,25 +88,20 @@ extension QUICStream where Consumer: ~Copyable {
     /// - Returns: What was handed over, and whether the peer's data is now exhausted.
     @inlinable
     public mutating func read(
-        maxBytes: Int,
         minContiguousBytes: Int = 1,
         _ body: (_ span: borrowing RawSpan) -> Int
     ) -> QUICStreamReadOutcome {
-        self.transport.pointee.core.read(maxBytes: maxBytes, minContiguous: minContiguousBytes, body)
+        self.transport.pointee.core.read(minContiguous: minContiguousBytes, body)
     }
 
     /// Appends the stream's inbound bytes to `buffer`.
     ///
     /// - Parameters:
-    ///   - maxBytes: The most bytes to take out of the stack.
     ///   - buffer: The buffer to append to.
     /// - Returns: What was appended, and whether the peer's data is now exhausted.
     @inlinable
-    public mutating func read(
-        maxBytes: Int,
-        into buffer: inout ByteBuffer
-    ) -> QUICStreamReadOutcome {
-        self.transport.pointee.core.read(maxBytes: maxBytes, minContiguous: 1) { bytes in
+    public mutating func read(into buffer: inout ByteBuffer) -> QUICStreamReadOutcome {
+        self.transport.pointee.core.read(minContiguous: 1) { bytes in
             buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: bytes.byteCount) { target in
                 bytes.withUnsafeBytes { target.copyMemory(from: $0) }
                 return bytes.byteCount

--- a/Sources/NIOQUIC/Streams/QUICStreamEvents.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamEvents.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A set of events which have happened to a stream since it was last visited.
+public struct QUICStreamEvents: OptionSet, Hashable, Sendable {
+    public var rawValue: UInt8
+
+    @inlinable
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    /// The stream was opened and assigned an ID.
+    @inlinable
+    public static var opened: Self {
+        Self(rawValue: 1 << 0)
+    }
+
+    /// The stream is readable.
+    ///
+    /// This indicates whether you should attempt to read data from the stream. Note that this isn't
+    /// a guarantee that bytes are available, only a hint that they might be. While this is a hint,
+    /// the outcome of the read isn't: it should be taken as the source of truth.
+    ///
+    /// Use this to gate a read during a visit in order to avoid an unnecessary trip through the
+    /// stack. You only need to check it once per visit and may then read from the stream as many
+    /// times as is necessary.
+    @inlinable
+    public static var readable: Self {
+        Self(rawValue: 1 << 1)
+    }
+
+    /// Indicates that writes can make progress.
+    ///
+    /// This indicates that you may start writing _again_: it isn't a precondition to start writing.
+    /// In other words: a newly opened stream is implicitly writable.
+    ///
+    /// Using this can be helpful for consumers which stop writing when ``QUICStream/writableBytes``
+    /// is zero.
+    @inlinable
+    public static var writable: Self {
+        Self(rawValue: 1 << 2)
+    }
+
+    /// The peer sent RESET\_STREAM.
+    @inlinable
+    public static var reset: Self {
+        Self(rawValue: 1 << 3)
+    }
+
+    /// The peer sent STOP\_SENDING.
+    @inlinable
+    public static var stopSending: Self {
+        Self(rawValue: 1 << 4)
+    }
+
+    /// The stream is closed, terminal.
+    @inlinable
+    public static var closed: Self {
+        Self(rawValue: 1 << 5)
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamConsumerStates.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamConsumerStates.swift
@@ -27,6 +27,7 @@ struct QUICStreamConsumerStates<State: ~Copyable>: ~Copyable {
         self._storage = PagedBuffer()
     }
 
+    @inlinable
     deinit {
         self._storage.deinitializeAll()
     }

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
@@ -209,41 +209,39 @@ extension QUICStreamCore {
     /// closed.
     ///
     /// - Parameters:
-    ///   - maxBytes: The maximum number of bytes to read.
     ///   - minContiguous: The shortest run of contiguous bytes to hand to `body`. Data is
-    ///     coalesced to reach it; `1` never coalesces. A run can still be shorter than
-    ///     `minContiguous` if `maxBytes` is smaller.
+    ///     coalesced to reach it; `1` never coalesces. If there aren't enough bytes available then
+    ///     and the peer hasn't yet sent FIN then `body` won't be called. Note that the when the
+    ///     peer sends FIN then `body` may be called with fewer bytes than `minContiguous`.
     ///   - body: Provided a contiguous block of bytes received from the remote peer, returning how
     ///     many of them it consumed. May be called more then once for each call to `read`.
     /// - Returns: The outcome of the read.
     @usableFromInline
     mutating func read(
-        maxBytes: Int,
         minContiguous: Int,
         _ body: (_ span: borrowing RawSpan) -> Int
     ) -> QUICStreamReadOutcome {
-        let contiguous = min(max(minContiguous, 1), maxBytes)
+        let contiguous = max(minContiguous, 1)
         var totalDelivered = 0
         var totalRead = 0
 
         while true {
-            var askedForBytes = false
-            var bytesRead = 0
+            let askedForBytes: Bool
+            let bytesRead: Int
 
             switch self.state.attemptRead() {
             case .proceedWithRead:
-                let bytesToRead = maxBytes &- totalRead &- self.undeliveredReads.unclaimedLength()
-                if bytesToRead > 0 {
-                    askedForBytes = true
-                    bytesRead = self.fillUndeliveredReads(maxBytes: bytesToRead)
-                    totalRead &+= bytesRead
-                }
+                askedForBytes = true
+                bytesRead = self.fillUndeliveredReads()
+                totalRead &+= bytesRead
 
             case .doNotRead:
-                ()  // Receive side closed: only what is already held here can still be handed over.
+                // Receive side closed: only what is already held here can still be handed over.
+                askedForBytes = false
+                bytesRead = 0
             }
 
-            // Delive the bytes.
+            // Deliver the bytes.
             totalDelivered &+= self.deliver(minContiguous: contiguous, body)
 
             if askedForBytes && bytesRead == 0 {
@@ -297,8 +295,8 @@ extension QUICStreamCore {
     /// Pulls and stores up to `maxBytes` data.
     ///
     /// - Returns: The number of bytes the stack handed over.
-    private mutating func fillUndeliveredReads(maxBytes: Int) -> Int {
-        var pulled = self.receiveFromStack(maxBytes: maxBytes)
+    private mutating func fillUndeliveredReads() -> Int {
+        var pulled = self.receiveFromStack()
         var bytesStored = 0
 
         while var frame = pulled.popFirst() {
@@ -341,7 +339,7 @@ extension QUICStreamCore {
         return bytesStored
     }
 
-    private func receiveFromStack(maxBytes: Int) -> FrameArray {
+    private func receiveFromStack() -> FrameArray {
         let received: FrameArray?
 
         switch self.handle.invokeReceiveStreamData() {
@@ -350,7 +348,7 @@ extension QUICStreamCore {
                 received = try linkage.invokeReceiveStreamData(
                     self.reference,
                     minimumBytes: 1,
-                    maximumBytes: maxBytes
+                    maximumBytes: .max
                 )
             } catch {
                 // Nothing readable: the stack reports what went wrong as a disconnect event

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
@@ -73,6 +73,7 @@ struct QUICStreamCore: ~Copyable {
     /// Creates a stream core which is not yet wired to the stack.
     ///
     /// - Parameter id: The stream ID, if the stack has already assigned one.
+    @usableFromInline
     init(id: QUICStreamID?) {
         self.id = id
         self.state = QUICStreamStateMachine()

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
@@ -1,0 +1,261 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import DequeModule
+import NIOQUICHelpers
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+@available(anyAppleOS 26, *)
+@usableFromInline
+final class QUICStreamTable<Consumer: QUICStreamConsumer & ~Copyable> {
+    /// The transport state for each stream.
+    @usableFromInline
+    var _transportStates: QUICStreamSlots<QUICStreamTransportState>
+
+    /// The consumer's state for each stream.
+    @usableFromInline
+    var _consumerStates: QUICStreamConsumerStates<Consumer.StreamState>
+
+    /// The streams which are ready to visit.
+    ///
+    /// Each stream appears at most once.
+    @usableFromInline
+    var _ready: Deque<QUICStreamHandle>
+
+    /// Stream handles keyed by their ID.
+    @usableFromInline
+    var _byID: QUICStreamIDDictionary<QUICStreamHandle>
+
+    /// Whether there is any pending output that needs to be drained by the connection.
+    @usableFromInline
+    var _outputPending: Bool
+
+    /// The role of the local peer.
+    let role: Role
+
+    /// Context for the `SwiftNetwork` stack.
+    let context: NetworkContext
+
+    init(role: Role, context: NetworkContext) {
+        self._transportStates = QUICStreamSlots()
+        self._consumerStates = QUICStreamConsumerStates()
+        self._ready = []
+        self._byID = QUICStreamIDDictionary()
+        self._outputPending = false
+        self.role = role
+        self.context = context
+    }
+
+    deinit {
+        // Failing to close may lead to `Frame`'s not being finalized (which will trap).
+        self.forceCloseAll(error: nil)
+    }
+
+    /// The number of streams in the table.
+    @inlinable
+    var count: Int {
+        self._transportStates.count
+    }
+
+    /// Whether a drain would have anything to report.
+    @inlinable
+    var hasPendingWork: Bool {
+        !self._ready.isEmpty
+    }
+}
+
+// MARK: - Bookkeeping
+
+@available(anyAppleOS 26, *)
+extension QUICStreamTable where Consumer: ~Copyable {
+    /// Marks the stream for the given handle as ready, enqueueing it if it isn't already enqueued.
+    @inlinable
+    func markReady(handle: QUICStreamHandle, events: QUICStreamEvents) {
+        if let transport = self._transportStates.pointer(for: handle) {
+            self._markReady(handle: handle, transport: transport, events: events)
+        }  // else: handle was invalid; no-op.
+    }
+
+    @inlinable
+    func _markReady(
+        handle: QUICStreamHandle,
+        transport: UnsafeMutablePointer<QUICStreamTransportState>,
+        events: QUICStreamEvents
+    ) {
+        let hadNoEvents = transport.pointee.events.isEmpty
+        transport.pointee.events.formUnion(events)
+
+        if hadNoEvents && !events.isEmpty {
+            self._ready.append(handle)
+        }
+    }
+
+    /// Records that a stream handed something to the stack which has to be flushed.
+    @inlinable
+    func markOutputPending() {
+        self._outputPending = true
+    }
+
+    /// Returns whether there is output pending, and clears the pending output state.
+    func clearOutputPending() -> Bool {
+        let hadOutputPending = self._outputPending
+        self._outputPending = false
+        return hadOutputPending
+    }
+
+    /// Adds a slot for a stream, with the consumer's state for it.
+    ///
+    /// - Parameters:
+    ///   - id: The stream ID, if the stack has already assigned one.
+    ///   - state: The consumer's state for the stream. Streams which don't provide state here
+    ///     will make state via ``QUICStreamConsumer/makeStreamState(_:)`` before their first visit.
+    @inlinable
+    func insertSlot(
+        id: QUICStreamID?,
+        state: consuming Consumer.StreamState?
+    ) -> QUICStreamHandle {
+        let transportState = QUICStreamTransportState(core: QUICStreamCore(id: id))
+        let handle = self._transportStates.insert(transportState)
+        let consumerStatePointer = self._consumerStates.reserve(at: handle.index)
+
+        if let state {
+            consumerStatePointer.pointee = consume state
+            self._transportStates.withValue(for: handle) { $0.hasState = true }
+        }  // else remote peer opened the stream, state is created before first visiting the stream.
+
+        if let id {
+            self._byID[id] = handle
+        }  // else local peer opened the stream, id is assigned later.
+
+        return handle
+    }
+
+    /// Records the ID the stack assigned, indexes it, and connects the stream's state machine.
+    @usableFromInline
+    func assignID(_ id: QUICStreamID, to handle: QUICStreamHandle) {
+        guard let pointer = self._transportStates.pointer(for: handle) else { return }
+
+        switch pointer.pointee.core.connected(id: id, direction: self.direction(of: id)) {
+        case .activateStream:
+            ()
+        case .ignoreAlreadyConnected:
+            ()  // A second connected event for the same stream; the ID cannot have changed.
+        case .ignoreAlreadyClosed:
+            ()  // Closed while the event was in flight.
+        }
+
+        self._byID.updateValue(handle, forID: id)
+    }
+
+    /// The handle for a stream ID, or `nil` if no live stream has it.
+    @usableFromInline
+    func handle(forID id: QUICStreamID) -> QUICStreamHandle? {
+        if let handle = self._byID[id], self._transportStates.containsValue(for: handle) {
+            return handle
+        } else {
+            return nil
+        }
+    }
+
+    /// Runs `body` on a stream and the consumer's state for it.
+    ///
+    /// > Important: You **MUST NOT** call `withStream` re-entrantly for the same handle. Doing so
+    /// > will result in a runtime trap.
+    ///
+    /// - Parameters:
+    ///   - handle: The handle for the stream to access.
+    ///   - body: Called with the stream and state for the stream aliased by the given handle.
+    ///     Called at most once. The closure won't be called if the handle doesn't alias an open
+    ///     stream.
+    /// - Returns: the result of `body`, or `nil` if the stream wasn't open.
+    @inlinable
+    func withStream<Result: ~Copyable>(
+        handle: QUICStreamHandle,
+        execute body: (
+            _ stream: inout QUICStream<Consumer>,
+            _ state: inout Consumer.StreamState
+        ) -> Result
+    ) -> Result? {
+        guard let pointer = self._transportStates.pointer(for: handle) else { return nil }
+        guard pointer.pointee.hasState else { return nil }
+
+        // The slot is "borrowed" for the duration of this call. Attempting to re-entrantly call
+        // `withStream` will trap here. Doing this would be very surprising user behavior (they
+        // are already accessing the stream in the same lexical scope) and potentially unsafe as
+        // both streams would be accessing the same underlying memory for the transport and consumer
+        // state.
+        pointer.pointee.beginBorrow()
+        defer { pointer.pointee.endBorrow() }
+
+        let consumerState = self._consumerStates.pointer(at: handle.index)
+        var stream = QUICStream<Consumer>(table: self, transport: pointer, handle: handle)
+        return body(&stream, &consumerState.pointee!)  // checked above
+    }
+
+    /// The direction of a stream from its ID and this endpoint's role.
+    private func direction(of id: QUICStreamID) -> QUICStreamDirection {
+        switch id.type {
+        case .clientInitiatedBidirectional, .serverInitiatedBidirectional:
+            return .bidirectional
+        case .clientInitiatedUnidirectional:
+            return self.role == .client ? .sendOnly : .receiveOnly
+        case .serverInitiatedUnidirectional:
+            return self.role == .server ? .sendOnly : .receiveOnly
+        }
+    }
+}
+
+// MARK: - Slot teardown
+
+@available(anyAppleOS 26, *)
+extension QUICStreamTable where Consumer: ~Copyable {
+    /// Closes and vacates a slot, without a visit.
+    @inlinable
+    func vacateSlot(_ handle: QUICStreamHandle) {
+        // Note: this is helpful for a stream which never reached the stack, the consumer wasn't
+        // told about it so there's nothing to report.
+        self._remove(handle: handle)
+    }
+
+    /// Closes a slot's stream core and vacates the slot.
+    ///
+    /// - Parameter handle: The handle the visit was made with.
+    @usableFromInline
+    func _remove(handle: QUICStreamHandle) {
+        guard let transport = self._transportStates.pointer(for: handle) else { return }
+
+        if let id = transport.pointee.core.id {
+            let removed = self._byID.removeValue(forID: id)
+            assert(removed == handle)
+        }
+
+        // Close in case it isn't already (close is idempotent).
+        let error = transport.pointee.disconnectError
+        transport.pointee.core.close(error: error)
+
+        self._transportStates.removeValue(for: handle)
+        self._consumerStates.removeValue(at: handle.index)
+    }
+
+    /// Closes and vacates every remaining slot, without a visit.
+    private func forceCloseAll(error: NetworkError?) {
+        self._transportStates.removeAll { transport in
+            var transport = consume transport
+            transport.core.close(error: error)
+        }
+        self._consumerStates.removeAll()
+        self._ready.removeAll(keepingCapacity: true)
+        self._byID.removeAll()
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTransportState.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTransportState.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+/// The state of a stream recorded by the transport.
+@available(anyAppleOS 26, *)
+@usableFromInline
+struct QUICStreamTransportState: ~Copyable {
+    /// Events which have occurred on the stream since the last visit.
+    @usableFromInline
+    var events: QUICStreamEvents
+
+    /// Whether the consumer's state for this stream has been created.
+    ///
+    /// This is the same as checking whether a value in the ``QUICStreamConsumerStates`` exists
+    /// for the stream but stored inline as it's a little cheaper.
+    @usableFromInline
+    var hasState: Bool
+
+    @usableFromInline
+    var core: QUICStreamCore
+
+    /// Why the stream closed, as the consumer sees it.
+    @usableFromInline
+    var closeError: (any Error)?
+
+    /// The application error code sent by the peer in a RESET\_STREAM frame.
+    @usableFromInline
+    var resetCode: QUICApplicationErrorCode?
+
+    /// The application error code sent by the peer in a STOP\_SENDING frame.
+    @usableFromInline
+    var stopSendingCode: QUICApplicationErrorCode?
+
+    /// Why the stream closed, as the stack and the peer see it.
+    var disconnectError: NetworkError?
+
+    /// Set while a view over this slot is live.
+    ///
+    /// See the note in 'QUICStreamTable.withStream' for more info.
+    @usableFromInline
+    var _isBorrowed: Bool
+
+    @inlinable
+    mutating func beginBorrow() {
+        precondition(!self._isBorrowed, "This stream is already in use.")
+        self._isBorrowed = true
+    }
+
+    @inlinable
+    mutating func endBorrow() {
+        self._isBorrowed = false
+    }
+
+    @usableFromInline
+    init(core: consuming QUICStreamCore) {
+        self.events = []
+        self.hasState = false
+        self.closeError = nil
+        self.disconnectError = nil
+        self.resetCode = nil
+        self.stopSendingCode = nil
+        self.core = consume core
+        self._isBorrowed = false
+    }
+}

--- a/Tests/NIOQUICTests/Streams/QUICStreamEventsTests.swift
+++ b/Tests/NIOQUICTests/Streams/QUICStreamEventsTests.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import NIOQUIC
+
+struct QUICStreamEventsTests {
+    @available(anyAppleOS 26, *)
+    @Test func distinctFlagsCombine() {
+        var events = QUICStreamEvents.readable
+        events.formUnion(.writable)
+        #expect(events.contains(.readable))
+        #expect(events.contains(.writable))
+        #expect(!events.contains(.closed))
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test func streamReadyEventsHaveDistinctBits() {
+        let all: [QUICStreamEvents] = [
+            .opened, .readable, .writable, .reset, .stopSending, .closed,
+        ]
+        let combined = all.reduce(into: QUICStreamEvents()) { $0.formUnion($1) }
+        #expect(combined.rawValue.nonzeroBitCount == all.count)
+    }
+}

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOEmbedded
+import NIOQUICHelpers
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+import Testing
+
+@testable import NIOQUIC
+
+@available(anyAppleOS 26, *)
+private enum TestConsumer: QUICStreamConsumer {
+    typealias StreamState = Int
+}
+
+@available(anyAppleOS 26, *)
+extension QUICStreamTable where Consumer: ~Copyable {
+    /// The events recorded against a slot, or `nil` if the handle doesn't address one.
+    fileprivate func events(for handle: QUICStreamHandle) -> QUICStreamEvents? {
+        self._transportStates.pointer(for: handle)?.pointee.events
+    }
+}
+
+@Suite
+struct QUICStreamTableTests {
+    @available(anyAppleOS 26, *)
+    private static func makeTable(role: Role = .client) -> QUICStreamTable<TestConsumer> {
+        QUICStreamTable(
+            role: role,
+            context: NetworkContext(
+                identifier: "quic-stream-table-tests",
+                externalScheduler: QUICChannelEventLoop(eventLoop: EmbeddedEventLoop())
+            )
+        )
+    }
+
+    // MARK: - ID indexing
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func insertWithIDIsIndexedByID() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: 4, state: 1)
+        #expect(table.handle(forID: 4) == handle)
+        #expect(table.count == 1)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func insertWithoutIDIsNotIndexedUntilAssigned() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: 1)
+        #expect(table.handle(forID: 4) == nil)
+
+        table.assignID(4, to: handle)
+        #expect(table.handle(forID: 4) == handle)
+
+        let id = table.withStream(handle: handle) { stream, _ in stream.id }
+        #expect(id == 4)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func idLookupFailsOnceTheSlotIsVacated() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: 4, state: 1)
+        table.vacateSlot(handle)
+        #expect(table.handle(forID: 4) == nil)
+        #expect(table.count == 0)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func assignIDToVacatedSlotIsIgnored() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: 1)
+        table.vacateSlot(handle)
+        table.assignID(4, to: handle)
+        #expect(table.handle(forID: 4) == nil)
+    }
+
+    // MARK: - Generations
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func eventsForARecycledSlotAreDroppedForTheStaleHandle() {
+        let table = Self.makeTable()
+        let stale = table.insertSlot(id: nil, state: 1)
+        table.vacateSlot(stale)
+
+        // 'live' should reuse the slot that 'stale' used.
+        let live = table.insertSlot(id: nil, state: 2)
+        #expect(stale.index == live.index)
+        #expect(stale.generation != live.generation)
+
+        table.markReady(handle: stale, events: .readable)
+        #expect(table.events(for: stale) == nil)
+        #expect(table.events(for: live) == [])
+    }
+
+    // MARK: - Ready queue
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func repeatedMarkReadyEnqueuesOnceAndUnionsEvents() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: 1)
+
+        table.markReady(handle: handle, events: .readable)
+        table.markReady(handle: handle, events: .writable)
+
+        #expect(table.hasPendingWork)
+        #expect(table.events(for: handle) == [.readable, .writable])
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func markReadyWithNoEventsDoesNotEnqueue() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: 1)
+        table.markReady(handle: handle, events: [])
+        #expect(!table.hasPendingWork)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func markReadyOnAVacatedSlotIsIgnored() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: 1)
+
+        table.vacateSlot(handle)
+        table.markReady(handle: handle, events: .readable)
+
+        #expect(!table.hasPendingWork)
+    }
+
+    // MARK: - Consumer state
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func slotWithoutStateIsNotVisited() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: nil)
+        #expect(table.withStream(handle: handle) { _, state in state } == nil)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func stateMutationsPersistBetweenVisits() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: 1)
+        table.withStream(handle: handle) { _, state in state += 1 }
+        #expect(table.withStream(handle: handle) { _, state in state } == 2)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func nestedVisitsToOneStreamTrap() async {
+        await #expect(processExitsWith: .failure) {
+            let table = Self.makeTable()
+            let handle = table.insertSlot(id: nil, state: 1)
+
+            table.withStream(handle: handle) { _, _ in
+                table.withStream(handle: handle) { _, _ in
+                }
+            }
+        }
+    }
+
+    // MARK: - Output pending
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func clearOutputPendingReportsOnce() {
+        let table = Self.makeTable()
+        table.markOutputPending()
+
+        #expect(table.clearOutputPending())
+        #expect(!table.clearOutputPending())
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func writeDoesNotMarkPendingOutput() {
+        let table = Self.makeTable()
+        let handle = table.insertSlot(id: nil, state: 1)
+        table.withStream(handle: handle) { stream, _ in
+            stream.write(ByteBuffer(string: "hello"))
+        }
+        #expect(!table.clearOutputPending())
+    }
+}


### PR DESCRIPTION
Motivation:

Many of the core pieces are in place for lightweight streams now so we can start putting them together.

Modifications:

- Add `QUICStreamEvents` which is a bitset of events that have happened to a stream since its last visit. Users can look at this to know, for example, whether it's worth attempting to pull bytes out of the stack.
- Add 'QUICStream', the public facing part of a stream presented to a consumer with various operations on it.
- Add 'QUICStreamTransportState', the state of the transport side of a stream as held the stream table
- Add 'QUICStreamTable' which pieces the above any a number of other bits together. It allows new streams to be inserted into storage and accessed via the handle associated with the storage. It also provides a 'withStream' function which provides scoped access to a stream and its underling storage.

Result:

Things are coming together. This is still not reachable.