### PR TITLE
Add the stream iterator, visit, and consumer API

### DIFF
--- a/Sources/NIOQUIC/Streams/QUICStreamConsumer.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamConsumer.swift
@@ -21,4 +21,21 @@ public protocol QUICStreamConsumer: SendableMetatype, ~Copyable {
     #else  // 6.3 doesn't support ~Copyable associatedtypes
     associatedtype StreamState
     #endif
+
+    /// Create a ``StreamState`` for the given stream.
+    ///
+    /// This is called once per inbound stream, immediately before it's first visited.
+    ///
+    /// - Parameter stream: The stream the state is for.
+    /// - Returns: The state to store.
+    mutating func makeStreamState(_ stream: inout QUICStream<Self>) -> StreamState
+
+    /// Process every stream with unhandled events.
+    ///
+    /// Use this function to handle streams which have changed state since the last call. If you
+    /// don't process a stream (i.e. do not pull it from the iterator) then it will be included
+    /// in the next visit.
+    ///
+    /// - Parameter streams: The streams to visit.
+    mutating func processStreams(_ streams: inout QUICStreamIterator<Self>)
 }

--- a/Sources/NIOQUIC/Streams/QUICStreamIterator.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamIterator.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+
+/// An iterator for streams to visit.
+///
+/// Consuming a stream from the iterator means its events are considered consumer and won't be
+/// presented again. If a stream _isn't_ consumed by the iterator then it will be included in the
+/// next visit.
+@available(anyAppleOS 26, *)
+public struct QUICStreamIterator<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyable, ~Escapable {
+    /// The handle and events that the last call to `next()` returned.
+    @usableFromInline
+    struct Pending {
+        @usableFromInline
+        var handle: QUICStreamHandle
+        @usableFromInline
+        var presented: QUICStreamEvents
+
+        @inlinable
+        init(handle: QUICStreamHandle, presented: QUICStreamEvents) {
+            self.handle = handle
+            self.presented = presented
+        }
+    }
+
+    @usableFromInline
+    let _table: QUICStreamTable<Consumer>
+
+    /// The handle and events which are currently being visited.
+    @usableFromInline
+    var _pending: Pending?
+
+    @inlinable
+    @_lifetime(immortal)
+    init(table: QUICStreamTable<Consumer>) {
+        self._table = table
+        self._pending = nil
+    }
+
+    deinit {
+        // Finish the last visit (in case the iterator wasn't completely consumed).
+        if let pending = self._pending {
+            self._table.finishVisit(pending.handle, presented: pending.presented)
+        }
+    }
+
+    /// The next stream to service, or `nil` if there are none left.
+    ///
+    /// - Returns: A stream visit.
+    @inlinable
+    @_lifetime(&self)
+    public mutating func next() -> QUICStreamVisit<Consumer>? {
+        // Finish the previous visit (which may close the stream). Doing this in a defer would be
+        // to early.
+        self._finishVisit()
+
+        while let handle = self._table.nextReadyHandle() {
+            guard let resolved = self._table.readySlot(for: handle) else { continue }
+
+            // Stash the pending state (for cleanup in `_finishVisit()`)
+            self._pending = Pending(handle: handle, presented: resolved.events)
+
+            return QUICStreamVisit(
+                table: self._table,
+                transport: resolved.transport,
+                state: resolved.state,
+                handle: handle,
+                events: resolved.events
+            )
+        }
+
+        return nil
+    }
+
+    /// Finishes the visit for the stream that was last handed over.
+    ///
+    /// Clear any events it presented and recycle its slot if the stream was closed.
+    @inlinable
+    mutating func _finishVisit() {
+        if let pending = self._pending.take() {
+            self._table.finishVisit(pending.handle, presented: pending.presented)
+        }
+    }
+}
+
+@available(anyAppleOS 26, *)
+@available(*, unavailable)
+extension QUICStreamIterator: Sendable where Consumer: ~Copyable {}

--- a/Sources/NIOQUIC/Streams/QUICStreamIterator.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamIterator.swift
@@ -16,9 +16,9 @@ import NIOQUICHelpers
 
 /// An iterator for streams to visit.
 ///
-/// Consuming a stream from the iterator means its events are considered consumer and won't be
-/// presented again. If a stream _isn't_ consumed by the iterator then it will be included in the
-/// next visit.
+/// Pulling a stream from the iterator with ``next()`` means its events are considered consumed and
+/// won't be presented again. If a stream _isn't_ pulled from the iterator then it (and its events)
+/// will be included in the next visit.
 @available(anyAppleOS 26, *)
 public struct QUICStreamIterator<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyable, ~Escapable {
     /// The handle and events that the last call to `next()` returned.

--- a/Sources/NIOQUIC/Streams/QUICStreamVisit.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamVisit.swift
@@ -14,6 +14,14 @@
 
 import NIOQUICHelpers
 
+/// A visit to a single QUIC stream returned from a ``QUICStreamIterator``.
+///
+/// During the visit you can find what events have happened on the stream since the last visit
+/// in ``events`` or poll the various properties on the visit object. You can read data from or
+/// write data to the network via the ``stream`` property.
+///
+/// You can also access and modify the consumer state for the stream via ``state``. Note that if
+/// you require simulatenous access to ``stream`` and ``state`` you can use ``withStream(execute:)``.
 @available(anyAppleOS 26, *)
 public struct QUICStreamVisit<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyable, ~Escapable {
     @usableFromInline

--- a/Sources/NIOQUIC/Streams/QUICStreamVisit.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamVisit.swift
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+
+@available(anyAppleOS 26, *)
+public struct QUICStreamVisit<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyable, ~Escapable {
+    @usableFromInline
+    let _table: QUICStreamTable<Consumer>
+
+    @usableFromInline
+    let _transport: UnsafeMutablePointer<QUICStreamTransportState>
+
+    @usableFromInline
+    let _state: UnsafeMutablePointer<Consumer.StreamState?>
+
+    /// An opaque identifier for this stream.
+    public let handle: QUICStreamHandle
+
+    /// Events which happened to the stream since it was last visited.
+    public let events: QUICStreamEvents
+
+    @inlinable
+    @_lifetime(immortal)
+    init(
+        table: QUICStreamTable<Consumer>,
+        transport: UnsafeMutablePointer<QUICStreamTransportState>,
+        state: UnsafeMutablePointer<Consumer.StreamState?>,
+        handle: QUICStreamHandle,
+        events: QUICStreamEvents
+    ) {
+        self._table = copy table
+        self._transport = transport
+        self._state = state
+        self.handle = handle
+        self.events = events
+    }
+
+    /// The ID of the stream, or `nil` if it hasn't been assigned one yet.
+    @inlinable
+    public var id: QUICStreamID? {
+        self._transport.pointee.core.id
+    }
+
+    /// Why the stream closed, or `nil` if it closed cleanly or hasn't closed yet.
+    ///
+    /// This may only be set if ``events`` contains ``QUICStreamEvents/closed``.
+    @inlinable
+    public var closeError: (any Error)? {
+        if self.events.contains(.closed) {
+            return self._transport.pointee.closeError
+        } else {
+            return nil
+        }
+    }
+
+    /// The error code the peer sent in RESET\_STREAM if ``events`` contains
+    /// ``QUICStreamReadyEvents/reset``, `nil` otherwise.
+    @inlinable
+    public var resetCode: QUICApplicationErrorCode? {
+        if self.events.contains(.reset) {
+            return self._transport.pointee.resetCode
+        } else {
+            return nil
+        }
+    }
+
+    /// The error code the peer sent in STOP\_SENDING if ``events`` contains
+    /// ``QUICStreamReadyEvents/stopSending``, `nil` otherwise.
+    @inlinable
+    public var stopSendingCode: QUICApplicationErrorCode? {
+        if self.events.contains(.stopSending) {
+            return self._transport.pointee.stopSendingCode
+        } else {
+            return nil
+        }
+    }
+
+    /// The stream being visited.
+    @inlinable
+    public var stream: QUICStream<Consumer> {
+        @_lifetime(&self)
+        mutating get {
+            QUICStream(table: self._table, transport: self._transport, handle: self.handle)
+        }
+        @_lifetime(&self)
+        mutating _modify {
+            // Discarded after the yield: the stream doesn't own anything directly, modifying it
+            // mutates the underlying storage.
+            var stream = QUICStream<Consumer>(
+                table: self._table,
+                transport: self._transport,
+                handle: self.handle
+            )
+
+            yield &stream
+        }
+    }
+
+    /// Access to the other streams on this connection.
+    @inlinable
+    public var streams: QUICStreams<Consumer> {
+        @_lifetime(borrow self)
+        get {
+            QUICStreams(table: self._table)
+        }
+    }
+
+    /// The consumer's own state for this stream, in place.
+    @inlinable
+    public var state: Consumer.StreamState {
+        _read {
+            yield self._state.pointee!
+        }
+        nonmutating _modify {
+            yield &self._state.pointee!
+        }
+    }
+
+    /// Runs `body` on this stream and the consumer's state for it.
+    ///
+    /// - Parameter body: Handed the stream and the consumer's state for it.
+    /// - Returns: What `body` returned.
+    @inlinable
+    public mutating func withStream<Result: ~Copyable, Failure: Error>(
+        execute body: (
+            _ stream: inout QUICStream<Consumer>,
+            _ state: inout Consumer.StreamState
+        ) throws(Failure) -> Result
+    ) throws(Failure) -> Result {
+        var stream = QUICStream<Consumer>(
+            table: self._table,
+            transport: self._transport,
+            handle: self.handle
+        )
+
+        return try body(&stream, &self._state.pointee!)
+    }
+
+    /// Ends the visit, taking the state out of the slot if the stream is closing.
+    ///
+    /// You can call this function when a stream is finished with if you need to take ownership
+    /// of the stream state. There is no requirement to call this function: the stream state will
+    /// be cleaned up automatically after the visit if this isn't called.
+    ///
+    /// - Returns: The state, or `nil` if ``events`` does not contain
+    ///   ``QUICStreamEvents/closed``.
+    @inlinable
+    public consuming func finish() -> Consumer.StreamState? {
+        guard self.events.contains(.closed) else { return nil }
+
+        // The visit is finished but its slot and its handle are still valid. Mark it as not having
+        // state so that the stream isn't handed out on another path, for example
+        // `QUICStreams.withStream(handle:body:)`.
+        self._transport.pointee.hasState = false
+
+        return self._state.pointee.take()
+    }
+}
+
+@available(anyAppleOS 26, *)
+@available(*, unavailable)
+extension QUICStreamVisit: Sendable where Consumer: ~Copyable {}

--- a/Sources/NIOQUIC/Streams/QUICStreamVisit.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreamVisit.swift
@@ -108,7 +108,7 @@ public struct QUICStreamVisit<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyab
         }
     }
 
-    /// Access to the other streams on this connection.
+    /// Access to all streams on this connection.
     @inlinable
     public var streams: QUICStreams<Consumer> {
         @_lifetime(borrow self)

--- a/Sources/NIOQUIC/Streams/QUICStreams.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreams.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+
+/// Access to the streams of a connection.
+@available(anyAppleOS 26, *)
+public struct QUICStreams<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyable, ~Escapable {
+    @usableFromInline
+    let _table: QUICStreamTable<Consumer>
+
+    @inlinable
+    @_lifetime(immortal)
+    init(table: QUICStreamTable<Consumer>) {
+        self._table = table
+    }
+
+    /// Runs `body` on a stream and its state.
+    ///
+    /// - Parameters:
+    ///   - handle: The stream to run on.
+    ///   - body: Handed the stream and the consumer's state for it.
+    /// - Returns: What `body` returned, or `nil` if `handle` doesn't address a ready stream.
+    @inlinable
+    public mutating func withStream<Result: ~Copyable, Failure: Error>(
+        handle: QUICStreamHandle,
+        execute body: (
+            _ stream: inout QUICStream<Consumer>,
+            _ state: inout Consumer.StreamState
+        ) throws(Failure) -> Result
+    ) throws(Failure) -> Result? {
+        try self._table.withStream(handle: handle, execute: body)
+    }
+
+    /// The handle for a stream ID.
+    ///
+    /// - Parameter id: The stream ID to look up.
+    /// - Returns: The handle for the stream with that ID, or `nil` if there's no valid handle
+    ///   for a stream with that ID (for example, the stream is closed).
+    @inlinable
+    public func handle(forID id: QUICStreamID) -> QUICStreamHandle? {
+        self._table.handle(forID: id)
+    }
+}
+
+@available(anyAppleOS 26, *)
+@available(*, unavailable)
+extension QUICStreams: Sendable where Consumer: ~Copyable {}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
@@ -45,6 +45,12 @@ struct QUICStreamCore: ~Copyable {
     @usableFromInline
     var _needsReadVisit: Bool
 
+    /// Whether a read left bytes in the stream that the consumer may still want.
+    @inlinable
+    var needsReadVisit: Bool {
+        self._needsReadVisit
+    }
+
     /// The handle used to talk to the SwiftNetwork stack.
     private var handle: SwiftNetworkStreamHandle
 
@@ -227,6 +233,8 @@ extension QUICStreamCore {
         minContiguous: Int,
         _ body: (_ span: borrowing RawSpan) -> Int
     ) -> QUICStreamReadOutcome {
+        self._needsReadVisit = false
+
         let contiguous = max(minContiguous, 1)
         var totalDelivered = 0
         var totalRead = 0
@@ -277,13 +285,6 @@ extension QUICStreamCore {
         }
 
         return outcome
-    }
-
-    /// Whether the stream should be revisited in the next tick because it has unread data.
-    @inlinable
-    mutating func needsReadVisit() -> Bool {
-        defer { self._needsReadVisit = false }
-        return self._needsReadVisit
     }
 
     /// Hands a FIN to the state machine, but only once all data has been handed over to the

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamCore.swift
@@ -41,6 +41,10 @@ struct QUICStreamCore: ~Copyable {
     /// Data received from `SwiftNetwork` which the application hasn't consumed yet.
     private var undeliveredReads: UniqueDeque<Frame>
 
+    /// Whether a read left bytes in the stream that the consumer may still want.
+    @usableFromInline
+    var _needsReadVisit: Bool
+
     /// The handle used to talk to the SwiftNetwork stack.
     private var handle: SwiftNetworkStreamHandle
 
@@ -68,6 +72,7 @@ struct QUICStreamCore: ~Copyable {
         self.undeliveredReads = UniqueDeque()
         self.finPending = false
         self.coalescedBytes = []
+        self._needsReadVisit = false
     }
 
     /// Creates a stream core which is not yet wired to the stack.
@@ -83,6 +88,7 @@ struct QUICStreamCore: ~Copyable {
         self.undeliveredReads = UniqueDeque()
         self.finPending = false
         self.coalescedBytes = []
+        self._needsReadVisit = false
     }
 
     /// Attaches this stream core to the stack.
@@ -265,7 +271,19 @@ extension QUICStreamCore {
             outcome = .nothingAvailable
         }
 
+        // Bytes are leftover: the stream should be marked as needing another visit.
+        if totalDelivered > 0 && !self.undeliveredReads.isEmpty {
+            self._needsReadVisit = true
+        }
+
         return outcome
+    }
+
+    /// Whether the stream should be revisited in the next tick because it has unread data.
+    @inlinable
+    mutating func needsReadVisit() -> Bool {
+        defer { self._needsReadVisit = false }
+        return self._needsReadVisit
     }
 
     /// Hands a FIN to the state machine, but only once all data has been handed over to the

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
@@ -33,6 +33,10 @@ final class QUICStreamTable<Consumer: QUICStreamConsumer & ~Copyable> {
     @usableFromInline
     var _ready: Deque<QUICStreamHandle>
 
+    /// The streams the consumer hasn't yet made state for.
+    @usableFromInline
+    var _needsState: Deque<QUICStreamHandle>
+
     /// Stream handles keyed by their ID.
     @usableFromInline
     var _byID: QUICStreamIDDictionary<QUICStreamHandle>
@@ -51,6 +55,7 @@ final class QUICStreamTable<Consumer: QUICStreamConsumer & ~Copyable> {
         self._transportStates = QUICStreamSlots()
         self._consumerStates = QUICStreamConsumerStates()
         self._ready = []
+        self._needsState = []
         self._byID = QUICStreamIDDictionary()
         self._outputPending = false
         self.role = role
@@ -132,7 +137,9 @@ extension QUICStreamTable where Consumer: ~Copyable {
         if let state {
             consumerStatePointer.pointee = consume state
             self._transportStates.withValue(for: handle) { $0.hasState = true }
-        }  // else remote peer opened the stream, state is created before first visiting the stream.
+        } else {
+            self._needsState.append(handle)
+        }
 
         if let id {
             self._byID[id] = handle
@@ -185,13 +192,13 @@ extension QUICStreamTable where Consumer: ~Copyable {
     ///     stream.
     /// - Returns: the result of `body`, or `nil` if the stream wasn't open.
     @inlinable
-    func withStream<Result: ~Copyable>(
+    func withStream<Result: ~Copyable, Failure: Error>(
         handle: QUICStreamHandle,
         execute body: (
             _ stream: inout QUICStream<Consumer>,
             _ state: inout Consumer.StreamState
-        ) -> Result
-    ) -> Result? {
+        ) throws(Failure) -> Result
+    ) throws(Failure) -> Result? {
         guard let pointer = self._transportStates.pointer(for: handle) else { return nil }
         guard pointer.pointee.hasState else { return nil }
 
@@ -205,7 +212,7 @@ extension QUICStreamTable where Consumer: ~Copyable {
 
         let consumerState = self._consumerStates.pointer(at: handle.index)
         var stream = QUICStream<Consumer>(table: self, transport: pointer, handle: handle)
-        return body(&stream, &consumerState.pointee!)  // checked above
+        return try body(&stream, &consumerState.pointee!)  // checked above
     }
 
     /// The direction of a stream from its ID and this endpoint's role.
@@ -276,6 +283,131 @@ extension QUICStreamTable where Consumer: ~Copyable {
     }
 }
 
+// MARK: - Draining
+
+@available(anyAppleOS 26, *)
+extension QUICStreamTable where Consumer: ~Copyable {
+    /// Hand each ready stream to the consumer.
+    @inlinable
+    func drain(into consumer: inout Consumer) {
+        while let handle = self._needsState.popFirst() {
+            guard let transport = self._transportStates.pointer(for: handle) else { continue }
+            assert(!transport.pointee.hasState)
+
+            var stream = QUICStream<Consumer>(table: self, transport: transport, handle: handle)
+            let consumerState = self._consumerStates.pointer(at: handle.index)
+            consumerState.pointee = consumer.makeStreamState(&stream)
+            transport.pointee.hasState = true
+        }
+
+        var iterator = QUICStreamIterator(table: self)
+        consumer.processStreams(&iterator)
+    }
+
+    /// Marks every stream as closed and visits each of them.
+    ///
+    /// - Parameters:
+    ///   - error: Reported to the consumer as the reason each stream closed.
+    ///   - disconnect: Sent to the stack, and through it the peer. Separate from `error` because a
+    ///     connection-level failure is not always a `NetworkError`, and narrowing to one would lose
+    ///     the more useful of the two on the consumer's side.
+    ///   - consumer: The consumer to drain into.
+    func closeAll(
+        error: (any Error)?,
+        disconnect: NetworkError?,
+        into consumer: inout Consumer
+    ) {
+        var index = QUICStreamHandle.Index.first
+        while index.rawValue < self._transportStates.allocated {
+            let transport = self._transportStates.pointer(at: index)
+            let handle = self._transportStates.handle(at: index)
+
+            if let transport, let handle {
+                transport.pointee.closeError = error
+                transport.pointee.disconnectError = disconnect
+                // `.readable` too: this is the last chance for the consumer to pull any data.
+                self._markReady(handle: handle, transport: transport, events: [.closed, .readable])
+            }
+
+            index.advance()
+        }
+
+        self.drain(into: &consumer)
+        self.forceCloseAll(error: disconnect)
+    }
+
+    /// Removes and returns the next stream from the ready queue.
+    @inlinable
+    func nextReadyHandle() -> QUICStreamHandle? {
+        self._ready.popFirst()
+    }
+
+    @usableFromInline
+    struct ReadySlot {
+        @usableFromInline
+        var transport: UnsafeMutablePointer<QUICStreamTransportState>
+        @usableFromInline
+        var state: UnsafeMutablePointer<Consumer.StreamState?>
+        @usableFromInline
+        var events: QUICStreamEvents
+
+        @inlinable
+        init(
+            transport: UnsafeMutablePointer<QUICStreamTransportState>,
+            state: UnsafeMutablePointer<Consumer.StreamState?>,
+            events: QUICStreamEvents
+        ) {
+            self.transport = transport
+            self.state = state
+            self.events = events
+        }
+    }
+
+    /// Returns the state of a ready slot prior to a visit, or `nil` if the handle is invalid.
+    @inlinable
+    func readySlot(
+        for handle: QUICStreamHandle
+    ) -> ReadySlot? {
+        guard let transport = self._transportStates.pointer(for: handle) else {
+            // Possible if the stream gets closed by SwiftNetwork before the first visit.
+            return nil
+        }
+
+        // Streams only get added to the ready queue when they have events.
+        precondition(!transport.pointee.events.isEmpty)
+        // State is created for streams before creating the iterator (which is the only caller of
+        // this function).
+        precondition(transport.pointee.hasState)
+
+        return ReadySlot(
+            transport: transport,
+            state: self._consumerStates.pointer(at: handle.index),
+            events: transport.pointee.events
+        )
+    }
+
+    /// Clears the flags a visit presented and, if that visit was the stream's last, recycles its
+    /// slot.
+    @inlinable
+    func finishVisit(_ handle: QUICStreamHandle, presented: QUICStreamEvents) {
+        if presented.contains(.closed) {
+            self._remove(handle: handle)
+        } else if let transport = self._transportStates.pointer(for: handle) {
+            // Clear the events which were shown in the last visit.
+            transport.pointee.events.subtract(presented)
+
+            // Visit didn't consume all bytes: it should be readable in the next visit.
+            if transport.pointee.core.needsReadVisit() {
+                transport.pointee.events.insert(.readable)
+            }
+
+            if !transport.pointee.events.isEmpty {
+                self._ready.append(handle)
+            }
+        }
+    }
+}
+
 // MARK: - Slot teardown
 
 @available(anyAppleOS 26, *)
@@ -316,6 +448,7 @@ extension QUICStreamTable where Consumer: ~Copyable {
         }
         self._consumerStates.removeAll()
         self._ready.removeAll(keepingCapacity: true)
+        self._needsState.removeAll(keepingCapacity: true)
         self._byID.removeAll()
     }
 }

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
@@ -399,7 +399,7 @@ extension QUICStreamTable where Consumer: ~Copyable {
             transport.pointee.events.subtract(presented)
 
             // Visit didn't consume all bytes: it should be readable in the next visit.
-            if transport.pointee.core.needsReadVisit() {
+            if transport.pointee.core.needsReadVisit {
                 transport.pointee.events.insert(.readable)
             }
 

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
@@ -363,7 +363,9 @@ extension QUICStreamTable where Consumer: ~Copyable {
         }
     }
 
-    /// Returns the state of a ready slot prior to a visit, or `nil` if the handle is invalid.
+    /// Returns the ``ReadySlot` for a handle, or `nil` if the handle is invalid.
+    ///
+    /// This is used only by ``QUICStreamIterator`` immediately prior to visiting the stream.
     @inlinable
     func readySlot(
         for handle: QUICStreamHandle

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
@@ -42,7 +42,7 @@ extension QUICStreamTable where Consumer: ~Copyable {
 
 @available(anyAppleOS 26, *)
 private struct RecordingConsumer: QUICStreamConsumer {
-    struct StreamState: ~Copyable {
+    struct StreamState {
         /// Which ``makeStreamState(_:)`` call produced this, counting from one.
         var madeAt: Int
     }

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import NIOEmbedded
 import NIOQUICHelpers
 @_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
 import Testing
@@ -21,29 +20,99 @@ import Testing
 @testable import NIOQUIC
 
 @available(anyAppleOS 26, *)
-private enum TestConsumer: QUICStreamConsumer {
+private struct TestConsumer: QUICStreamConsumer {
     typealias StreamState = Int
+
+    mutating func makeStreamState(_ stream: inout NIOQUIC.QUICStream<Self>) -> Int {
+        Issue.record("state requested for a table which is never drained")
+        return 0
+    }
+
+    mutating func processStreams(_ streams: inout QUICStreamIterator<Self>) {
+        Issue.record("drained a table which is never drained")
+    }
 }
 
 @available(anyAppleOS 26, *)
 extension QUICStreamTable where Consumer: ~Copyable {
-    /// The events recorded against a slot, or `nil` if the handle doesn't address one.
     fileprivate func events(for handle: QUICStreamHandle) -> QUICStreamEvents? {
         self._transportStates.pointer(for: handle)?.pointee.events
     }
 }
 
+@available(anyAppleOS 26, *)
+private struct RecordingConsumer: QUICStreamConsumer {
+    struct StreamState: ~Copyable {
+        /// Which ``makeStreamState(_:)`` call produced this, counting from one.
+        var madeAt: Int
+    }
+
+    struct Sighting: Equatable {
+        var handle: QUICStreamHandle
+        var events: QUICStreamEvents
+        var stateMadeAt: Int
+    }
+
+    init(
+        pullLimit: Int? = nil,
+        onVisit: ((_ visit: consuming QUICStreamVisit<Self>) -> Void)? = nil
+    ) {
+        self.pullLimit = pullLimit
+        self.onVisit = onVisit
+        self.madeStates = 0
+        self.sightings = []
+    }
+
+    /// How many states have been made.
+    var madeStates: Int
+
+    /// One entry per visit, across every drain.
+    var sightings: [Sighting]
+
+    /// The most visits to pull per drain, or `nil` to pull them all.
+    var pullLimit: Int?
+
+    /// Called for each visit.
+    var onVisit: ((_ visit: consuming QUICStreamVisit<Self>) -> Void)?
+
+    mutating func makeStreamState(_ stream: inout NIOQUIC.QUICStream<Self>) -> StreamState {
+        self.madeStates &+= 1
+        return StreamState(madeAt: self.madeStates)
+    }
+
+    mutating func processStreams(_ streams: inout QUICStreamIterator<Self>) {
+        var pulled = 0
+
+        while self.pullLimit != pulled, let visit = streams.next() {
+            pulled &+= 1
+
+            let sighting = Sighting(
+                handle: visit.handle,
+                events: visit.events,
+                stateMadeAt: visit.state.madeAt
+            )
+
+            self.sightings.append(sighting)
+
+            if let onVisit = self.onVisit {
+                onVisit(visit)
+            }
+        }
+    }
+}
+
+private struct Boom: Error {}
+
 @Suite
 struct QUICStreamTableTests {
     @available(anyAppleOS 26, *)
     private static func makeTable(role: Role = .client) -> QUICStreamTable<TestConsumer> {
-        QUICStreamTable(
-            role: role,
-            context: NetworkContext(
-                identifier: "quic-stream-table-tests",
-                externalScheduler: QUICChannelEventLoop(eventLoop: EmbeddedEventLoop())
-            )
-        )
+        QUICStreamTable(role: role)
+    }
+
+    @available(anyAppleOS 26, *)
+    private static func makeRecordingTable(role: Role = .client) -> QUICStreamTable<RecordingConsumer> {
+        QUICStreamTable(role: role)
     }
 
     // MARK: - ID indexing
@@ -200,5 +269,249 @@ struct QUICStreamTableTests {
             stream.write(ByteBuffer(string: "hello"))
         }
         #expect(!table.clearOutputPending())
+    }
+
+    // MARK: - Draining
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func readyStreamIsVisitedOnceAndNotAgain() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let handle = table.insertSlot(id: 0, state: nil)
+        table.markReady(handle: handle, events: .readable)
+
+        table.drain(into: &consumer)
+        let sighting = RecordingConsumer.Sighting(handle: handle, events: .readable, stateMadeAt: 1)
+        #expect(consumer.sightings == [sighting])
+
+        // Shouldn't be seen a second time.
+        table.drain(into: &consumer)
+        #expect(consumer.sightings == [sighting])
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func visitedOncePerTick() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let handle = table.insertSlot(id: 0, state: nil)
+        table.markReady(handle: handle, events: .readable)
+        table.markReady(handle: handle, events: [.stopSending, .writable])
+
+        table.drain(into: &consumer)
+        #expect(consumer.sightings.count == 1)
+        #expect(consumer.sightings[0].events == [.readable, .writable, .stopSending])
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func ignoredVisitIsOfferedAgain() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+
+        // Don't pull any streams.
+        consumer.pullLimit = 0
+        let handle = table.insertSlot(id: 0, state: nil)
+        table.markReady(handle: handle, events: .readable)
+
+        // Run the first drain.
+        table.drain(into: &consumer)
+        #expect(consumer.sightings.isEmpty)
+
+        // Remove the pull limit and drain again.
+        consumer.pullLimit = nil
+        table.drain(into: &consumer)
+        #expect(consumer.sightings.count == 1)
+        #expect(consumer.sightings[0].events == .readable)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func lastVisitIsFinishedWhenTheConsumerNeverSeesNil() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer(pullLimit: 1)
+        let handle = table.insertSlot(id: 0, state: nil)
+        table.markReady(handle: handle, events: .readable)
+        table.drain(into: &consumer)
+        #expect(consumer.sightings.count == 1)
+
+        // The visit should've been finished by the iterator: on events, and no pending work.
+        #expect(table.events(for: handle) == [])
+        #expect(!table.hasPendingWork)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func makeStreamStateIsCalledOncePerStream() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let handle = table.insertSlot(id: 0, state: nil)
+
+        table.markReady(handle: handle, events: .readable)
+        table.drain(into: &consumer)
+        table.markReady(handle: handle, events: .readable)
+        table.drain(into: &consumer)
+
+        #expect(consumer.madeStates == 1)
+        #expect(consumer.sightings.map { $0.stateMadeAt } == [1, 1])
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func slotInsertedWithStateIsNotOfferedToTheConsumer() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let handle = table.insertSlot(id: 0, state: RecordingConsumer.StreamState(madeAt: 42))
+        table.markReady(handle: handle, events: [.opened, .readable])
+        table.drain(into: &consumer)
+
+        #expect(consumer.madeStates == 0)
+        #expect(consumer.sightings.map { $0.stateMadeAt } == [42])
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func nestedAccessToAnotherStreamFromInsideAVisit() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let first = table.insertSlot(id: 0, state: nil)
+        let second = table.insertSlot(id: 4, state: nil)
+
+        // Reach the second stream from inside every visit, which is the case the exclusivity rules
+        // make impossible through the slot store's closure-taking members.
+        var visitedBy: [Int] = []
+        consumer.onVisit = { visit in
+            var streams = visit.streams
+            let outer = visit.state.madeAt
+
+            if let inner = streams.withStream(handle: second, execute: { _, state in state.madeAt }) {
+                visitedBy.append(outer)
+                visitedBy.append(inner)
+            }
+        }
+
+        table.markReady(handle: first, events: .readable)
+        table.markReady(handle: second, events: .readable)
+        table.drain(into: &consumer)
+
+        #expect(consumer.sightings.count == 2)
+        // Each visit sees two streams: the outer stream (first and second) and then the second
+        // stream.
+        #expect(visitedBy == [1, 2, 2, 2])
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func withStreamHandsOverTheStreamAndItsStateTogether() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        consumer.onVisit = { visit in
+            var visit = consume visit
+            visit.withStream { stream, state in
+                stream.write(ByteBuffer(string: "hello"))
+                try? stream.flush()
+                state.madeAt &+= 100
+            }
+        }
+
+        let handle = table.insertSlot(id: 0, state: nil)
+        table.markReady(handle: handle, events: .readable)
+        table.drain(into: &consumer)
+
+        consumer.onVisit = nil
+        table.markReady(handle: handle, events: .writable)
+        table.drain(into: &consumer)
+        #expect(consumer.sightings.map { $0.stateMadeAt } == [1, 101])
+    }
+
+    // MARK: - Closing
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func closedIsDeliveredOnceAndRecyclesTheSlot() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let handle = table.insertSlot(id: 0, state: nil)
+
+        var takenStates: [Int] = []
+        var reachedAfterTake: [Int?] = []
+        consumer.onVisit = { visit in
+            guard let state = visit.finish() else { return }
+
+            takenStates.append(state.madeAt)
+
+            // The state's been taken but the handle is still valid (the visit hasn't finished
+            // yet). Reaching back through the table shouldn't give us access to the stream
+            // (i.e. this should return `nil`).
+            let madeAt = table.withStream(handle: handle) { _, state in state.madeAt }
+            reachedAfterTake.append(madeAt)
+        }
+
+        table.markReady(handle: handle, events: [.readable, .closed])
+        table.drain(into: &consumer)
+        #expect(consumer.sightings.count == 1)
+        #expect(consumer.sightings[0].events == [.readable, .closed])
+        #expect(takenStates == [1])
+        #expect(reachedAfterTake == [nil])
+        #expect(table.count == 0)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func closeAllDeliversClosedForEveryLiveStream() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let first = table.insertSlot(id: 0, state: nil)
+        let second = table.insertSlot(id: 4, state: nil)
+        let third = table.insertSlot(id: 8, state: nil)
+        table.markReady(handle: second, events: .readable)
+
+        table.closeAll(error: Boom(), disconnect: nil, into: &consumer)
+
+        #expect(consumer.sightings.count == 3)
+        #expect(consumer.sightings.map { $0.handle } == [first, second, third])
+        #expect(consumer.sightings.allSatisfy { $0.events.contains(.closed) })
+        #expect(table.count == 0)
+
+        table.drain(into: &consumer)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func closeAllRecyclesSlotsTheConsumerNeverPulls() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer(pullLimit: 1)
+
+        _ = table.insertSlot(id: 0, state: nil)
+        _ = table.insertSlot(id: 4, state: nil)  // ignored because of pullLimit
+
+        table.closeAll(error: Boom(), disconnect: nil, into: &consumer)
+        #expect(consumer.sightings.count == 1)
+        #expect(table.count == 0)
+    }
+
+    // MARK: - Stack events
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func roomAvailableMarksTheStreamWritable() {
+        let table = Self.makeRecordingTable()
+        var consumer = RecordingConsumer()
+        let handle = table.insertSlot(id: 0, state: nil)
+
+        let proxy = QUICStreamProxy(table: table, handle: handle)
+        proxy.handleOutboundRoomAvailableEvent(table.reference(for: handle))
+
+        table.drain(into: &consumer)
+        #expect(consumer.sightings.count == 1)
+        #expect(consumer.sightings[0].events == .writable)
+    }
+}
+
+@available(anyAppleOS 26, *)
+extension QUICStreamTable {
+    convenience init(role: Role) {
+        self.init(role: role, context: Parameters().context)
     }
 }

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
@@ -474,8 +474,6 @@ struct QUICStreamTableTests {
         #expect(consumer.sightings.map { $0.handle } == [second, first, third])
         #expect(consumer.sightings.allSatisfy { $0.events.contains(.closed) })
         #expect(table.count == 0)
-
-        table.drain(into: &consumer)
     }
 
     @available(anyAppleOS 26, *)

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
@@ -466,11 +466,12 @@ struct QUICStreamTableTests {
         let second = table.insertSlot(id: 4, state: nil)
         let third = table.insertSlot(id: 8, state: nil)
         table.markReady(handle: second, events: .readable)
-
         table.closeAll(error: Boom(), disconnect: nil, into: &consumer)
 
         #expect(consumer.sightings.count == 3)
-        #expect(consumer.sightings.map { $0.handle } == [first, second, third])
+        // Second is enqueued first (when marked as ready), first and third are added to the
+        // queue by 'closeAll'.
+        #expect(consumer.sightings.map { $0.handle } == [second, first, third])
         #expect(consumer.sightings.allSatisfy { $0.events.contains(.closed) })
         #expect(table.count == 0)
 


### PR DESCRIPTION
Motivation:

We have a stream table that can be hooked up to SwiftNetwork, but the consumer API doesn't exist. This PR adds it and wires it up to the table.

There are a few new parts here:
- `QUICStreamIterator`, an iterator over the ready streams in the table
- `QUICStreamVisit`, a single visit to a ready stream produced by the iterator, this is the API that users interact with in the consumer
- `QUICStreams` a handle for getting access to streams out-of-band (e.g. outside of a read loop)

Modifications:

- Add the types listed above
- Wire them up to the stream table
- More tests driven by the table

Result:

Aside from being wired into the actual stack, this is more or less the stream part done.