### PR TITLE
Reuse the protocol instance reference when entering SwiftNetwork

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
@@ -134,8 +134,9 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
     func start(_ view: SwiftNetworkQUICConnection.NewFlowView) {
         log("start")
         self.connectionView = view
-        self.fromExternal {
-            self.lowerProtocol.invokeConnect(self.reference)
+        let reference = self.reference
+        reference.fromExternal {
+            self.lowerProtocol.invokeConnect(reference)
         }
     }
 
@@ -143,24 +144,27 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
     // `connectionMetadata.activeConnectionIDLimit` is the peer's advertised cap
     // on how many connection IDs we may issue (RFC 9000 §18.2).
     func getConnectionMetadata() -> ProtocolMetadata<QUICProtocol>? {
-        self.fromExternal {
-            self.lowerProtocol.invokeGetMetadata(self.reference) as? ProtocolMetadata<QUICProtocol>
+        let reference = self.reference
+        return reference.fromExternal {
+            self.lowerProtocol.invokeGetMetadata(reference) as? ProtocolMetadata<QUICProtocol>
         }
     }
 
     // Stop the new flow handler
     func stop(error: NetworkError? = nil) {
         log("stop")
-        self.fromExternal {
-            self.lowerProtocol.invokeDisconnect(self.reference, error: error)
+        let reference = self.reference
+        reference.fromExternal {
+            self.lowerProtocol.invokeDisconnect(reference, error: error)
         }
     }
 
     // Teardown the new flow handler
     internal func teardown() {
-        self.fromExternal {
+        let reference = self.reference
+        reference.fromExternal {
             do throws(NetworkError) {
-                try self.lowerProtocol.invokeDetach(self.reference)
+                try self.lowerProtocol.invokeDetach(reference)
                 self.lowerProtocol = .init(reference: .init())
             } catch {
                 self.log("Failed to detach lower protocol: \(error)")
@@ -170,8 +174,9 @@ final class QUICChannelNewFlowHandler: ProtocolInstanceContainer, InboundFlowHan
 
     func outboundBatching(_ isEnabled: Bool) {
         let event: ApplicationEvent = isEnabled ? .outboundDataBatchStart : .outboundDataBatchEnd
-        self.fromExternal {
-            self.lowerProtocol.invokeApplicationEvent(self.reference, event: event)
+        let reference = self.reference
+        reference.fromExternal {
+            self.lowerProtocol.invokeApplicationEvent(reference, event: event)
         }
     }
 
@@ -303,8 +308,9 @@ extension QUICChannelNewFlowHandler: UpperProtocolHandler {
         )
         let event = ApplicationEvent(quicEvent: quicEvent)
 
-        self.fromExternal {
-            self.lowerProtocol.invokeApplicationEvent(self.reference, event: event)
+        let reference = self.reference
+        reference.fromExternal {
+            self.lowerProtocol.invokeApplicationEvent(reference, event: event)
         }
     }
 
@@ -316,8 +322,9 @@ extension QUICChannelNewFlowHandler: UpperProtocolHandler {
         let quicEvent = QUICApplicationEvent.retireOutboundConnectionID(cid)
         let event = ApplicationEvent(quicEvent: quicEvent)
 
-        self.fromExternal {
-            self.lowerProtocol.invokeApplicationEvent(self.reference, event: event)
+        let reference = self.reference
+        reference.fromExternal {
+            self.lowerProtocol.invokeApplicationEvent(reference, event: event)
         }
     }
 }

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelOutputHandler.swift
@@ -93,8 +93,9 @@ final class QUICChannelOutputHandler: ProtocolInstanceContainer, OutboundDatagra
     // Called from SwiftNetworkQUICConnection to notify the stack that there are inbound packets available.
     // This function is important for getting data into the stack
     func invokeInputAvailable() {
-        self.fromExternal {
-            self.upperProtocol.deliverInboundDataAvailableEvent(self.reference)
+        let reference = self.reference
+        reference.fromExternal {
+            self.upperProtocol.deliverInboundDataAvailableEvent(reference)
         }
     }
 

--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelStreamHandler.swift
@@ -448,12 +448,13 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
 
     // Send a STOP_SENDING frame to close the read (Note, this stream will receive a RESET_STREAM in return)
     internal func abortInbound(error: NetworkError?) {
-        self.fromExternal {
+        let reference = self.reference
+        reference.fromExternal {
             do throws(NetworkError) {
                 self.log("abortInbound")
                 switch self.swiftNetworkStreamHandle.invokeAbortInbound() {
                 case .proceed(let linkage):
-                    try linkage.invokeAbortInbound(self.reference, error: error)
+                    try linkage.invokeAbortInbound(reference, error: error)
                 case .ignore:
                     break
                 }
@@ -466,11 +467,12 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
 
     // Send a RESET_STREAM frame to close the write
     internal func abortOutbound(error: NetworkError?) {
-        self.fromExternal {
+        let reference = self.reference
+        reference.fromExternal {
             do throws(NetworkError) {
                 switch self.swiftNetworkStreamHandle.invokeAbortOutbound() {
                 case .proceed(let linkage):
-                    try linkage.invokeAbortOutbound(self.reference, error: error)
+                    try linkage.invokeAbortOutbound(reference, error: error)
                 case .ignore:
                     break
                 }
@@ -883,10 +885,11 @@ final class QUICChannelStreamHandler: ProtocolInstanceContainer, InboundStreamHa
 
     // Get metadata about the stream from the internal QUIC stack
     private final func getMetadata<P: NetworkProtocol>() -> ProtocolMetadata<P>? {
-        self.fromExternal {
+        let reference = self.reference
+        return reference.fromExternal {
             switch self.swiftNetworkStreamHandle.invokeGetMetadata() {
             case .proceed(let linkage):
-                return linkage.invokeGetMetadata(self.reference) as ProtocolMetadata<P>?
+                return linkage.invokeGetMetadata(reference) as ProtocolMetadata<P>?
             case .ignore:
                 return nil
             }


### PR DESCRIPTION
Motivation:

When crossing into the SwiftNetwork stack, types typically call `fromExternal { someFunc(self.reference) }`.  The `fromExternal` is really `self.reference.fromExternal`, and `self.reference` is a computed property which registers with the event manager on each construction. In other words: each `fromExternal` call here creates a second unnecessary protocol instance reference.

Modifications:

- Create each reference once and reuse it

Result:

Fewer instance registrations