### PR TITLE
Don't crash on inbound flows delivered after teardown

### DIFF
--- a/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/QUICChannelNewFlowHandler.swift
@@ -62,7 +62,7 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
     // an implicitly unwrapped optionals because Swift's initialization rules prevent
     // passing 'self' method references during init.
     private var connectionView: SwiftNetworkQUICConnection<Consumer>.NewFlowView!
-    private var lowerProtocol = LowerProtocol(reference: .init())
+    private var lowerProtocol: LowerProtocol?
 
     private var datagramListener: DatagramListenerLinkage
 
@@ -138,7 +138,7 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
         self.connectionView = view
         let reference = self.reference
         reference.fromExternal {
-            self.lowerProtocol.invokeConnect(reference)
+            self.lowerProtocol?.invokeConnect(reference)
         }
     }
 
@@ -148,7 +148,7 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
     func getConnectionMetadata() -> ProtocolMetadata<QUICProtocol>? {
         let reference = self.reference
         return reference.fromExternal {
-            self.lowerProtocol.invokeGetMetadata(reference) as? ProtocolMetadata<QUICProtocol>
+            self.lowerProtocol?.invokeGetMetadata(reference) as? ProtocolMetadata<QUICProtocol>
         }
     }
 
@@ -157,7 +157,7 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
         log("stop")
         let reference = self.reference
         reference.fromExternal {
-            self.lowerProtocol.invokeDisconnect(reference, error: error)
+            self.lowerProtocol?.invokeDisconnect(reference, error: error)
         }
     }
 
@@ -166,8 +166,8 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
         let reference = self.reference
         reference.fromExternal {
             do throws(NetworkError) {
-                try self.lowerProtocol.invokeDetach(reference)
-                self.lowerProtocol = .init(reference: .init())
+                let lower = self.lowerProtocol.take()
+                try lower?.invokeDetach(reference)
             } catch {
                 self.log("Failed to detach lower protocol: \(error)")
             }
@@ -178,7 +178,7 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
         let event: ApplicationEvent = isEnabled ? .outboundDataBatchStart : .outboundDataBatchEnd
         let reference = self.reference
         reference.fromExternal {
-            self.lowerProtocol.invokeApplicationEvent(reference, event: event)
+            self.lowerProtocol?.invokeApplicationEvent(reference, event: event)
         }
     }
 
@@ -207,6 +207,11 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
             fatalError("connection channel is not available")
         }
 
+        guard let lowerProtocol = self.lowerProtocol else {
+            self.log("Dropping new inbound flow: lower protocol has been detached")
+            return
+        }
+
         do throws(NetworkError) {
             guard let metadata = flowMetadata as? ProtocolMetadata<QUICProtocol>,
                 let inputHandlerStreamID = metadata.streamID
@@ -225,7 +230,7 @@ final class QUICChannelNewFlowHandler<Consumer: QUICStreamConsumer & ~Copyable>:
                 keepAliveInterval: keepAliveInterval
             )
 
-            let linkage = try self.lowerProtocol.invokeAttachUpperStreamProtocolToExistingFlow(
+            let linkage = try lowerProtocol.invokeAttachUpperStreamProtocolToExistingFlow(
                 streamHandler.reference,
                 flowReference: flowReference
             )
@@ -312,7 +317,7 @@ extension QUICChannelNewFlowHandler: UpperProtocolHandler where Consumer: ~Copya
 
         let reference = self.reference
         reference.fromExternal {
-            self.lowerProtocol.invokeApplicationEvent(reference, event: event)
+            self.lowerProtocol?.invokeApplicationEvent(reference, event: event)
         }
     }
 
@@ -326,7 +331,7 @@ extension QUICChannelNewFlowHandler: UpperProtocolHandler where Consumer: ~Copya
 
         let reference = self.reference
         reference.fromExternal {
-            self.lowerProtocol.invokeApplicationEvent(reference, event: event)
+            self.lowerProtocol?.invokeApplicationEvent(reference, event: event)
         }
     }
 }

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -851,17 +851,9 @@ final class SwiftNetworkQUICConnection<Consumer: QUICStreamConsumer & ~Copyable>
         // inactive: it's still needed here to deliver 'connectionClosed' back to the channel.
         log("close sentApplicationClose: \(sendApplicationClose), errorCode: \(errorCode), reason: \(reason)")
 
-        // For connections that never established (still in idle or early handshake states), and
-        // for those which weren't stopped above (so won't be given a disconnected event), clean up
-        // synchronously.
-        if !hasEstablishedConnection {
-            // Never established - clean up synchronously
-            self.tearDownConnectionState()
-            assert(
-                self.connectionStateMachine.stateDescription == "disconnected",
-                "State should be closed after teardown"
-            )
-        } else if !didStop {
+        // For connections that never established (still in idle or early handshake states), or
+        // which weren't stopped above, clean up synchronously: neither gets a disconnected event.
+        if !didStop || !hasEstablishedConnection {
             self.tearDownConnectionState()
         }
         // For established connections, teardown happens via handleConnectionDisconnected (called by newFlowHandler.stop above)

--- a/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
+++ b/Sources/NIOQUIC/SwiftNetwork/SwiftNetworkQUICConnection.swift
@@ -835,20 +835,25 @@ final class SwiftNetworkQUICConnection<Consumer: QUICStreamConsumer & ~Copyable>
         // Now tell SwiftNetwork to send CONNECTION_CLOSE and clean up streams
         // newFlowHandler.stop() will synchronously trigger handleConnectionDisconnected()
         // which will see we're in .closing state and transition to .closed
+        let didStop: Bool
         if sendApplicationClose {
             newFlowHandler.stop(error: NetworkError(quicApplicationError: UInt64(errorCode), reason: reason))
+            didStop = true
         } else {
             if let transportError = QUICTransportError(UInt64(errorCode), reason) {
                 newFlowHandler.stop(error: NetworkError(quicTransportError: transportError))
+                didStop = true
+            } else {
+                didStop = false
             }
         }
         // The channel reference is dropped in 'dropChannelReferences()' once the channel has gone
         // inactive: it's still needed here to deliver 'connectionClosed' back to the channel.
-        newFlowHandler.teardown()
         log("close sentApplicationClose: \(sendApplicationClose), errorCode: \(errorCode), reason: \(reason)")
 
-        // For connections that never established (still in idle or early handshake states),
-        // clean up synchronously.
+        // For connections that never established (still in idle or early handshake states), and
+        // for those which weren't stopped above (so won't be given a disconnected event), clean up
+        // synchronously.
         if !hasEstablishedConnection {
             // Never established - clean up synchronously
             self.tearDownConnectionState()
@@ -856,6 +861,8 @@ final class SwiftNetworkQUICConnection<Consumer: QUICStreamConsumer & ~Copyable>
                 self.connectionStateMachine.stateDescription == "disconnected",
                 "State should be closed after teardown"
             )
+        } else if !didStop {
+            self.tearDownConnectionState()
         }
         // For established connections, teardown happens via handleConnectionDisconnected (called by newFlowHandler.stop above)
         return .closeInitiated


### PR DESCRIPTION
Motivation:

9e266473 changed I/O slightly which surfaced a bug in the new flow handler.

Detaching stops new events from being routed to the handler but doesn't cancel ones that are already queued. `teardown()` is a direct call so it skips the event queue. A stream opened in the same read as the close is delivered after teardown where the lower protocol a `nil` event state index (so traps).

`close()` made it easy to hit: it called `teardown()` directly rather than going via `tearDownConnectionState()`, which is what clears `connectionNewFlowHandler`.

Modifications:

- Make lower protocol optional and `nil` it out on teardown, dropping inbound flows which arrive after that
- Only tear down from `tearDownConnectionState()`
- Clean up synchronously in `close()` when `stop()` wasn't called, nothing else will

Result:

Fewer crashes