### PR TITLE
Open streams from a stream table

### DIFF
--- a/Sources/NIOQUIC/Streams/QUICStreams.swift
+++ b/Sources/NIOQUIC/Streams/QUICStreams.swift
@@ -26,6 +26,21 @@ public struct QUICStreams<Consumer: QUICStreamConsumer & ~Copyable>: ~Copyable, 
         self._table = table
     }
 
+    /// Opens a stream.
+    ///
+    /// - Parameters:
+    ///   - type: The type of stream to open.
+    ///   - state: The consumer's state for the new stream.
+    /// - Returns: The handle for the new stream. Its ID is assigned by the stack, which reports it
+    ///   as a ``QUICStreamReadyEvents/opened`` visit.
+    /// - Throws: If the stream could not be opened, in which case `state` is destroyed.
+    public mutating func open(
+        _ type: QUICStreamType,
+        state: consuming Consumer.StreamState
+    ) throws -> QUICStreamHandle {
+        try self._table.open(type, state: consume state)
+    }
+
     /// Runs `body` on a stream and its state.
     ///
     /// - Parameters:

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamOpener.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamOpener.swift
@@ -23,9 +23,7 @@ struct QUICStreamOpener {
     /// The stack's connection instance.
     let connection: ProtocolInstanceReference
 
-    let context: SwiftNetwork.NetworkContext
-    let local: Endpoint
-    let remote: Endpoint
+    let context: NetworkContext
 
     /// Attaches a new outbound flow for a stream.
     ///
@@ -48,8 +46,8 @@ struct QUICStreamOpener {
 
         return try self.listener.invokeAttachUpperStreamProtocolToNewFlow(
             reference,
-            remote: self.remote,
-            local: self.local,
+            remote: nil,
+            local: nil,
             parameters: parameters,
             path: path
         )

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamOpener.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamOpener.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+/// What a stream table needs to attach a locally-opened stream to the stack.
+@available(anyAppleOS 26, *)
+struct QUICStreamOpener {
+    /// The connection's stream listener.
+    let listener: StreamListenerLinkage
+
+    /// The stack's connection instance.
+    let connection: ProtocolInstanceReference
+
+    let context: SwiftNetwork.NetworkContext
+    let local: Endpoint
+    let remote: Endpoint
+
+    /// Attaches a new outbound flow for a stream.
+    ///
+    /// - Parameters:
+    ///   - isUnidirectional: Whether the stream has a send side only.
+    ///   - reference: The reference the stack routes the stream's events back through.
+    /// - Returns: The flow the stack attached, which is not yet connected.
+    func attach(
+        isUnidirectional: Bool,
+        from reference: ProtocolInstanceReference
+    ) throws(NetworkError) -> OutboundStreamLinkage {
+        var parameters = SwiftNetwork.Parameters()
+        parameters.context = self.context
+        let path = SwiftNetwork.PathProperties(parameters: parameters)
+
+        let options = QUICStreamProtocol.options()
+        options.isUnidirectional = isUnidirectional
+        options.setProtocolInstance(self.connection)
+        parameters.defaultStack.prepend(applicationProtocol: options)
+
+        return try self.listener.invokeAttachUpperStreamProtocolToNewFlow(
+            reference,
+            remote: self.remote,
+            local: self.local,
+            parameters: parameters,
+            path: path
+        )
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable+Open.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable+Open.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOQUICHelpers
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+
+@available(anyAppleOS 26, *)
+extension QUICStreamTable where Consumer: ~Copyable {
+    /// Opens a stream, attaching it to the stack and connecting it.
+    ///
+    /// - Parameters:
+    ///   - type: The type of stream to open.
+    ///   - state: The consumer's state for the new stream.
+    /// - Returns: The handle for the new stream.
+    /// - Throws: If the type is not one this endpoint may initiate, or the stack refused the flow,
+    ///   in which case `state` is destroyed.
+    func open(_ type: QUICStreamType, state: consuming Consumer.StreamState) throws -> QUICStreamHandle {
+        if type.isClientInitiated && self.role == .server {
+            throw QUICError.invalidStreamTypeForRole
+        }
+
+        if type.isServerInitiated && self.role == .client {
+            throw QUICError.invalidStreamTypeForRole
+        }
+
+        guard let opener = self.opener else { throw QUICError.invalidStreamState }
+
+        let handle = self.insertSlot(id: nil, state: consume state)
+        let reference = self.reference(for: handle)
+        let linkage: OutboundStreamLinkage
+
+        do throws(NetworkError) {
+            linkage = try opener.attach(isUnidirectional: type.isUnidirectional, from: reference)
+        } catch {
+            self.vacateSlot(handle)
+            throw QUICError.invalidStreamState
+        }
+
+        if let transport = self.transportState(for: handle) {
+            transport.pointee.core.attach(reference: reference, linkage: linkage)
+        } else {
+            preconditionFailure("slot for \(handle) was recycled while its stream was being opened")
+        }
+
+        linkage.invokeConnect(reference)
+        return handle
+    }
+}

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
@@ -45,6 +45,10 @@ final class QUICStreamTable<Consumer: QUICStreamConsumer & ~Copyable> {
     @usableFromInline
     var _outputPending: Bool
 
+    /// Used for attaching locally opened streams to the `SwiftNetwork` stack. Returns `nil` if
+    /// the table isn't associated with a connection.
+    var opener: QUICStreamOpener?
+
     /// The role of the local peer.
     let role: Role
 
@@ -58,6 +62,7 @@ final class QUICStreamTable<Consumer: QUICStreamConsumer & ~Copyable> {
         self._needsState = []
         self._byID = QUICStreamIDDictionary()
         self._outputPending = false
+        self.opener = nil
         self.role = role
         self.context = context
     }

--- a/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
+++ b/Sources/NIOQUIC/Streams/Transport/QUICStreamTable.swift
@@ -45,7 +45,7 @@ final class QUICStreamTable<Consumer: QUICStreamConsumer & ~Copyable> {
     @usableFromInline
     var _outputPending: Bool
 
-    /// Used for attaching locally opened streams to the `SwiftNetwork` stack. Returns `nil` if
+    /// Used for attaching locally opened streams to the `SwiftNetwork` stack. `nil` if
     /// the table isn't associated with a connection.
     var opener: QUICStreamOpener?
 

--- a/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
+++ b/Tests/NIOQUICTests/Streams/Transport/QUICStreamTableTests.swift
@@ -490,6 +490,37 @@ struct QUICStreamTableTests {
         #expect(table.count == 0)
     }
 
+    // MARK: - Opening
+
+    @available(anyAppleOS 26, *)
+    @Test(
+        arguments: [
+            (Role.client, QUICStreamType.serverInitiatedBidirectional),
+            (.client, .serverInitiatedUnidirectional),
+            (.server, .clientInitiatedBidirectional),
+            (.server, .clientInitiatedUnidirectional),
+        ]
+    )
+    func openRejectsAStreamTypeThisRoleCannotInitiate(role: Role, type: QUICStreamType) {
+        let table = Self.makeRecordingTable(role: role)
+
+        #expect(throws: QUICError.invalidStreamTypeForRole) {
+            _ = try table.open(type, state: .init(madeAt: 1))
+        }
+        #expect(table.count == 0)
+    }
+
+    @available(anyAppleOS 26, *)
+    @Test
+    func openWithoutAConnectionBehindTheTableThrows() {
+        let table = Self.makeRecordingTable(role: .client)
+
+        #expect(throws: QUICError.invalidStreamState) {
+            _ = try table.open(.clientInitiatedBidirectional, state: .init(madeAt: 1))
+        }
+        #expect(table.count == 0)
+    }
+
     // MARK: - Stack events
 
     @available(anyAppleOS 26, *)


### PR DESCRIPTION
Motivation:

There's currently no API for opening streams via the stream table, only for accepting inbound streams.

Modifications:

- Add 'QUICStreamOpener' which holds what the bits required to attach an outbound flow.
- Add 'QUICStreamTable.open(_:state:)', which validates the type of stream being opened against the role of the local peer and drives the machinery to open a stream.
- Add 'QUICStreams.open(_:state:)' which is the public API for opening streams.

Result:

Streams can be opened