### PR TITLE
Don't flush during read complete

### DIFF
--- a/Sources/NIOQUIC/QUICConnectionChannel.swift
+++ b/Sources/NIOQUIC/QUICConnectionChannel.swift
@@ -905,15 +905,6 @@ extension QUICConnectionChannel {
             self._connection.receivePacketsComplete()
         }
 
-        // Disable outbound batching so that SwiftQUIC emits frames into the connection. They'll
-        // be picked up when draining starts a few lines below. Re-enable again (i.e. disable
-        // temporarily) if there are pending streams as they may also produce output during their
-        // init.
-        self._connection.withLiveOnly { connection in
-            let hasPendingStreams = !self._pendingStreams.isEmpty
-            connection.flushOutboundBatch(resumeBatching: hasPendingStreams)
-        }
-
         self.drainAndReconcileLifecycle()
         self.processPendingInboundStreams()
 

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -116,13 +116,6 @@ final class SwiftNetworkQUICConnection {
         newFlowHandler.outboundBatching(enabled)
     }
 
-    internal func flushOutboundBatch(resumeBatching: Bool) {
-        self.setOutboundBatching(false)
-        if resumeBatching {
-            self.setOutboundBatching(true)
-        }
-    }
-
     /// Sets the connection channel and propagates it as the parent channel for inbound streams
     /// (via the new flow handler) and any pre-created outbound stream (the initial client stream).
     ///


### PR DESCRIPTION
Motivation:

For reasons unknown the connection channel flushes outbound data part way through `_parentChannelReadComplete`. This shouldn't be necessary, and worse, it incurs a perf hit.

Modifications:

Remove the redundant outbound flush

Result:

Better perf; ~8% improvement in the 1K download cases