### PR TITLE
Add a quic stream proxy

### DIFF
--- a/Sources/NIOQUIC/Streams/QUICStreamHandle.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamHandle.swift
@@ -17,13 +17,12 @@ public struct QUICStreamHandle: Hashable, Sendable {
     @usableFromInline
     var _index: Index
     @usableFromInline
-    var _generation: UInt32
+    var _generation: Generation
 
     @inlinable
-    var rawValue: UInt64 {
-        // Index asserts it's no greater than a UInt32.
-        let indexBits = UInt64(UInt32(truncatingIfNeeded: self._index.rawValue))
-        return indexBits | UInt64(self._generation) << 32
+    var rawValue: UInt {
+        let indexBits = UInt(self._index._rawValue)
+        return indexBits | UInt(self._generation.rawValue) << UIntHalf.bitWidth
     }
 
     /// The index of the slot the stream occupies in the connection's stream table.
@@ -34,21 +33,49 @@ public struct QUICStreamHandle: Hashable, Sendable {
 
     /// How many times that slot has been reused.
     @inlinable
-    var generation: UInt32 {
+    var generation: Generation {
         self._generation
     }
 
+    /// Creates a new handle from its slot index and generation.
     @inlinable
-    init(index: Index, generation: UInt32) {
+    init(index: Index, generation: Generation) {
         self._index = index
         self._generation = generation
     }
 
     /// Rebuilds a handle which was flattened to its raw bits.
     @inlinable
-    init(rawValue: UInt64) {
-        self._index = Index(Int(UInt32(truncatingIfNeeded: rawValue)))
-        self._generation = UInt32(truncatingIfNeeded: rawValue >> 32)
+    init(rawValue: UInt) {
+        self._index = Index(UIntHalf(truncatingIfNeeded: rawValue))
+        let generationBits = rawValue >> UIntHalf.bitWidth
+        self._generation = Generation(UIntHalf(truncatingIfNeeded: generationBits))
+    }
+}
+
+extension QUICStreamHandle {
+    @usableFromInline
+    struct Generation: Hashable, Sendable {
+        @usableFromInline
+        var rawValue: UIntHalf
+
+        @inlinable
+        init(_ rawValue: UIntHalf) {
+            self.rawValue = rawValue
+        }
+
+        /// The first generation of a slot.
+        @inlinable
+        static var first: Generation {
+            Generation(0)
+        }
+
+        @inlinable
+        mutating func advance() {
+            // Wrapping is fine: it takes a full generation counter's worth of reuses of one slot,
+            // by which point any handle old enough _should_ be long gone.
+            self.rawValue &+= 1
+        }
     }
 }
 
@@ -56,14 +83,21 @@ extension QUICStreamHandle {
     /// The index into ``QUICStreamSlots`` for the handle the stream occupies.
     @usableFromInline
     struct Index: Hashable, Comparable, Sendable {
-        /// The slot the stream occupies, as a subscript into storage which is addressed by `Int`.
         @usableFromInline
-        var rawValue: Int
+        var _rawValue: UIntHalf
+
+        /// The slot the stream occupies, as a subscript into storage which is addressed by `Int`.
+        @inlinable
+        var rawValue: Int { Int(self._rawValue) }
+
+        @inlinable
+        init(_ rawValue: UIntHalf) {
+            self._rawValue = rawValue
+        }
 
         @inlinable
         init(_ rawValue: Int) {
-            assert(rawValue <= Int(UInt32.max))
-            self.rawValue = rawValue
+            self._rawValue = UIntHalf(rawValue)
         }
 
         /// The first slot a store hands out.
@@ -74,13 +108,50 @@ extension QUICStreamHandle {
 
         @inlinable
         mutating func advance() {
-            self.rawValue &+= 1
-            assert(self.rawValue <= Int(UInt32.max))
+            self._rawValue &+= 1
         }
 
         @inlinable
         static func < (lhs: Index, rhs: Index) -> Bool {
             lhs.rawValue < rhs.rawValue
         }
+    }
+}
+
+// MARK: - NetworkFramework indexing
+
+// When creating a `ProtocolInstanceReference` for a given stream you can specify the container and
+// an index. That is, a `ProtocolInstanceContainer` can service many `ProtocolInstance`s as each is
+// keyed by an `Int` index. Since the index is only an `Int` we need to pack the whole handle into
+// it: its slot index and generation.
+//
+// Note that this will change in SwiftNetwork so this is unlikely to be the end state and will need
+// to be revisited then. (That's no bad thing because the slot indexing and generation are a lot
+// smaller on 32-bit platforms to squeeze them into an `Int`.)
+
+#if _pointerBitWidth(_64)
+@usableFromInline
+/// An unsigned integer with half the bytes of a `UInt`.
+typealias UIntHalf = UInt32
+#elseif _pointerBitWidth(_32)
+@usableFromInline
+/// An unsigned integer with half the bytes of a `UInt`.
+typealias UIntHalf = UInt16
+#else
+#error("Unsupported pointer size")
+#endif
+
+@available(anyAppleOS 26, *)
+extension QUICStreamHandle {
+    /// The index stored by SwiftNetwork for a given handle.
+    @inlinable
+    var protocolInstanceReferenceIndex: Int {
+        Int(bitPattern: self.rawValue)
+    }
+
+    /// Rebuilds the handle the stack was given as a container index.
+    @inlinable
+    init(protocolInstanceReferenceIndex: Int) {
+        self.init(rawValue: UInt(bitPattern: protocolInstanceReferenceIndex))
     }
 }

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamProxy.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamProxy.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+@available(anyAppleOS 26, *)
+struct QUICStreamProxy<Consumer: QUICStreamConsumer & ~Copyable> {
+    typealias LowerProtocol = OutboundStreamLinkage
+
+    let table: QUICStreamTable<Consumer>
+    let handle: QUICStreamHandle
+}
+
+// MARK: - ProtocolInstance
+
+@available(anyAppleOS 26, *)
+extension QUICStreamProxy: ProtocolInstance where Consumer: ~Copyable {
+    var context: SwiftNetwork.NetworkContext {
+        self.table.context
+    }
+
+    var reference: ProtocolInstanceReference {
+        self.table.reference(for: self.handle)
+    }
+
+    /// The slot's event manager, or the table's spare if the slot has been recycled.
+    var eventManager: ProtocolEventManager {
+        // The event manager in each `else` branch _should_ be unreachable: a reference is only
+        // ever built for a live handle, and all stack callbacks go via the table which drops
+        // handles that no longer resolve.
+        _read {
+            if let transport = self.table.transportState(for: self.handle) {
+                yield transport.pointee.eventManager
+            } else {
+                let eventManager = ProtocolEventManager()
+                yield eventManager
+            }
+        }
+        nonmutating _modify {
+            if let transport = self.table.transportState(for: self.handle) {
+                yield &transport.pointee.eventManager
+            } else {
+                var eventManager = ProtocolEventManager()
+                yield &eventManager
+            }
+        }
+    }
+}
+
+// MARK: - InboundStreamHandler
+
+@available(anyAppleOS 26, *)
+extension QUICStreamProxy: InboundStreamHandler where Consumer: ~Copyable {
+    /// The stack assigned the stream its ID.
+    func handleConnectedEvent(_ from: ProtocolInstanceReference) {
+        self.table.streamConnected(self.handle)
+    }
+
+    /// The stream is finished with, cleanly or not.
+    func handleDisconnectedEvent(_ from: ProtocolInstanceReference, error: NetworkError?) {
+        self.table.streamDisconnected(self.handle, error: error)
+    }
+
+    /// The peer's data can be read.
+    func handleInboundDataAvailableEvent(_ from: ProtocolInstanceReference) {
+        self.table.markReady(handle: self.handle, events: .readable)
+    }
+
+    /// The stack has room for more outbound data.
+    func handleOutboundRoomAvailableEvent(_ from: ProtocolInstanceReference) {
+        self.table.markReady(handle: self.handle, events: .writable)
+    }
+
+    /// The peer sent RESET\_STREAM.
+    func handleInboundAbortedEvent(_ from: ProtocolInstanceReference, error: NetworkError?) {
+        switch Self.applicationErrorCode(error) {
+        case .some(let code):
+            self.table.peerResetStream(self.handle, code: code)
+        case .none:
+            ()  // No application error code: nothing to surface as a reset.
+        }
+    }
+
+    /// The peer sent STOP\_SENDING.
+    func handleOutboundAbortedEvent(_ from: ProtocolInstanceReference, error: NetworkError?) {
+        switch Self.applicationErrorCode(error) {
+        case .some(let code):
+            self.table.peerStoppedSending(self.handle, code: code)
+        case .none:
+            ()  // No application error code: nothing to surface as a stop-sending.
+        }
+    }
+
+    func handleNetworkProtocolEvent(_ from: ProtocolInstanceReference, event: NetworkProtocolEvent) {
+        // Connection-scoped events are delivered on the connection's own instance, not on a stream's.
+        ()
+    }
+
+    func attachLowerProtocol(
+        _ lowerProtocol: ProtocolInstanceReference,
+        remote: Endpoint?,
+        local: Endpoint?,
+        parameters: Parameters?,
+        path: PathProperties?
+    ) throws(NetworkError) {
+        throw NetworkError.posix(ENOTSUP)
+    }
+
+    func attachLowerStreamProtocol(
+        _ lowerProtocol: ProtocolInstanceReference,
+        remote: Endpoint?,
+        local: Endpoint?,
+        parameters: Parameters?,
+        path: PathProperties?
+    ) throws(NetworkError) {
+        throw NetworkError.posix(ENOTSUP)
+    }
+
+    func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError) {
+        throw NetworkError.posix(ENOTSUP)
+    }
+
+    private static func applicationErrorCode(_ error: NetworkError?) -> QUICApplicationErrorCode? {
+        switch error?.quicApplicationError {
+        case .some(let code) where code >= 0:
+            return QUICApplicationErrorCode(UInt64(code))
+        case .some, .none:
+            return nil
+        }
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamProxy.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamProxy.swift
@@ -43,7 +43,7 @@ extension QUICStreamProxy: ProtocolInstance where Consumer: ~Copyable {
         self.table.reference(for: self.handle)
     }
 
-    /// The slot's event manager, or the table's spare if the slot has been recycled.
+    /// The slot's event manager.
     var eventManager: ProtocolEventManager {
         // The event manager in each `else` branch _should_ be unreachable: a reference is only
         // ever built for a live handle, and all stack callbacks go via the table which drops
@@ -52,6 +52,7 @@ extension QUICStreamProxy: ProtocolInstance where Consumer: ~Copyable {
             if let transport = self.table.transportState(for: self.handle) {
                 yield transport.pointee.eventManager
             } else {
+                assertionFailure("No eventManager for proxy")
                 let eventManager = ProtocolEventManager()
                 yield eventManager
             }
@@ -60,6 +61,7 @@ extension QUICStreamProxy: ProtocolInstance where Consumer: ~Copyable {
             if let transport = self.table.transportState(for: self.handle) {
                 yield &transport.pointee.eventManager
             } else {
+                assertionFailure("No eventManager for proxy")
                 var eventManager = ProtocolEventManager()
                 yield &eventManager
             }

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamSlotRecord.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamSlotRecord.swift
@@ -16,13 +16,13 @@
 @usableFromInline
 struct QUICStreamSlotRecord {
     @usableFromInline
-    var _generation: UInt32
+    var _generation: QUICStreamHandle.Generation
     @usableFromInline
     var _isOccupied: Bool
 
     /// How many times the slot has been reused.
     @inlinable
-    var generation: UInt32 { self._generation }
+    var generation: QUICStreamHandle.Generation { self._generation }
 
     /// Whether the slot is currently occupied.
     @inlinable
@@ -30,22 +30,20 @@ struct QUICStreamSlotRecord {
 
     @inlinable
     init() {
-        self._generation = 0
+        self._generation = .first
         self._isOccupied = false
     }
 
     @inlinable
-    func isOccupied(by generation: UInt32) -> Bool {
+    func isOccupied(by generation: QUICStreamHandle.Generation) -> Bool {
         self._isOccupied && self._generation == generation
     }
 
     @inlinable
-    mutating func occupy() -> UInt32 {
+    mutating func occupy() -> QUICStreamHandle.Generation {
         assert(!self._isOccupied)
         self._isOccupied = true
-        // Wrapping is fine: it takes ~4 billion reuses of one slot, by which point any handle old
-        // enough to alias is long gone.
-        self._generation &+= 1
+        self._generation.advance()
         return self._generation
     }
 

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable+ProtocolInstanceContainer.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable+ProtocolInstanceContainer.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+@available(anyAppleOS 26, *)
+@_spi(ProtocolProvider)
+extension QUICStreamTable: ProtocolInstanceContainer where Consumer: ~Copyable {
+    @usableFromInline
+    func accessInstance<R, E: Error>(
+        at index: Int?,
+        _ body: (inout any ProtocolInstance) throws(E) -> R
+    ) throws(E) -> R {
+        var instance = self.proxy(at: index) as any ProtocolInstance
+        return try body(&instance)
+    }
+
+    @usableFromInline
+    func accessUpper<R, E: Error>(
+        at index: Int?,
+        _ body: (inout any UpperProtocolHandler) throws(E) -> R
+    ) throws(E) -> R {
+        var instance = self.proxy(at: index) as any UpperProtocolHandler
+        return try body(&instance)
+    }
+
+    @usableFromInline
+    func accessInboundDataHandler<R, E: Error>(
+        at index: Int?,
+        _ body: (inout any InboundDataHandler) throws(E) -> R
+    ) throws(E) -> R {
+        var instance = self.proxy(at: index) as any InboundDataHandler
+        return try body(&instance)
+    }
+
+    @usableFromInline
+    func accessInboundStreamHandler<R, E: Error>(
+        at index: Int?,
+        _ body: (inout any InboundStreamHandler) throws(E) -> R
+    ) throws(E) -> R {
+        var instance = self.proxy(at: index) as any InboundStreamHandler
+        return try body(&instance)
+    }
+
+    /// The proxy for the index the stack passed back.
+    private func proxy(at index: Int?) -> QUICStreamProxy<Consumer> {
+        QUICStreamProxy(
+            table: self,
+            // Index can't be `nil`: PIRs are only created by the table with an index, so the unwrap
+            // is safe.
+            handle: QUICStreamHandle(protocolInstanceReferenceIndex: index!)
+        )
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
@@ -141,6 +141,11 @@ extension QUICStreamTable where Consumer: ~Copyable {
         return handle
     }
 
+    /// The reference the `SwiftNetwork` stack routes the given stream's events through.
+    func reference(for handle: QUICStreamHandle) -> ProtocolInstanceReference {
+        ProtocolInstanceReference(custom: self, index: handle.protocolInstanceReferenceIndex)
+    }
+
     /// Records the ID the stack assigned, indexes it, and connects the stream's state machine.
     @usableFromInline
     func assignID(_ id: QUICStreamID, to handle: QUICStreamHandle) {
@@ -213,6 +218,61 @@ extension QUICStreamTable where Consumer: ~Copyable {
         case .serverInitiatedUnidirectional:
             return self.role == .server ? .sendOnly : .receiveOnly
         }
+    }
+}
+
+// MARK: - Stack events
+
+@available(anyAppleOS 26, *)
+extension QUICStreamTable where Consumer: ~Copyable {
+    /// The slot a handle addresses, or `nil` if it has been recycled since.
+    @inlinable
+    func transportState(
+        for handle: QUICStreamHandle
+    ) -> UnsafeMutablePointer<QUICStreamTransportState>? {
+        self._transportStates.pointer(for: handle)
+    }
+
+    /// The stack assigned the stream its ID.
+    func streamConnected(_ handle: QUICStreamHandle) {
+        guard let transport = self._transportStates.pointer(for: handle) else { return }
+
+        if let rawID = transport.pointee.core.metadata()?.streamID {
+            self.assignID(QUICStreamID(rawValue: rawID), to: handle)
+            self._markReady(handle: handle, transport: transport, events: .opened)
+        }
+    }
+
+    /// The stream disconnected.
+    func streamDisconnected(_ handle: QUICStreamHandle, error: NetworkError?) {
+        guard let transport = self._transportStates.pointer(for: handle) else { return }
+
+        transport.pointee.closeError = error
+        transport.pointee.disconnectError = error
+
+        // `.readable` as well: there may be leftover data and this will be the last chance to
+        // get it.
+        self._markReady(handle: handle, transport: transport, events: [.closed, .readable])
+    }
+
+    /// The peer sent RESET\_STREAM.
+    func peerResetStream(_ handle: QUICStreamHandle, code: QUICApplicationErrorCode) {
+        guard let transport = self._transportStates.pointer(for: handle) else { return }
+
+        transport.pointee.core.receiveResetStream(code: code)
+        transport.pointee.resetCode = code
+
+        self._markReady(handle: handle, transport: transport, events: .reset)
+    }
+
+    /// The peer sent STOP\_SENDING.
+    func peerStoppedSending(_ handle: QUICStreamHandle, code: QUICApplicationErrorCode) {
+        guard let transport = self._transportStates.pointer(for: handle) else { return }
+
+        transport.pointee.core.receiveStopSending(code: code)
+        transport.pointee.stopSendingCode = code
+
+        self._markReady(handle: handle, transport: transport, events: .stopSending)
     }
 }
 

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTransportState.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTransportState.swift
@@ -33,6 +33,9 @@ struct QUICStreamTransportState: ~Copyable {
     @usableFromInline
     var core: QUICStreamCore
 
+    /// Pending events for this slot for `SwiftNetwork`.
+    var eventManager: ProtocolEventManager
+
     /// Why the stream closed, as the consumer sees it.
     @usableFromInline
     var closeError: (any Error)?
@@ -74,6 +77,7 @@ struct QUICStreamTransportState: ~Copyable {
         self.resetCode = nil
         self.stopSendingCode = nil
         self.core = consume core
+        self.eventManager = ProtocolEventManager()
         self._isBorrowed = false
     }
 }

--- a/Tests/NIOQUICTests/Streams/QUICStreamHandleTests.swift
+++ b/Tests/NIOQUICTests/Streams/QUICStreamHandleTests.swift
@@ -20,16 +20,33 @@ import Testing
 struct QUICStreamHandleTests {
     @Test
     func indexAndGenerationRoundTrip() {
-        let handle = QUICStreamHandle(index: QUICStreamHandle.Index(3), generation: 7)
+        let handle = QUICStreamHandle(index: QUICStreamHandle.Index(3), generation: .init(7))
         #expect(handle.index == QUICStreamHandle.Index(3))
-        #expect(handle.generation == 7)
+        #expect(handle.generation == QUICStreamHandle.Generation(7))
     }
 
     @Test
     func handlesWithDifferentGenerationsDiffer() {
         let index = QUICStreamHandle.Index(1)
-        let lhs = QUICStreamHandle(index: index, generation: 1)
-        let rhs = QUICStreamHandle(index: index, generation: 2)
+        let lhs = QUICStreamHandle(index: index, generation: .init(1))
+        let rhs = QUICStreamHandle(index: index, generation: .init(2))
         #expect(lhs != rhs)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func pirIndexRoundTrips() {
+        let maxIndex = QUICStreamHandle.Index(UIntHalf.max)
+        let maxGeneration = QUICStreamHandle.Generation(UIntHalf.max)
+
+        for handle in [
+            QUICStreamHandle(index: .first, generation: .first),
+            QUICStreamHandle(index: QUICStreamHandle.Index(3), generation: .init(7)),
+            QUICStreamHandle(index: maxIndex, generation: maxGeneration),
+            QUICStreamHandle(index: maxIndex, generation: .first),
+            QUICStreamHandle(index: .first, generation: maxGeneration),
+        ] {
+            #expect(QUICStreamHandle(protocolInstanceReferenceIndex: handle.protocolInstanceReferenceIndex) == handle)
+        }
     }
 }

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamSlotsTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamSlotsTests.swift
@@ -200,7 +200,7 @@ struct QUICStreamSlotsTests {
         #expect(reusedIsOccupied)
         #expect(staleIsOccupied == false)
 
-        let outOfRangeIsOccupied = store.containsValue(for: QUICStreamHandle(index: .init(999), generation: 1))
+        let outOfRangeIsOccupied = store.containsValue(for: QUICStreamHandle(index: .init(999), generation: .init(1)))
         #expect(outOfRangeIsOccupied == false)
     }
 
@@ -226,18 +226,18 @@ struct QUICStreamSlotsTests {
     func generationsCountSlotReuse() {
         var store = QUICStreamSlots<Int>()
         // Zero is never handed out, so an all-zero handle addresses nothing.
-        #expect(store.containsValue(for: QUICStreamHandle(index: .first, generation: 0)) == false)
+        #expect(store.containsValue(for: QUICStreamHandle(index: .first, generation: .first)) == false)
 
         let first = store.insert(1)
         _ = store.removeValue(for: first)
 
         let second = store.insert(2)
         #expect(second.index == first.index)
-        #expect(second.generation == first.generation &+ 1)
+        #expect(second.generation.rawValue == first.generation.rawValue &+ 1)
 
         _ = store.removeValue(for: second)
         let third = store.insert(3)
         #expect(third.index == first.index)
-        #expect(third.generation == first.generation &+ 2)
+        #expect(third.generation.rawValue == first.generation.rawValue &+ 2)
     }
 }


### PR DESCRIPTION
Motivation:

At the moment SwiftNetwork has no way of accessing the stream table or storing events for a stream.

This change takes a little explaining... In SwiftNetwork a `ProtocolInstanceContainer` can store and service one or many `ProtocolInstance`s. A `ProtocolInstanceReference` is the reference to a single instance within a container and can use an `Int` to identify a single instance in a container (if the container stores multiple instances).

This change introduce a few things: `QUICStreamTable` becomes a `ProtocolInstanceContainer`, `QUICStreamProxy` is added and becomes a `ProtocolInstance`.

This leaves `ProtocolInstanceReference`: our idea of identity for a stream is a `QUICStreamHandle` which is currently 64-bits wide. This is an issue because `Int` isn't always 64-bits.

Modifications:

- Add a nominal type for the generation in a `QUICStreamHandle`
- Change the generation and slot index to be backed by half of a `UInt` so that handle can be packed into an `Int`. This is a bit limiting on 32-bit platforms but probably fine. (SwiftNetwork has plans to change this mechanism soon anyway so it'll likely just go away as an issue anyway.)
- Add `QUICStreamProxy`, effectively a handle and a table ref.
- Make `QUICStreamTable` a `ProtocolInstanceContainer`.

Result:

SwiftNetwork can reach the stream table (if we wire it up)